### PR TITLE
libghostty-vt: fix broken dynamic linking with pkg-config

### DIFF
--- a/nix/libghostty-vt.nix
+++ b/nix/libghostty-vt.nix
@@ -59,9 +59,6 @@ stdenv.mkDerivation (finalAttrs: {
     "-Dapp-runtime=none"
     "-Demit-lib-vt=true"
     "-Dsimd=${lib.boolToString simd}"
-    # Install headers directly into the `dev` output
-    "--prefix-include-dir"
-    "${placeholder "dev"}/include"
   ];
   zigCheckFlags = finalAttrs.zigBuildFlags ++ ["test-lib-vt"];
 

--- a/nix/libghostty-vt.nix
+++ b/nix/libghostty-vt.nix
@@ -59,6 +59,9 @@ stdenv.mkDerivation (finalAttrs: {
     "-Dapp-runtime=none"
     "-Demit-lib-vt=true"
     "-Dsimd=${lib.boolToString simd}"
+    # Install headers directly into the `dev` output
+    "--prefix-include-dir"
+    "${placeholder "dev"}/include"
   ];
   zigCheckFlags = finalAttrs.zigBuildFlags ++ ["test-lib-vt"];
 
@@ -69,17 +72,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   postInstall = ''
     mkdir -p "$dev/lib"
-    mv "$out/lib/libghostty-vt.a" "$dev/lib"
-    rm "$out/lib/libghostty-vt.so"
-    mv "$out/include" "$dev"
-    mv "$out/share" "$dev"
-
-    ln -sf "$out/lib/libghostty-vt.so.${lib.versions.major finalAttrs.version}"  "$dev/lib/libghostty-vt.so"
+    mv "$out/lib/libghostty-vt.a" "$dev/lib/"
   '';
 
   postFixup = ''
-    substituteInPlace "$dev/share/pkgconfig/libghostty-vt.pc" \
-      --replace-fail "$out" "$dev"
     substituteInPlace "$dev/share/pkgconfig/libghostty-vt-static.pc" \
       --replace-fail "$out" "$dev"
   '';
@@ -128,8 +124,7 @@ stdenv.mkDerivation (finalAttrs: {
         runHook preBuildHooks
 
         cc -o test test_libghostty_vt.c \
-          ''$(pkg-config --cflags --libs libghostty-vt) \
-          -Wl,-rpath,"${finalAttrs.finalPackage}/lib"
+          ''$(pkg-config --cflags --libs libghostty-vt)
 
         runHook postBuildHooks
       '';
@@ -207,8 +202,7 @@ stdenv.mkDerivation (finalAttrs: {
         runHook preBuildHooks
 
         cc -o test main.c \
-          ''$(pkg-config --cflags --libs libghostty-vt) \
-          -Wl,-rpath,"${finalAttrs.finalPackage}/lib"
+          ''$(pkg-config --cflags --libs libghostty-vt)
 
         runHook postBuildHooks
       '';

--- a/src/build/GhosttyLibVt.zig
+++ b/src/build/GhosttyLibVt.zig
@@ -371,8 +371,8 @@ fn pkgConfigFiles(
     return .{
         .shared = wf.add("libghostty-vt.pc", b.fmt(
             \\prefix={s}
-            \\includedir=${{prefix}}/include
-            \\libdir=${{prefix}}/lib
+            \\includedir={s}
+            \\libdir={s}
             \\
             \\Name: libghostty-vt
             \\URL: https://github.com/ghostty-org/ghostty
@@ -382,11 +382,18 @@ fn pkgConfigFiles(
             \\Libs: -L${{libdir}} -lghostty-vt
             \\Libs.private: {s}
             \\Requires.private: {s}
-        , .{ b.install_prefix, zig.version, libs_private, requires_private })),
+        , .{
+            b.install_prefix,
+            b.h_dir,
+            b.lib_dir,
+            zig.version,
+            libs_private,
+            requires_private,
+        })),
         .static = wf.add("libghostty-vt-static.pc", b.fmt(
             \\prefix={s}
-            \\includedir=${{prefix}}/include
-            \\libdir=${{prefix}}/lib
+            \\includedir={s}
+            \\libdir={s}
             \\
             \\Name: libghostty-vt-static
             \\URL: https://github.com/ghostty-org/ghostty
@@ -398,6 +405,8 @@ fn pkgConfigFiles(
             \\Requires.private: {s}
         , .{
             b.install_prefix,
+            b.h_dir,
+            b.lib_dir,
             zig.version,
             staticLibraryName(os_tag),
             libs_private,

--- a/src/build/GhosttyLibVt.zig
+++ b/src/build/GhosttyLibVt.zig
@@ -371,8 +371,8 @@ fn pkgConfigFiles(
     return .{
         .shared = wf.add("libghostty-vt.pc", b.fmt(
             \\prefix={s}
-            \\includedir={s}
-            \\libdir={s}
+            \\includedir=${{prefix}}/include
+            \\libdir=${{prefix}}/lib
             \\
             \\Name: libghostty-vt
             \\URL: https://github.com/ghostty-org/ghostty
@@ -382,18 +382,11 @@ fn pkgConfigFiles(
             \\Libs: -L${{libdir}} -lghostty-vt
             \\Libs.private: {s}
             \\Requires.private: {s}
-        , .{
-            b.install_prefix,
-            b.h_dir,
-            b.lib_dir,
-            zig.version,
-            libs_private,
-            requires_private,
-        })),
+        , .{ b.install_prefix, zig.version, libs_private, requires_private })),
         .static = wf.add("libghostty-vt-static.pc", b.fmt(
             \\prefix={s}
-            \\includedir={s}
-            \\libdir={s}
+            \\includedir=${{prefix}}/include
+            \\libdir=${{prefix}}/lib
             \\
             \\Name: libghostty-vt-static
             \\URL: https://github.com/ghostty-org/ghostty
@@ -405,8 +398,6 @@ fn pkgConfigFiles(
             \\Requires.private: {s}
         , .{
             b.install_prefix,
-            b.h_dir,
-            b.lib_dir,
             zig.version,
             staticLibraryName(os_tag),
             libs_private,


### PR DESCRIPTION
~`${prefix}/include` and `${prefix}/lib` are incorrect under split-prefix installs (e.g. Nix multi-output). Use `b.h_dir` / `b.lib_dir` instead and drop the unneeded Nix postInstall/postFixup hooks.~

Refactors the libghostty-vt derivation to:

- fix `libdir` pointing to the wrong output in the pkg-config files. This would throw a missing library error at runtime.
- reduce the amount of manual copying, linking, and patching of files.

An earlier version of this PR used the zig compiler + `.pc` files to do this. People pointed out concerns, so I came up with a simpler solution.

Claude Code was used to debug and write an initial fix. Final changes rewritten and simplified by me. No AI was used to write comments, descriptions, etc.