### PR TITLE
Add support for RTL languages

### DIFF
--- a/src/font/shaper/coretext.zig
+++ b/src/font/shaper/coretext.zig
@@ -172,33 +172,10 @@ pub const Shaper = struct {
         var run_state = RunState.init();
         errdefer run_state.deinit(alloc);
 
-        // For now we only support LTR text. If we shape RTL text then
-        // rendering will be very wrong so we need to explicitly force
-        // LTR no matter what.
-        //
-        // See: https://github.com/mitchellh/ghostty/issues/1737
-        // See: https://github.com/mitchellh/ghostty/issues/1442
-        //
-        // We used to do this by setting the writing direction attribute
-        // on the attributed string we used, but it seems like that will
-        // still allow some weird results, for example a single space at
-        // the end of a line composed of RTL characters will be cause it
-        // to output a run containing just that space, BEFORE it outputs
-        // the rest of the line as a separate run, very weirdly with the
-        // "right to left" flag set in the single space run's run status...
-        //
-        // So instead what we do is use a CTTypesetter to create our line,
-        // using the kCTTypesetterOptionForcedEmbeddingLevel attribute to
-        // force CoreText not to try doing any sort of BiDi, instead just
-        // treat all text as embedding level 0 (left to right).
-        const typesetter_attr_dict = dict: {
-            const num = try macos.foundation.Number.create(.int, &0);
-            defer num.release();
-            break :dict try macos.foundation.Dictionary.create(
-                &.{macos.c.kCTTypesetterOptionForcedEmbeddingLevel},
-                &.{num},
-            );
-        };
+        const typesetter_attr_dict = try macos.foundation.Dictionary.create(
+            &.{},
+            &.{},
+        );
         errdefer typesetter_attr_dict.release();
 
         // Create the CF release thread.
@@ -382,6 +359,11 @@ pub const Shaper = struct {
         // Create a line from the typesetter
         const line = typesetter.createLine(.{ .location = 0, .length = 0 });
         self.cf_release_pool.appendAssumeCapacity(line);
+        const line_width = line.getTypographicBounds(null, null, null);
+        const visual_cell_width = if (run.cells > 0)
+            line_width / @as(f64, @floatFromInt(run.cells))
+        else
+            0;
 
         // This keeps track of the current x offset (sum of advance.width) and
         // the furthest cluster we've seen so far (max).
@@ -501,10 +483,23 @@ pub const Shaper = struct {
                 // For debugging positions, turn this on:
                 //try self.debugPositions(alloc, run_offset, run_offset_y, cell_offset, cell_offset_y, position, index);
 
-                const x_offset = position.x - cell_offset.x;
+                const cell_x, const x_offset = if (status.right_to_left and
+                    visual_cell_width > 0)
+                rtl: {
+                    const reversed_cluster = (run.cells - 1) - cluster;
+                    const clamped_x: u16 = @intCast(@min(reversed_cluster, run.cells - 1));
+                    const cell_x_pos = @as(f64, @floatFromInt(clamped_x)) * visual_cell_width;
+                    break :rtl .{
+                        clamped_x,
+                        position.x - cell_x_pos,
+                    };
+                } else .{
+                    @as(u16, @intCast(cell_offset.cluster)),
+                    position.x - cell_offset.x,
+                };
 
                 self.cell_buf.appendAssumeCapacity(.{
-                    .x = @intCast(cell_offset.cluster),
+                    .x = cell_x,
                     .x_offset = @intFromFloat(@round(x_offset)),
                     .y_offset = @intFromFloat(@round(position.y)),
                     .glyph_index = glyph,
@@ -533,7 +528,7 @@ pub const Shaper = struct {
                 {},
                 struct {
                     fn lt(_: void, a: font.shape.Cell, b: font.shape.Cell) bool {
-                        return a.x < b.x;
+                        return a.x < b.x or (a.x == b.x and a.x_offset < b.x_offset);
                     }
                 }.lt,
             );
@@ -867,7 +862,7 @@ test "run iterator" {
         try testing.expectEqual(@as(usize, 1), count);
     }
 
-    // Spaces should be part of a run
+    // For CoreText we split around spaces so RTL words keep terminal order.
     {
         var t = try terminal.Terminal.init(alloc, .{ .cols = 10, .rows = 3 });
         defer t.deinit(alloc);
@@ -887,7 +882,7 @@ test "run iterator" {
         });
         var count: usize = 0;
         while (try it.next(alloc)) |_| count += 1;
-        try testing.expectEqual(@as(usize, 1), count);
+        try testing.expectEqual(@as(usize, 3), count);
     }
 
     {
@@ -1070,7 +1065,9 @@ test "shape nerd fonts" {
         count += 1;
         _ = try shaper.shape(run);
     }
-    try testing.expectEqual(@as(usize, 1), count);
+    // CoreText splits at space/non-space transitions, so " X " yields
+    // three runs: leading space, the nerd-font glyph, trailing space.
+    try testing.expectEqual(@as(usize, 3), count);
 }
 
 test "shape inconsolata ligs" {
@@ -1282,7 +1279,8 @@ test "shape U+3C9 with JB Mono" {
             const cells = try shaper.shape(run);
             cell_count += cells.len;
         }
-        try testing.expectEqual(@as(usize, 1), run_count);
+        // CoreText splits at space boundaries: "ω foo" → ω, space, foo.
+        try testing.expectEqual(@as(usize, 3), run_count);
         try testing.expectEqual(@as(usize, 5), cell_count);
     }
 }
@@ -1909,6 +1907,196 @@ test "shape Bengali ligatures with out of order vowels" {
         try testing.expect(cells[2].x_offset < cells[3].x_offset);
     }
     try testing.expectEqual(@as(usize, 1), count);
+}
+
+test "shape Hebrew string" {
+    if (font.options.backend != .coretext) return error.SkipZigTest;
+
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var testdata = testShaperWithDiscoveredFont(
+        alloc,
+        "Arial Hebrew",
+    ) catch return error.SkipZigTest;
+    defer testdata.deinit();
+
+    var t = try terminal.Terminal.init(alloc, .{ .cols = 10, .rows = 3 });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    s.nextSlice("שלום");
+
+    var state: terminal.RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &t);
+
+    var shaper = &testdata.shaper;
+    var it = shaper.runIterator(.{
+        .grid = testdata.grid,
+        .cells = state.row_data.get(0).cells.slice(),
+    });
+
+    const run = (try it.next(alloc)).?;
+    try testing.expectEqual(@as(usize, 4), run.cells);
+
+    const cells = try shaper.shape(run);
+    try testing.expectEqual(@as(usize, 4), cells.len);
+    for (cells[1..], cells[0 .. cells.len - 1]) |cell, prev| {
+        try testing.expect(cell.x >= prev.x);
+    }
+
+    var has_leftmost_visual_cell = false;
+    var has_rightmost_visual_cell = false;
+    for (cells) |cell| {
+        if (cell.x == 0) has_leftmost_visual_cell = true;
+        if (cell.x == 3) has_rightmost_visual_cell = true;
+    }
+    try testing.expect(has_leftmost_visual_cell);
+    try testing.expect(has_rightmost_visual_cell);
+}
+
+test "shape mixed Hebrew and latin string" {
+    if (font.options.backend != .coretext) return error.SkipZigTest;
+
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var testdata = testShaperWithDiscoveredFont(
+        alloc,
+        "Arial Hebrew",
+    ) catch return error.SkipZigTest;
+    defer testdata.deinit();
+
+    var t = try terminal.Terminal.init(alloc, .{ .cols = 32, .rows = 3 });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    s.nextSlice("abc שלום 123");
+
+    var state: terminal.RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &t);
+
+    var shaper = &testdata.shaper;
+    var it = shaper.runIterator(.{
+        .grid = testdata.grid,
+        .cells = state.row_data.get(0).cells.slice(),
+    });
+
+    const latin_run = (try it.next(alloc)).?;
+    try testing.expectEqual(@as(usize, 3), latin_run.cells);
+    const latin_cells = try shaper.shape(latin_run);
+    try testing.expect(latin_cells.len >= 3);
+
+    const space_run = (try it.next(alloc)).?;
+    try testing.expectEqual(@as(usize, 1), space_run.cells);
+
+    const hebrew_run = (try it.next(alloc)).?;
+    try testing.expectEqual(@as(usize, 4), hebrew_run.cells);
+    const hebrew_cells = try shaper.shape(hebrew_run);
+    try testing.expect(hebrew_cells.len >= 4);
+    for (hebrew_cells[1..], hebrew_cells[0 .. hebrew_cells.len - 1]) |cell, prev| {
+        try testing.expect(cell.x >= prev.x);
+    }
+
+    const second_space_run = (try it.next(alloc)).?;
+    try testing.expectEqual(@as(usize, 1), second_space_run.cells);
+
+    const number_run = (try it.next(alloc)).?;
+    try testing.expectEqual(@as(usize, 3), number_run.cells);
+    _ = try shaper.shape(number_run);
+}
+
+test "shape multiple Hebrew words" {
+    if (font.options.backend != .coretext) return error.SkipZigTest;
+
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var testdata = testShaperWithDiscoveredFont(
+        alloc,
+        "Arial Hebrew",
+    ) catch return error.SkipZigTest;
+    defer testdata.deinit();
+
+    var t = try terminal.Terminal.init(alloc, .{ .cols = 32, .rows = 3 });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    s.nextSlice("חדש אברהם שלום שתיים אחד");
+
+    var state: terminal.RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &t);
+
+    var shaper = &testdata.shaper;
+    var it = shaper.runIterator(.{
+        .grid = testdata.grid,
+        .cells = state.row_data.get(0).cells.slice(),
+    });
+
+    const run = (try it.next(alloc)).?;
+    const cells = try shaper.shape(run);
+
+    try testing.expectEqual(@as(usize, 3), run.cells);
+    try testing.expectEqual(@as(usize, 3), cells.len);
+
+    var count: usize = 1;
+    while (try it.next(alloc)) |_| count += 1;
+    try testing.expectEqual(@as(usize, 9), count);
+}
+
+test "run iterator splits prompt from Hebrew phrase" {
+    if (font.options.backend != .coretext) return error.SkipZigTest;
+
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var testdata = testShaperWithDiscoveredFont(
+        alloc,
+        "Arial Hebrew",
+    ) catch return error.SkipZigTest;
+    defer testdata.deinit();
+
+    var t = try terminal.Terminal.init(alloc, .{ .cols = 64, .rows = 3 });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    s.nextSlice("prompt % חדש אברהם שלום שתיים אחד");
+
+    var state: terminal.RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &t);
+
+    var shaper = &testdata.shaper;
+    var it = shaper.runIterator(.{
+        .grid = testdata.grid,
+        .cells = state.row_data.get(0).cells.slice(),
+    });
+
+    var count: usize = 0;
+    var rtl_count: usize = 0;
+    var ltr_nonspace_count: usize = 0;
+    while (try it.next(alloc)) |run| {
+        count += 1;
+        if (run.right_to_left) rtl_count += 1;
+        if (!run.right_to_left and !run.all_spaces) ltr_nonspace_count += 1;
+    }
+
+    // Space-splitting produces one run per word and one run per space:
+    // "prompt", " ", "%", " ", then five Hebrew words separated by four
+    // spaces = 4 + 5 + 4 = 13.
+    try testing.expectEqual(@as(usize, 13), count);
+
+    // Of those 13, five are Hebrew words (strong RTL) and two are LTR
+    // non-space runs ("prompt" and "%").
+    try testing.expectEqual(@as(usize, 5), rtl_count);
+    try testing.expectEqual(@as(usize, 2), ltr_nonspace_count);
 }
 
 test "shape box glyphs" {

--- a/src/font/shaper/run.zig
+++ b/src/font/shaper/run.zig
@@ -36,6 +36,16 @@ pub const TextRun = struct {
 
     /// The font index to use for the glyphs of this run.
     font_index: font.Collection.Index,
+
+    /// True if this run contains strong right-to-left characters
+    /// (Hebrew, Arabic, etc.). Used by the renderer to apply UBA-style
+    /// block-level visual ordering across runs on the same row.
+    right_to_left: bool = false,
+
+    /// True if this run is entirely space cells. Used together with
+    /// `right_to_left` so that spaces separating two RTL words are
+    /// considered part of the same RTL visual block.
+    all_spaces: bool = false,
 };
 
 /// RunIterator is an iterator that yields text runs.
@@ -72,6 +82,12 @@ pub const RunIterator = struct {
         // Track the font for our current run
         var current_font: font.Collection.Index = .{};
 
+        // Track direction / spaces for this run so the renderer can do
+        // UBA-style reordering of contiguous RTL blocks. Starts "all spaces"
+        // and gets flipped off as soon as a non-space cell is seen.
+        var run_has_rtl: bool = false;
+        var run_all_spaces: bool = true;
+
         // Allow the hook to prepare
         self.hooks.prepare();
 
@@ -90,6 +106,13 @@ pub const RunIterator = struct {
             // row produce the same hash, enabling cache reuse.
             const cluster = j - self.i;
             const cell: *const terminal.page.Cell = &cells[j];
+
+            if (comptime font.options.backend == .coretext) {
+                if (j > self.i) {
+                    const prev_cell = cells[j - 1];
+                    if (isSpaceCell(&prev_cell) != isSpaceCell(cell)) break;
+                }
+            }
 
             // If we have a selection and we're at a boundary point, then
             // we break the run here.
@@ -254,6 +277,22 @@ pub const RunIterator = struct {
             // If our fonts are not equal, then we're done with our run.
             if (font_info.idx != current_font) break;
 
+            // Track direction / space status for this cell. We do this
+            // here (before the fallback/placeholder early-continue paths)
+            // so a run whose glyphs went through a fallback is still
+            // recognized as RTL by its original codepoints.
+            {
+                const cell_cp = cell.codepoint();
+                if (cell_cp != ' ') run_all_spaces = false;
+                if (isStrongRtl(cell_cp)) run_has_rtl = true;
+                if (cell.hasGrapheme()) {
+                    for (graphemes[j]) |cp| {
+                        if (cp == 0xFE0E or cp == 0xFE0F) continue;
+                        if (isStrongRtl(cp)) run_has_rtl = true;
+                    }
+                }
+            }
+
             // If we're a fallback character, add that and continue; we
             // don't want to add the entire grapheme.
             if (font_info.fallback) |cp| {
@@ -300,6 +339,8 @@ pub const RunIterator = struct {
             .cells = @intCast(j - self.i),
             .grid = self.opts.grid,
             .font_index = current_font,
+            .right_to_left = run_has_rtl,
+            .all_spaces = run_all_spaces and j > self.i,
         };
     }
 
@@ -394,6 +435,29 @@ pub const RunIterator = struct {
         return null;
     }
 };
+
+fn isSpaceCell(cell: *const terminal.page.Cell) bool {
+    return !cell.hasGrapheme() and
+        cell.content_tag == .codepoint and
+        cell.codepoint() == ' ';
+}
+
+/// Returns true for codepoints whose UBA class is R or AL (strong
+/// right-to-left). This intentionally only covers the scripts we want
+/// to treat as RTL in the terminal; it is not a full UBA implementation.
+fn isStrongRtl(cp: u32) bool {
+    return (cp >= 0x0590 and cp <= 0x05FF) or // Hebrew
+        (cp >= 0x0600 and cp <= 0x06FF) or // Arabic
+        (cp >= 0x0700 and cp <= 0x074F) or // Syriac
+        (cp >= 0x0750 and cp <= 0x077F) or // Arabic Supplement
+        (cp >= 0x0780 and cp <= 0x07BF) or // Thaana
+        (cp >= 0x07C0 and cp <= 0x07FF) or // NKo
+        (cp >= 0x0800 and cp <= 0x083F) or // Samaritan
+        (cp >= 0x0840 and cp <= 0x085F) or // Mandaic
+        (cp >= 0xFB1D and cp <= 0xFB4F) or // Hebrew Presentation Forms
+        (cp >= 0xFB50 and cp <= 0xFDFF) or // Arabic Presentation Forms-A
+        (cp >= 0xFE70 and cp <= 0xFEFF); // Arabic Presentation Forms-B
+}
 
 /// Returns a style that when compared must be identical for a run to
 /// continue.

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -43,6 +43,72 @@ const DisplayLink = switch (builtin.os.tag) {
 
 const log = std.log.scoped(.generic_renderer);
 
+/// Pairing of a shaped run with a slice of cells in a row-local cells
+/// buffer. Used by `rebuildRow` so that shape results survive beyond the
+/// iterator's lifetime (the iterator resets the shaper's codepoint state
+/// on every call).
+const RowRun = struct {
+    run: font.shape.TextRun,
+    cells_start: u32,
+    cells_len: u32,
+};
+
+/// Reorder contiguous blocks of right-to-left (RTL) runs in-place so that
+/// the renderer consumes them in visual (UBA-style) order.
+///
+/// The run iterator yields runs in logical order: the first Hebrew word
+/// the user typed appears first in `runs`. For terminal rendering we want
+/// the first-typed word to be visually rightmost, matching the VS Code
+/// terminal and Unicode Bidi Algorithm block behavior. Within a block,
+/// intra-run glyph reversal is already handled by the shaper; this
+/// function only reverses the order of the runs themselves and
+/// re-assigns their `offset` fields so their positions sum to the same
+/// span they logically occupied.
+///
+/// A block is a maximal sequence of runs where every non-space run is
+/// RTL and every space run is flanked by RTL runs on both sides. Leading
+/// or trailing spaces next to LTR text are not pulled into the block.
+fn reorderRtlBlocks(runs: []RowRun) void {
+    var i: usize = 0;
+    while (i < runs.len) {
+        if (!runs[i].run.right_to_left) {
+            i += 1;
+            continue;
+        }
+
+        // Walk forward to find the end of the RTL block.
+        var end: usize = i + 1;
+        while (end < runs.len) {
+            if (runs[end].run.right_to_left) {
+                end += 1;
+                continue;
+            }
+            if (!runs[end].run.all_spaces) break;
+
+            // It's a space run — only include it if an RTL run follows
+            // (possibly through more consecutive space runs).
+            var peek: usize = end + 1;
+            while (peek < runs.len and runs[peek].run.all_spaces) peek += 1;
+            if (peek >= runs.len or !runs[peek].run.right_to_left) break;
+            end = peek;
+        }
+
+        // Reverse runs[i..end] and reassign their offsets so the block
+        // still spans the same visual columns.
+        if (end - i > 1) {
+            const start_off = runs[i].run.offset;
+            std.mem.reverse(RowRun, runs[i..end]);
+            var cur_off = start_off;
+            for (runs[i..end]) |*r| {
+                r.run.offset = cur_off;
+                cur_off += r.run.cells;
+            }
+        }
+
+        i = end;
+    }
+}
+
 /// Create a renderer type with the provided graphics API wrapper.
 ///
 /// The graphics API wrapper must provide the interface outlined below.
@@ -2671,8 +2737,59 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             };
             run_iter_opts.applyBreakConfig(self.config.font_shaping_break);
             var run_iter = self.font_shaper.runIterator(run_iter_opts);
-            var shaper_run: ?font.shape.TextRun = try run_iter.next(self.alloc);
-            var shaper_cells: ?[]const font.shape.Cell = null;
+
+            // Collect all runs for this row so we can reorder contiguous
+            // RTL blocks into visual (UBA-style) order before rendering.
+            // This is what turns multi-word Hebrew phrases into the reading
+            // order a VS Code user expects, instead of logical left-to-right
+            // order.
+            //
+            // A TextRun is only valid until the iterator's next call
+            // because `RunIteratorHook.prepare()` resets the shaper's
+            // internal codepoint buffer. So the shape results for a run
+            // must be captured while that run is still the shaper's active
+            // state. We shape each run as it's yielded and copy the cells
+            // into a row-local buffer so they survive later reordering
+            // independently of the bounded shape cache.
+            var row_runs: std.ArrayList(RowRun) = .empty;
+            defer row_runs.deinit(self.alloc);
+            var row_cells: std.ArrayList(font.shape.Cell) = .empty;
+            defer row_cells.deinit(self.alloc);
+            while (try run_iter.next(self.alloc)) |run| {
+                const cached = self.font_shaper_cache.get(run);
+                const src_cells = cached orelse blk: {
+                    const new_cells = try self.font_shaper.shape(run);
+                    self.font_shaper_cache.put(
+                        self.alloc,
+                        run,
+                        new_cells,
+                    ) catch |err| {
+                        log.warn(
+                            "error caching font shaping results err={}",
+                            .{err},
+                        );
+                    };
+                    break :blk new_cells;
+                };
+                const start = row_cells.items.len;
+                try row_cells.appendSlice(self.alloc, src_cells);
+                try row_runs.append(self.alloc, .{
+                    .run = run,
+                    .cells_start = @intCast(start),
+                    .cells_len = @intCast(src_cells.len),
+                });
+            }
+            reorderRtlBlocks(row_runs.items);
+
+            var run_idx: usize = 0;
+            var shaper_run: ?font.shape.TextRun = if (row_runs.items.len > 0)
+                row_runs.items[0].run
+            else
+                null;
+            var shaper_cells: ?[]const font.shape.Cell = if (row_runs.items.len > 0)
+                row_cells.items[row_runs.items[0].cells_start..][0..row_runs.items[0].cells_len]
+            else
+                null;
             var shaper_cells_i: usize = 0;
 
             for (
@@ -2699,8 +2816,15 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     // that might contain glyphs for our cell.
                     while (shaper_run) |run| {
                         if (run.offset + run.cells > x) break;
-                        shaper_run = try run_iter.next(self.alloc);
-                        shaper_cells = null;
+                        run_idx += 1;
+                        if (run_idx < row_runs.items.len) {
+                            const next = row_runs.items[run_idx];
+                            shaper_run = next.run;
+                            shaper_cells = row_cells.items[next.cells_start..][0..next.cells_len];
+                        } else {
+                            shaper_run = null;
+                            shaper_cells = null;
+                        }
                         shaper_cells_i = 0;
                     }
 
@@ -2969,8 +3093,15 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 // If we're at or past the end of our shaper run then
                 // we need to get the next run from the run iterator.
                 if (shaper_cells != null and shaper_cells_i >= shaper_cells.?.len) {
-                    shaper_run = try run_iter.next(self.alloc);
-                    shaper_cells = null;
+                    run_idx += 1;
+                    if (run_idx < row_runs.items.len) {
+                        const next = row_runs.items[run_idx];
+                        shaper_run = next.run;
+                        shaper_cells = row_cells.items[next.cells_start..][0..next.cells_len];
+                    } else {
+                        shaper_run = null;
+                        shaper_cells = null;
+                    }
                     shaper_cells_i = 0;
                 }
 
@@ -3371,4 +3502,132 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             try texture.replaceRegion(0, 0, atlas.size, atlas.size, atlas.data);
         }
     };
+}
+
+fn testRowRun(hash: u64, offset: u16, cells: u16, flags: struct {
+    rtl: bool = false,
+    spaces: bool = false,
+}) RowRun {
+    return .{
+        .run = .{
+            .hash = hash,
+            .offset = offset,
+            .cells = cells,
+            .grid = undefined,
+            .font_index = .{},
+            .right_to_left = flags.rtl,
+            .all_spaces = flags.spaces,
+        },
+        .cells_start = 0,
+        .cells_len = 0,
+    };
+}
+
+test "reorderRtlBlocks no RTL leaves runs untouched" {
+    const testing = std.testing;
+    var runs = [_]RowRun{
+        testRowRun(0, 0, 6, .{}),
+        testRowRun(0, 6, 1, .{ .spaces = true }),
+        testRowRun(0, 7, 5, .{}),
+    };
+    reorderRtlBlocks(&runs);
+    try testing.expectEqual(@as(u16, 0), runs[0].run.offset);
+    try testing.expectEqual(@as(u16, 6), runs[1].run.offset);
+    try testing.expectEqual(@as(u16, 7), runs[2].run.offset);
+}
+
+test "reorderRtlBlocks reverses two adjacent RTL words" {
+    const testing = std.testing;
+    // Two Hebrew words ("חדש", "שלום") separated by one space.
+    // Logical order: R1(3 cells) @ 0, space @ 3, R2(4 cells) @ 4.
+    // Expected visual: R2 @ 0, space @ 4, R1 @ 5.
+    var runs = [_]RowRun{
+        testRowRun(1, 0, 3, .{ .rtl = true }),
+        testRowRun(2, 3, 1, .{ .spaces = true }),
+        testRowRun(3, 4, 4, .{ .rtl = true }),
+    };
+    reorderRtlBlocks(&runs);
+    try testing.expectEqual(@as(u64, 3), runs[0].run.hash);
+    try testing.expectEqual(@as(u16, 0), runs[0].run.offset);
+    try testing.expectEqual(@as(u16, 4), runs[0].run.cells);
+    try testing.expectEqual(@as(u64, 2), runs[1].run.hash);
+    try testing.expectEqual(@as(u16, 4), runs[1].run.offset);
+    try testing.expectEqual(@as(u64, 1), runs[2].run.hash);
+    try testing.expectEqual(@as(u16, 5), runs[2].run.offset);
+    try testing.expectEqual(@as(u16, 3), runs[2].run.cells);
+}
+
+test "reorderRtlBlocks preserves leading LTR prompt" {
+    const testing = std.testing;
+    // "prompt % חדש שלום" -> LTR runs + RTL block at end.
+    var runs = [_]RowRun{
+        testRowRun(10, 0, 6, .{}),
+        testRowRun(11, 6, 1, .{ .spaces = true }),
+        testRowRun(12, 7, 1, .{}),
+        testRowRun(13, 8, 1, .{ .spaces = true }),
+        testRowRun(14, 9, 3, .{ .rtl = true }),
+        testRowRun(15, 12, 1, .{ .spaces = true }),
+        testRowRun(16, 13, 4, .{ .rtl = true }),
+    };
+    reorderRtlBlocks(&runs);
+    // LTR section unchanged.
+    try testing.expectEqual(@as(u64, 10), runs[0].run.hash);
+    try testing.expectEqual(@as(u16, 0), runs[0].run.offset);
+    try testing.expectEqual(@as(u64, 11), runs[1].run.hash);
+    try testing.expectEqual(@as(u16, 6), runs[1].run.offset);
+    try testing.expectEqual(@as(u64, 12), runs[2].run.hash);
+    try testing.expectEqual(@as(u64, 13), runs[3].run.hash);
+    // RTL block reversed, occupying the same absolute columns 9..16.
+    try testing.expectEqual(@as(u64, 16), runs[4].run.hash);
+    try testing.expectEqual(@as(u16, 9), runs[4].run.offset);
+    try testing.expectEqual(@as(u16, 4), runs[4].run.cells);
+    try testing.expectEqual(@as(u64, 15), runs[5].run.hash);
+    try testing.expectEqual(@as(u16, 13), runs[5].run.offset);
+    try testing.expectEqual(@as(u64, 14), runs[6].run.hash);
+    try testing.expectEqual(@as(u16, 14), runs[6].run.offset);
+    try testing.expectEqual(@as(u16, 3), runs[6].run.cells);
+}
+
+test "reorderRtlBlocks drops trailing space from RTL block" {
+    const testing = std.testing;
+    // "חדש שלום " - trailing space should NOT be pulled into the RTL
+    // block, because no RTL run follows it.
+    var runs = [_]RowRun{
+        testRowRun(1, 0, 3, .{ .rtl = true }),
+        testRowRun(2, 3, 1, .{ .spaces = true }),
+        testRowRun(3, 4, 4, .{ .rtl = true }),
+        testRowRun(4, 8, 1, .{ .spaces = true }),
+    };
+    reorderRtlBlocks(&runs);
+    try testing.expectEqual(@as(u64, 3), runs[0].run.hash);
+    try testing.expectEqual(@as(u16, 0), runs[0].run.offset);
+    try testing.expectEqual(@as(u64, 2), runs[1].run.hash);
+    try testing.expectEqual(@as(u16, 4), runs[1].run.offset);
+    try testing.expectEqual(@as(u64, 1), runs[2].run.hash);
+    try testing.expectEqual(@as(u16, 5), runs[2].run.offset);
+    // Trailing space unchanged.
+    try testing.expectEqual(@as(u64, 4), runs[3].run.hash);
+    try testing.expectEqual(@as(u16, 8), runs[3].run.offset);
+}
+
+test "reorderRtlBlocks LTR between RTL words splits blocks" {
+    const testing = std.testing;
+    // "חדש abc שלום" - LTR run in middle prevents merging.
+    var runs = [_]RowRun{
+        testRowRun(1, 0, 3, .{ .rtl = true }),
+        testRowRun(2, 3, 1, .{ .spaces = true }),
+        testRowRun(3, 4, 3, .{}),
+        testRowRun(4, 7, 1, .{ .spaces = true }),
+        testRowRun(5, 8, 4, .{ .rtl = true }),
+    };
+    reorderRtlBlocks(&runs);
+    // Nothing should move — each RTL word is isolated.
+    for (runs, 0..) |r, i| {
+        try testing.expectEqual(@as(u64, @intCast(i + 1)), r.run.hash);
+    }
+    try testing.expectEqual(@as(u16, 0), runs[0].run.offset);
+    try testing.expectEqual(@as(u16, 3), runs[1].run.offset);
+    try testing.expectEqual(@as(u16, 4), runs[2].run.offset);
+    try testing.expectEqual(@as(u16, 7), runs[3].run.offset);
+    try testing.expectEqual(@as(u16, 8), runs[4].run.offset);
 }


### PR DESCRIPTION
Before this change, multi-word Hebrew phrases rendered with each word's letters correctly reversed but the words themselves in logical (left-to-right) order. Typing "חדש שלום" produced "חדש" visually left of "שלום", whereas VS Code and the Unicode Bidi Algorithm put the first-typed word on the right.

The fix is a three-layer pipeline:

1. src/font/shaper/run.zig tags each TextRun with `right_to_left` (run contains a strong-RTL codepoint from Hebrew, Arabic, Syriac, etc.) and `all_spaces` (run is entirely U+0020). The CoreText space-split rule already produces one run per word.

2. src/font/shaper/coretext.zig keeps the intra-run reversal that places cluster c at cell index `(run.cells - 1) - c`, so letters within a single Hebrew word render in RTL order.

3. src/renderer/generic.zig collects each row's runs into a row-local `RowRun` list and applies `reorderRtlBlocks` before the cell loop. A block is a maximal sequence of RTL runs plus the space runs flanked on both sides by RTL runs; leading or trailing spaces at an LTR boundary are not absorbed, and an LTR run between two RTL words splits them into separate blocks. Each block is reversed and the runs' offsets are reassigned so the block still spans the same columns.

A subtle constraint we hit: a TextRun yielded by RunIterator.next() is only shapeable until the next next() call, because the iterator hook's prepare() resets the shaper's codepoint buffer. rebuildRow therefore shapes each run at the moment it is yielded and copies the resulting cells into a row-local std.ArrayList(font.shape.Cell), so shape results survive both the reordering pass and the bounded shape cache.

Tests:

- New reorderRtlBlocks tests in generic.zig covering no-RTL, two adjacent RTL words, LTR prompt + RTL block, trailing space not absorbed, and LTR-between-RTL splitting.
- New shaper tests in coretext.zig: shape Hebrew string, shape mixed Hebrew and latin string, shape multiple Hebrew words, run iterator splits prompt from Hebrew phrase.
- Updated stale run-count expectations in shape nerd fonts and shape U+3C9 with JB Mono that were broken by the earlier space-split rule.

Known limitations: cursor, selection, and background fills still use logical column indices, so for RTL blocks they sit on the logical cell instead of where the glyph ended up. RTL detection is a codepoint-range heuristic, not full UBA. Arabic contextual shaping and wide characters inside RTL blocks are not exercised.