### PR TITLE
ci: add GNU-ABI Windows library build job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,6 +96,7 @@ jobs:
       - build-libghostty-vt-android
       - build-libghostty-vt-macos
       - build-libghostty-vt-windows
+      - build-libghostty-windows-gnu
       - build-linux
       - build-linux-libghostty
       - build-nix
@@ -712,6 +713,20 @@ jobs:
 
       - name: Build libghostty-vt
         run: zig build -Demit-lib-vt
+
+  build-libghostty-windows-gnu:
+    runs-on: namespace-profile-ghostty-windows
+    timeout-minutes: 45
+    needs: test
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Zig
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+
+      - name: Build libghostty (GNU ABI)
+        run: zig build -Dtarget=native-native-gnu -Dapp-runtime=none
 
   build-linux:
     strategy:


### PR DESCRIPTION
Adds a new CI job `build-libghostty-windows-gnu` that exercises the GNU-ABI Windows library build path. The existing `build-libghostty-vt-windows` job covers the MSVC ABI; with the recent fixes (#12373 / #12381 / #12382) the GNU path is now viable, and this job catches regressions before the upcoming Win32 apprt (discussion #2563) starts to depend on it.

Named `build-libghostty-windows-gnu` rather than following the `build-libghostty-vt-*` convention because this job also builds `ghostty-internal.dll`, not just libghostty-vt. Happy to rename if you prefer a different convention.

Part of the Win32 apprt upstreaming series (see discussion #2563 / mattn/ghostty#1).