### PR TITLE
apprt: minimal Win32 skeleton (window + WGL + CoreSurface wiring)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -61,6 +61,12 @@
             .hash = "gobject-0.3.0-Skun7ANLnwDvEfIpVmohcppXgOvg_I6YOJFmPIsKfXk-",
             .lazy = true,
         },
+        .win32 = .{
+            // marlersoft/zigwin32 -- Win32 API bindings for the win32 apprt.
+            .url = "git+https://github.com/marlersoft/zigwin32#ec98bb4d9eea532320a8551720a9e3ec6de64994",
+            .hash = "win32-25.0.28-preview-mX5pFWMt5QPTVIGh3r2-OpPunpcCCjApyRbA6Zn6WALH",
+            .lazy = true,
+        },
 
         // C libs
         .dcimgui = .{ .path = "./pkg/dcimgui", .lazy = true },

--- a/src/apprt.zig
+++ b/src/apprt.zig
@@ -16,6 +16,7 @@ pub const action = @import("apprt/action.zig");
 pub const ipc = @import("apprt/ipc.zig");
 pub const gtk = @import("apprt/gtk.zig");
 pub const none = @import("apprt/none.zig");
+pub const win32 = @import("apprt/win32.zig");
 pub const browser = @import("apprt/browser.zig");
 pub const embedded = @import("apprt/embedded.zig");
 pub const surface = @import("apprt/surface.zig");
@@ -43,6 +44,7 @@ pub const runtime = switch (build_config.artifact) {
     .exe => switch (build_config.app_runtime) {
         .none => none,
         .gtk => gtk,
+        .win32 => win32,
     },
     .lib => embedded,
     .wasm_module => browser,

--- a/src/apprt/runtime.zig
+++ b/src/apprt/runtime.zig
@@ -11,11 +11,17 @@ pub const Runtime = enum {
     /// approach to building the application.
     gtk,
 
+    /// Win32. Native Windows application using the Win32 API with OpenGL
+    /// rendering.
+    win32,
+
     pub fn default(target: std.Target) Runtime {
         return switch (target.os.tag) {
             // The Linux and FreeBSD default is GTK because it is a full
             // featured application.
             .linux, .freebsd => .gtk,
+            // Windows uses the native Win32 API.
+            .windows => .win32,
             // Otherwise, we do NONE so we don't create an exe and we create
             // libghostty. On macOS, Xcode is used to build the app that links
             // to libghostty.

--- a/src/apprt/structs.zig
+++ b/src/apprt/structs.zig
@@ -54,7 +54,7 @@ pub const Clipboard = enum(Backing) {
             .{ .name = "GhosttyApprtClipboard" },
         ),
 
-        .none => void,
+        .none, .win32 => void,
     };
 };
 

--- a/src/apprt/win32.zig
+++ b/src/apprt/win32.zig
@@ -1,0 +1,8 @@
+// The required comptime API for any apprt.
+pub const App = @import("win32/App.zig");
+pub const Surface = @import("win32/Surface.zig");
+pub const resourcesDir = @import("../os/main.zig").resourcesDir;
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/apprt/win32/App.zig
+++ b/src/apprt/win32/App.zig
@@ -350,6 +350,14 @@ fn wndProc(hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM) callconv(.wina
                 if (width > 0 and height > 0) {
                     app.surface.width = width;
                     app.surface.height = height;
+                    if (app.surface.core_surface) |core| {
+                        core.sizeCallback(.{
+                            .width = width,
+                            .height = height,
+                        }) catch |err| {
+                            log.err("size callback error: {}", .{err});
+                        };
+                    }
                 }
             }
             return 0;

--- a/src/apprt/win32/App.zig
+++ b/src/apprt/win32/App.zig
@@ -117,6 +117,7 @@ extern "user32" fn GetWindowLongPtrW(hWnd: HWND, nIndex: c_int) callconv(.winapi
 extern "user32" fn GetClientRect(hWnd: HWND, lpRect: *RECT) callconv(.winapi) BOOL;
 extern "user32" fn InvalidateRect(hWnd: ?HWND, lpRect: ?*const RECT, bErase: BOOL) callconv(.winapi) BOOL;
 extern "kernel32" fn GetModuleHandleW(lpModuleName: ?[*:0]const u16) callconv(.winapi) ?HINSTANCE;
+extern "kernel32" fn GetLastError() callconv(.winapi) DWORD;
 
 /// The core app instance.
 core_app: *CoreApp,
@@ -194,7 +195,9 @@ pub fn run(self: *App) !void {
 pub fn terminate(self: *App) void {
     self.surface.deinit();
     if (self.hwnd) |hwnd| {
-        _ = DestroyWindow(hwnd);
+        if (DestroyWindow(hwnd) == 0) {
+            log.warn("DestroyWindow failed: err={d}", .{GetLastError()});
+        }
         self.hwnd = null;
     }
     self.config.deinit();
@@ -203,7 +206,9 @@ pub fn terminate(self: *App) void {
 
 pub fn wakeup(self: *App) void {
     if (self.hwnd) |hwnd| {
-        _ = PostMessageW(hwnd, WM_WAKEUP, 0, 0);
+        if (PostMessageW(hwnd, WM_WAKEUP, 0, 0) == 0) {
+            log.warn("PostMessage(WM_WAKEUP) failed: err={d}", .{GetLastError()});
+        }
     }
 }
 

--- a/src/apprt/win32/App.zig
+++ b/src/apprt/win32/App.zig
@@ -1,0 +1,289 @@
+/// Win32 application runtime for Ghostty. This is a minimal native Windows
+/// application using the Win32 API with OpenGL rendering.
+const App = @This();
+
+const std = @import("std");
+const builtin = @import("builtin");
+const Allocator = std.mem.Allocator;
+const apprt = @import("../../apprt.zig");
+const configpkg = @import("../../config.zig");
+const Config = configpkg.Config;
+const CoreApp = @import("../../App.zig");
+const CoreSurface = @import("../../Surface.zig");
+const Surface = @import("Surface.zig");
+
+const log = std.log.scoped(.win32);
+
+// Win32 type definitions
+const BOOL = i32;
+const UINT = u32;
+const DWORD = u32;
+const WPARAM = usize;
+const LPARAM = isize;
+const LRESULT = isize;
+const HWND = std.os.windows.HWND;
+const HINSTANCE = std.os.windows.HINSTANCE;
+const HICON = ?*anyopaque;
+const HCURSOR = ?*anyopaque;
+const HBRUSH = ?*anyopaque;
+const HDC = ?*anyopaque;
+const HMENU = ?*anyopaque;
+const ATOM = u16;
+
+const POINT = extern struct {
+    x: i32,
+    y: i32,
+};
+
+const MSG = extern struct {
+    hwnd: ?HWND,
+    message: UINT,
+    wParam: WPARAM,
+    lParam: LPARAM,
+    time: DWORD,
+    pt: POINT,
+};
+
+const RECT = extern struct {
+    left: i32,
+    top: i32,
+    right: i32,
+    bottom: i32,
+};
+
+const PAINTSTRUCT = extern struct {
+    hdc: HDC,
+    fErase: BOOL,
+    rcPaint: RECT,
+    fRestore: BOOL,
+    fIncUpdate: BOOL,
+    rgbReserved: [32]u8,
+};
+
+const WNDPROC = *const fn (HWND, UINT, WPARAM, LPARAM) callconv(.winapi) LRESULT;
+
+const WNDCLASSEXW = extern struct {
+    cbSize: UINT,
+    style: UINT,
+    lpfnWndProc: WNDPROC,
+    cbClsExtra: c_int,
+    cbWndExtra: c_int,
+    hInstance: ?HINSTANCE,
+    hIcon: HICON,
+    hCursor: HCURSOR,
+    hbrBackground: HBRUSH,
+    lpszMenuName: ?[*:0]const u16,
+    lpszClassName: [*:0]const u16,
+    hIconSm: HICON,
+};
+
+// Win32 constants
+const WM_CLOSE = 0x0010;
+const WM_PAINT = 0x000F;
+const WM_USER = 0x0400;
+const WM_WAKEUP = WM_USER + 1;
+const CS_HREDRAW = 0x0002;
+const CS_VREDRAW = 0x0001;
+const CS_OWNDC = 0x0020;
+const WS_OVERLAPPEDWINDOW = 0x00CF0000;
+const CW_USEDEFAULT: i32 = @bitCast(@as(u32, 0x80000000));
+const SW_SHOWNORMAL = 1;
+const IDC_ARROW: ?[*:0]align(1) const u16 = @ptrFromInt(32512);
+
+// Win32 API extern declarations
+extern "user32" fn RegisterClassExW(lpWndClass: *const WNDCLASSEXW) callconv(.winapi) ATOM;
+extern "user32" fn CreateWindowExW(dwExStyle: DWORD, lpClassName: ?[*:0]const u16, lpWindowName: ?[*:0]const u16, dwStyle: DWORD, x: i32, y: i32, nWidth: i32, nHeight: i32, hWndParent: ?HWND, hMenu: HMENU, hInstance: ?HINSTANCE, lpParam: ?*anyopaque) callconv(.winapi) ?HWND;
+extern "user32" fn ShowWindow(hWnd: HWND, nCmdShow: c_int) callconv(.winapi) BOOL;
+extern "user32" fn UpdateWindow(hWnd: HWND) callconv(.winapi) BOOL;
+extern "user32" fn DestroyWindow(hWnd: HWND) callconv(.winapi) BOOL;
+extern "user32" fn DefWindowProcW(hWnd: HWND, msg: UINT, wParam: WPARAM, lParam: LPARAM) callconv(.winapi) LRESULT;
+extern "user32" fn GetMessageW(lpMsg: *MSG, hWnd: ?HWND, wMsgFilterMin: UINT, wMsgFilterMax: UINT) callconv(.winapi) BOOL;
+extern "user32" fn TranslateMessage(lpMsg: *const MSG) callconv(.winapi) BOOL;
+extern "user32" fn DispatchMessageW(lpMsg: *const MSG) callconv(.winapi) LRESULT;
+extern "user32" fn PostMessageW(hWnd: HWND, msg: UINT, wParam: WPARAM, lParam: LPARAM) callconv(.winapi) BOOL;
+extern "user32" fn PostQuitMessage(nExitCode: c_int) callconv(.winapi) void;
+extern "user32" fn BeginPaint(hWnd: HWND, lpPaint: *PAINTSTRUCT) callconv(.winapi) HDC;
+extern "user32" fn EndPaint(hWnd: HWND, lpPaint: *const PAINTSTRUCT) callconv(.winapi) BOOL;
+extern "user32" fn LoadCursorW(hInstance: ?HINSTANCE, lpCursorName: ?[*:0]align(1) const u16) callconv(.winapi) HCURSOR;
+extern "kernel32" fn GetModuleHandleW(lpModuleName: ?[*:0]const u16) callconv(.winapi) ?HINSTANCE;
+
+/// The core app instance.
+core_app: *CoreApp,
+
+/// The configuration.
+config: *Config,
+
+/// The allocator.
+alloc: Allocator,
+
+/// Whether the app is running.
+running: bool = true,
+
+/// The main window handle.
+hwnd: ?HWND = null,
+
+pub fn init(
+    self: *App,
+    core_app: *CoreApp,
+    opts: struct {},
+) !void {
+    _ = opts;
+
+    const alloc = core_app.alloc;
+
+    // Load configuration
+    var config = try Config.load(alloc);
+    errdefer config.deinit();
+
+    const config_ptr = try alloc.create(Config);
+    config_ptr.* = config;
+
+    self.* = .{
+        .core_app = core_app,
+        .config = config_ptr,
+        .alloc = alloc,
+    };
+
+    // Create the main window
+    try self.createWindow();
+}
+
+pub fn run(self: *App) !void {
+    log.info("starting Win32 event loop", .{});
+
+    while (self.running) {
+        var msg: MSG = std.mem.zeroes(MSG);
+        const ret = GetMessageW(&msg, null, 0, 0);
+        if (ret == 0) {
+            // WM_QUIT
+            self.running = false;
+            break;
+        }
+        if (ret == -1) {
+            log.err("GetMessage failed", .{});
+            return error.Win32Error;
+        }
+        _ = TranslateMessage(&msg);
+        _ = DispatchMessageW(&msg);
+    }
+}
+
+pub fn terminate(self: *App) void {
+    if (self.hwnd) |hwnd| {
+        _ = DestroyWindow(hwnd);
+        self.hwnd = null;
+    }
+    self.config.deinit();
+    self.alloc.destroy(self.config);
+}
+
+pub fn wakeup(self: *App) void {
+    if (self.hwnd) |hwnd| {
+        _ = PostMessageW(hwnd, WM_WAKEUP, 0, 0);
+    }
+}
+
+pub fn performAction(
+    self: *App,
+    target: apprt.Target,
+    comptime action: apprt.Action.Key,
+    value: apprt.Action.Value(action),
+) !bool {
+    _ = self;
+    _ = target;
+    _ = value;
+
+    switch (action) {
+        .quit => {
+            PostQuitMessage(0);
+            return true;
+        },
+        .new_window => {
+            // TODO: implement multiple windows
+            return false;
+        },
+        else => return false,
+    }
+}
+
+pub fn performIpc(
+    _: Allocator,
+    _: apprt.ipc.Target,
+    comptime action: apprt.ipc.Action.Key,
+    _: apprt.ipc.Action.Value(action),
+) !bool {
+    return false;
+}
+
+pub fn redrawInspector(_: *App, _: *Surface) void {}
+
+fn createWindow(self: *App) !void {
+    const class_name = std.unicode.utf8ToUtf16LeStringLiteral("GhosttyWindow");
+    const hinstance = GetModuleHandleW(null);
+
+    const wc: WNDCLASSEXW = .{
+        .cbSize = @sizeOf(WNDCLASSEXW),
+        .style = CS_HREDRAW | CS_VREDRAW | CS_OWNDC,
+        .lpfnWndProc = wndProc,
+        .cbClsExtra = 0,
+        .cbWndExtra = 0,
+        .hInstance = hinstance,
+        .hIcon = null,
+        .hCursor = LoadCursorW(null, IDC_ARROW),
+        .hbrBackground = null,
+        .lpszMenuName = null,
+        .lpszClassName = class_name,
+        .hIconSm = null,
+    };
+
+    if (RegisterClassExW(&wc) == 0) {
+        log.err("RegisterClassEx failed", .{});
+        return error.Win32Error;
+    }
+
+    const title = std.unicode.utf8ToUtf16LeStringLiteral("Ghostty");
+
+    self.hwnd = CreateWindowExW(
+        0,
+        class_name,
+        title,
+        WS_OVERLAPPEDWINDOW,
+        CW_USEDEFAULT,
+        CW_USEDEFAULT,
+        800,
+        600,
+        null,
+        null,
+        hinstance,
+        null,
+    );
+
+    if (self.hwnd == null) {
+        log.err("CreateWindowEx failed", .{});
+        return error.Win32Error;
+    }
+
+    _ = ShowWindow(self.hwnd.?, SW_SHOWNORMAL);
+    _ = UpdateWindow(self.hwnd.?);
+}
+
+fn wndProc(hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM) callconv(.winapi) LRESULT {
+    switch (msg) {
+        WM_CLOSE => {
+            PostQuitMessage(0);
+            return 0;
+        },
+        WM_PAINT => {
+            var ps: PAINTSTRUCT = std.mem.zeroes(PAINTSTRUCT);
+            _ = BeginPaint(hwnd, &ps);
+            // TODO: render via OpenGL
+            _ = EndPaint(hwnd, &ps);
+            return 0;
+        },
+        WM_WAKEUP => {
+            // Wakeup from core app
+            return 0;
+        },
+        else => return DefWindowProcW(hwnd, msg, wparam, lparam),
+    }
+}

--- a/src/apprt/win32/App.zig
+++ b/src/apprt/win32/App.zig
@@ -4,6 +4,7 @@ const App = @This();
 
 const std = @import("std");
 const builtin = @import("builtin");
+const win32 = @import("win32").everything;
 const Allocator = std.mem.Allocator;
 const apprt = @import("../../apprt.zig");
 const configpkg = @import("../../config.zig");
@@ -15,109 +16,9 @@ const renderer = @import("../../renderer.zig");
 
 const log = std.log.scoped(.win32);
 
-// Win32 type definitions
-const BOOL = i32;
-const UINT = u32;
-const DWORD = u32;
-const WPARAM = usize;
-const LPARAM = isize;
-const LRESULT = isize;
-const HWND = std.os.windows.HWND;
-const HINSTANCE = std.os.windows.HINSTANCE;
-const HICON = ?*anyopaque;
-const HCURSOR = ?*anyopaque;
-const HBRUSH = ?*anyopaque;
-const HDC = ?*anyopaque;
-const HMENU = ?*anyopaque;
-const ATOM = u16;
-const LONG_PTR = isize;
-
-const POINT = extern struct {
-    x: i32,
-    y: i32,
-};
-
-const MSG = extern struct {
-    hwnd: ?HWND,
-    message: UINT,
-    wParam: WPARAM,
-    lParam: LPARAM,
-    time: DWORD,
-    pt: POINT,
-};
-
-const RECT = extern struct {
-    left: i32,
-    top: i32,
-    right: i32,
-    bottom: i32,
-};
-
-const PAINTSTRUCT = extern struct {
-    hdc: HDC,
-    fErase: BOOL,
-    rcPaint: RECT,
-    fRestore: BOOL,
-    fIncUpdate: BOOL,
-    rgbReserved: [32]u8,
-};
-
-const WNDPROC = *const fn (HWND, UINT, WPARAM, LPARAM) callconv(.winapi) LRESULT;
-
-const WNDCLASSEXW = extern struct {
-    cbSize: UINT,
-    style: UINT,
-    lpfnWndProc: WNDPROC,
-    cbClsExtra: c_int,
-    cbWndExtra: c_int,
-    hInstance: ?HINSTANCE,
-    hIcon: HICON,
-    hCursor: HCURSOR,
-    hbrBackground: HBRUSH,
-    lpszMenuName: ?[*:0]const u16,
-    lpszClassName: [*:0]const u16,
-    hIconSm: HICON,
-};
-
-// Win32 constants
-const WM_CLOSE = 0x0010;
-const WM_DESTROY = 0x0002;
-const WM_PAINT = 0x000F;
-const WM_SIZE = 0x0005;
-const WM_KEYDOWN = 0x0100;
-const WM_CHAR = 0x0102;
-const WM_USER = 0x0400;
-const WM_WAKEUP = WM_USER + 1;
-const CS_HREDRAW = 0x0002;
-const CS_VREDRAW = 0x0001;
-const CS_OWNDC = 0x0020;
-const WS_OVERLAPPEDWINDOW = 0x00CF0000;
-const CW_USEDEFAULT: i32 = @bitCast(@as(u32, 0x80000000));
-const SW_SHOWNORMAL = 1;
-const IDC_ARROW: ?[*:0]align(1) const u16 = @ptrFromInt(32512);
-const GWLP_USERDATA: c_int = -21;
-
-// Win32 API extern declarations
-extern "user32" fn RegisterClassExW(lpWndClass: *const WNDCLASSEXW) callconv(.winapi) ATOM;
-extern "user32" fn CreateWindowExW(dwExStyle: DWORD, lpClassName: ?[*:0]const u16, lpWindowName: ?[*:0]const u16, dwStyle: DWORD, x: i32, y: i32, nWidth: i32, nHeight: i32, hWndParent: ?HWND, hMenu: HMENU, hInstance: ?HINSTANCE, lpParam: ?*anyopaque) callconv(.winapi) ?HWND;
-extern "user32" fn ShowWindow(hWnd: HWND, nCmdShow: c_int) callconv(.winapi) BOOL;
-extern "user32" fn UpdateWindow(hWnd: HWND) callconv(.winapi) BOOL;
-extern "user32" fn DestroyWindow(hWnd: HWND) callconv(.winapi) BOOL;
-extern "user32" fn DefWindowProcW(hWnd: HWND, msg: UINT, wParam: WPARAM, lParam: LPARAM) callconv(.winapi) LRESULT;
-extern "user32" fn GetMessageW(lpMsg: *MSG, hWnd: ?HWND, wMsgFilterMin: UINT, wMsgFilterMax: UINT) callconv(.winapi) BOOL;
-extern "user32" fn TranslateMessage(lpMsg: *const MSG) callconv(.winapi) BOOL;
-extern "user32" fn DispatchMessageW(lpMsg: *const MSG) callconv(.winapi) LRESULT;
-extern "user32" fn PostMessageW(hWnd: HWND, msg: UINT, wParam: WPARAM, lParam: LPARAM) callconv(.winapi) BOOL;
-extern "user32" fn PostQuitMessage(nExitCode: c_int) callconv(.winapi) void;
-extern "user32" fn BeginPaint(hWnd: HWND, lpPaint: *PAINTSTRUCT) callconv(.winapi) HDC;
-extern "user32" fn EndPaint(hWnd: HWND, lpPaint: *const PAINTSTRUCT) callconv(.winapi) BOOL;
-extern "user32" fn LoadCursorW(hInstance: ?HINSTANCE, lpCursorName: ?[*:0]align(1) const u16) callconv(.winapi) HCURSOR;
-extern "user32" fn SetWindowLongPtrW(hWnd: HWND, nIndex: c_int, dwNewLong: LONG_PTR) callconv(.winapi) LONG_PTR;
-extern "user32" fn GetWindowLongPtrW(hWnd: HWND, nIndex: c_int) callconv(.winapi) LONG_PTR;
-extern "user32" fn GetClientRect(hWnd: HWND, lpRect: *RECT) callconv(.winapi) BOOL;
-extern "user32" fn InvalidateRect(hWnd: ?HWND, lpRect: ?*const RECT, bErase: BOOL) callconv(.winapi) BOOL;
-extern "kernel32" fn GetModuleHandleW(lpModuleName: ?[*:0]const u16) callconv(.winapi) ?HINSTANCE;
-extern "kernel32" fn GetLastError() callconv(.winapi) DWORD;
+/// User-defined wakeup message sent via PostMessage to break out of
+/// GetMessage and run the core app's tick.
+const WM_WAKEUP = win32.WM_USER + 1;
 
 /// The core app instance.
 core_app: *CoreApp,
@@ -132,7 +33,7 @@ alloc: Allocator,
 running: bool = true,
 
 /// The main window handle.
-hwnd: ?HWND = null,
+hwnd: ?win32.HWND = null,
 
 /// The surface for the main window.
 surface: Surface = undefined,
@@ -165,8 +66,14 @@ pub fn init(
     // Initialize the surface with OpenGL
     try self.surface.init(self.hwnd.?);
 
-    // Store self pointer in window for use in wndProc
-    _ = SetWindowLongPtrW(self.hwnd.?, GWLP_USERDATA, @bitCast(@intFromPtr(self)));
+    // Store self pointer in window for use in wndProc. SetWindowLongPtrW
+    // returns the previous value, which for a freshly created window is 0;
+    // we don't care about it here.
+    _ = win32.SetWindowLongPtrW(
+        self.hwnd.?,
+        win32.GWLP_USERDATA,
+        @bitCast(@intFromPtr(self)),
+    );
 
     // Initialize the core surface (terminal emulation + rendering)
     try self.initCoreSurface();
@@ -176,27 +83,27 @@ pub fn run(self: *App) !void {
     log.info("starting Win32 event loop", .{});
 
     while (self.running) {
-        var msg: MSG = std.mem.zeroes(MSG);
-        const ret = GetMessageW(&msg, null, 0, 0);
+        var msg: win32.MSG = std.mem.zeroes(win32.MSG);
+        const ret = win32.GetMessageW(&msg, null, 0, 0);
         if (ret == 0) {
             // WM_QUIT
             self.running = false;
             break;
         }
         if (ret == -1) {
-            log.err("GetMessage failed", .{});
+            log.err("GetMessage failed: err={d}", .{@intFromEnum(win32.GetLastError())});
             return error.Win32Error;
         }
-        _ = TranslateMessage(&msg);
-        _ = DispatchMessageW(&msg);
+        _ = win32.TranslateMessage(&msg);
+        _ = win32.DispatchMessageW(&msg);
     }
 }
 
 pub fn terminate(self: *App) void {
     self.surface.deinit();
     if (self.hwnd) |hwnd| {
-        if (DestroyWindow(hwnd) == 0) {
-            log.warn("DestroyWindow failed: err={d}", .{GetLastError()});
+        if (win32.DestroyWindow(hwnd) == 0) {
+            log.warn("DestroyWindow failed: err={d}", .{@intFromEnum(win32.GetLastError())});
         }
         self.hwnd = null;
     }
@@ -206,8 +113,8 @@ pub fn terminate(self: *App) void {
 
 pub fn wakeup(self: *App) void {
     if (self.hwnd) |hwnd| {
-        if (PostMessageW(hwnd, WM_WAKEUP, 0, 0) == 0) {
-            log.warn("PostMessage(WM_WAKEUP) failed: err={d}", .{GetLastError()});
+        if (win32.PostMessageW(hwnd, WM_WAKEUP, 0, 0) == 0) {
+            log.warn("PostMessage(WM_WAKEUP) failed: err={d}", .{@intFromEnum(win32.GetLastError())});
         }
     }
 }
@@ -224,7 +131,7 @@ pub fn performAction(
 
     switch (action) {
         .quit => {
-            PostQuitMessage(0);
+            win32.PostQuitMessage(0);
             return true;
         },
         .new_window => {
@@ -287,68 +194,66 @@ fn initCoreSurface(self: *App) !void {
 }
 
 fn createWindow(self: *App) !void {
-    const class_name = std.unicode.utf8ToUtf16LeStringLiteral("GhosttyWindow");
-    const hinstance = GetModuleHandleW(null);
+    const class_name = win32.L("GhosttyWindow");
+    const hinstance = win32.GetModuleHandleW(null);
 
-    const wc: WNDCLASSEXW = .{
-        .cbSize = @sizeOf(WNDCLASSEXW),
-        .style = CS_HREDRAW | CS_VREDRAW | CS_OWNDC,
+    const wc: win32.WNDCLASSEXW = .{
+        .cbSize = @sizeOf(win32.WNDCLASSEXW),
+        .style = .{ .HREDRAW = 1, .VREDRAW = 1, .OWNDC = 1 },
         .lpfnWndProc = wndProc,
         .cbClsExtra = 0,
         .cbWndExtra = 0,
         .hInstance = hinstance,
         .hIcon = null,
-        .hCursor = LoadCursorW(null, IDC_ARROW),
+        .hCursor = win32.LoadCursorW(null, win32.IDC_ARROW),
         .hbrBackground = null,
         .lpszMenuName = null,
         .lpszClassName = class_name,
         .hIconSm = null,
     };
 
-    if (RegisterClassExW(&wc) == 0) {
-        log.err("RegisterClassEx failed", .{});
+    if (win32.RegisterClassExW(&wc) == 0) {
+        log.err("RegisterClassExW failed: err={d}", .{@intFromEnum(win32.GetLastError())});
         return error.Win32Error;
     }
 
-    const title = std.unicode.utf8ToUtf16LeStringLiteral("Ghostty");
+    const title = win32.L("Ghostty");
 
-    self.hwnd = CreateWindowExW(
-        0,
+    self.hwnd = win32.CreateWindowExW(
+        .{},
         class_name,
         title,
-        WS_OVERLAPPEDWINDOW,
-        CW_USEDEFAULT,
-        CW_USEDEFAULT,
+        win32.WS_OVERLAPPEDWINDOW,
+        win32.CW_USEDEFAULT,
+        win32.CW_USEDEFAULT,
         800,
         600,
         null,
         null,
         hinstance,
         null,
-    );
-
-    if (self.hwnd == null) {
-        log.err("CreateWindowEx failed", .{});
+    ) orelse {
+        log.err("CreateWindowExW failed: err={d}", .{@intFromEnum(win32.GetLastError())});
         return error.Win32Error;
-    }
+    };
 
-    _ = ShowWindow(self.hwnd.?, SW_SHOWNORMAL);
-    _ = UpdateWindow(self.hwnd.?);
+    _ = win32.ShowWindow(self.hwnd.?, win32.SW_SHOWNORMAL);
+    _ = win32.UpdateWindow(self.hwnd.?);
 }
 
-fn getApp(hwnd: HWND) ?*App {
-    const ptr = GetWindowLongPtrW(hwnd, GWLP_USERDATA);
+fn getApp(hwnd: win32.HWND) ?*App {
+    const ptr = win32.GetWindowLongPtrW(hwnd, win32.GWLP_USERDATA);
     if (ptr == 0) return null;
     return @ptrFromInt(@as(usize, @bitCast(ptr)));
 }
 
-fn wndProc(hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM) callconv(.winapi) LRESULT {
+fn wndProc(hwnd: win32.HWND, msg: u32, wparam: win32.WPARAM, lparam: win32.LPARAM) callconv(.winapi) win32.LRESULT {
     switch (msg) {
-        WM_CLOSE => {
-            PostQuitMessage(0);
+        win32.WM_CLOSE => {
+            win32.PostQuitMessage(0);
             return 0;
         },
-        WM_SIZE => {
+        win32.WM_SIZE => {
             if (getApp(hwnd)) |app| {
                 const width: u32 = @intCast(lparam & 0xFFFF);
                 const height: u32 = @intCast((lparam >> 16) & 0xFFFF);
@@ -367,13 +272,13 @@ fn wndProc(hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM) callconv(.wina
             }
             return 0;
         },
-        WM_PAINT => {
-            var ps: PAINTSTRUCT = std.mem.zeroes(PAINTSTRUCT);
-            _ = BeginPaint(hwnd, &ps);
+        win32.WM_PAINT => {
+            var ps: win32.PAINTSTRUCT = std.mem.zeroes(win32.PAINTSTRUCT);
+            _ = win32.BeginPaint(hwnd, &ps);
             if (getApp(hwnd)) |app| {
                 app.surface.swapBuffers();
             }
-            _ = EndPaint(hwnd, &ps);
+            _ = win32.EndPaint(hwnd, &ps);
             return 0;
         },
         WM_WAKEUP => {
@@ -384,6 +289,6 @@ fn wndProc(hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM) callconv(.wina
             }
             return 0;
         },
-        else => return DefWindowProcW(hwnd, msg, wparam, lparam),
+        else => return win32.DefWindowProcW(hwnd, msg, wparam, lparam),
     }
 }

--- a/src/apprt/win32/App.zig
+++ b/src/apprt/win32/App.zig
@@ -11,6 +11,7 @@ const Config = configpkg.Config;
 const CoreApp = @import("../../App.zig");
 const CoreSurface = @import("../../Surface.zig");
 const Surface = @import("Surface.zig");
+const renderer = @import("../../renderer.zig");
 
 const log = std.log.scoped(.win32);
 
@@ -29,6 +30,7 @@ const HBRUSH = ?*anyopaque;
 const HDC = ?*anyopaque;
 const HMENU = ?*anyopaque;
 const ATOM = u16;
+const LONG_PTR = isize;
 
 const POINT = extern struct {
     x: i32,
@@ -79,7 +81,11 @@ const WNDCLASSEXW = extern struct {
 
 // Win32 constants
 const WM_CLOSE = 0x0010;
+const WM_DESTROY = 0x0002;
 const WM_PAINT = 0x000F;
+const WM_SIZE = 0x0005;
+const WM_KEYDOWN = 0x0100;
+const WM_CHAR = 0x0102;
 const WM_USER = 0x0400;
 const WM_WAKEUP = WM_USER + 1;
 const CS_HREDRAW = 0x0002;
@@ -89,6 +95,7 @@ const WS_OVERLAPPEDWINDOW = 0x00CF0000;
 const CW_USEDEFAULT: i32 = @bitCast(@as(u32, 0x80000000));
 const SW_SHOWNORMAL = 1;
 const IDC_ARROW: ?[*:0]align(1) const u16 = @ptrFromInt(32512);
+const GWLP_USERDATA: c_int = -21;
 
 // Win32 API extern declarations
 extern "user32" fn RegisterClassExW(lpWndClass: *const WNDCLASSEXW) callconv(.winapi) ATOM;
@@ -105,6 +112,10 @@ extern "user32" fn PostQuitMessage(nExitCode: c_int) callconv(.winapi) void;
 extern "user32" fn BeginPaint(hWnd: HWND, lpPaint: *PAINTSTRUCT) callconv(.winapi) HDC;
 extern "user32" fn EndPaint(hWnd: HWND, lpPaint: *const PAINTSTRUCT) callconv(.winapi) BOOL;
 extern "user32" fn LoadCursorW(hInstance: ?HINSTANCE, lpCursorName: ?[*:0]align(1) const u16) callconv(.winapi) HCURSOR;
+extern "user32" fn SetWindowLongPtrW(hWnd: HWND, nIndex: c_int, dwNewLong: LONG_PTR) callconv(.winapi) LONG_PTR;
+extern "user32" fn GetWindowLongPtrW(hWnd: HWND, nIndex: c_int) callconv(.winapi) LONG_PTR;
+extern "user32" fn GetClientRect(hWnd: HWND, lpRect: *RECT) callconv(.winapi) BOOL;
+extern "user32" fn InvalidateRect(hWnd: ?HWND, lpRect: ?*const RECT, bErase: BOOL) callconv(.winapi) BOOL;
 extern "kernel32" fn GetModuleHandleW(lpModuleName: ?[*:0]const u16) callconv(.winapi) ?HINSTANCE;
 
 /// The core app instance.
@@ -121,6 +132,9 @@ running: bool = true,
 
 /// The main window handle.
 hwnd: ?HWND = null,
+
+/// The surface for the main window.
+surface: Surface = undefined,
 
 pub fn init(
     self: *App,
@@ -146,6 +160,12 @@ pub fn init(
 
     // Create the main window
     try self.createWindow();
+
+    // Initialize the surface with OpenGL
+    try self.surface.init(self.hwnd.?);
+
+    // Store self pointer in window for use in wndProc
+    _ = SetWindowLongPtrW(self.hwnd.?, GWLP_USERDATA, @bitCast(@intFromPtr(self)));
 }
 
 pub fn run(self: *App) !void {
@@ -169,6 +189,7 @@ pub fn run(self: *App) !void {
 }
 
 pub fn terminate(self: *App) void {
+    self.surface.deinit();
     if (self.hwnd) |hwnd| {
         _ = DestroyWindow(hwnd);
         self.hwnd = null;
@@ -215,7 +236,9 @@ pub fn performIpc(
     return false;
 }
 
-pub fn redrawInspector(_: *App, _: *Surface) void {}
+pub fn redrawInspector(_: *App, surface: *Surface) void {
+    surface.redrawInspector();
+}
 
 fn createWindow(self: *App) !void {
     const class_name = std.unicode.utf8ToUtf16LeStringLiteral("GhosttyWindow");
@@ -267,21 +290,44 @@ fn createWindow(self: *App) !void {
     _ = UpdateWindow(self.hwnd.?);
 }
 
+fn getApp(hwnd: HWND) ?*App {
+    const ptr = GetWindowLongPtrW(hwnd, GWLP_USERDATA);
+    if (ptr == 0) return null;
+    return @ptrFromInt(@as(usize, @bitCast(ptr)));
+}
+
 fn wndProc(hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM) callconv(.winapi) LRESULT {
     switch (msg) {
         WM_CLOSE => {
             PostQuitMessage(0);
             return 0;
         },
+        WM_SIZE => {
+            if (getApp(hwnd)) |app| {
+                const width: u32 = @intCast(lparam & 0xFFFF);
+                const height: u32 = @intCast((lparam >> 16) & 0xFFFF);
+                if (width > 0 and height > 0) {
+                    app.surface.width = width;
+                    app.surface.height = height;
+                }
+            }
+            return 0;
+        },
         WM_PAINT => {
             var ps: PAINTSTRUCT = std.mem.zeroes(PAINTSTRUCT);
             _ = BeginPaint(hwnd, &ps);
-            // TODO: render via OpenGL
+            if (getApp(hwnd)) |app| {
+                app.surface.swapBuffers();
+            }
             _ = EndPaint(hwnd, &ps);
             return 0;
         },
         WM_WAKEUP => {
-            // Wakeup from core app
+            if (getApp(hwnd)) |app| {
+                app.core_app.tick(app) catch |err| {
+                    log.err("core app tick failed: {}", .{err});
+                };
+            }
             return 0;
         },
         else => return DefWindowProcW(hwnd, msg, wparam, lparam),

--- a/src/apprt/win32/App.zig
+++ b/src/apprt/win32/App.zig
@@ -166,6 +166,9 @@ pub fn init(
 
     // Store self pointer in window for use in wndProc
     _ = SetWindowLongPtrW(self.hwnd.?, GWLP_USERDATA, @bitCast(@intFromPtr(self)));
+
+    // Initialize the core surface (terminal emulation + rendering)
+    try self.initCoreSurface();
 }
 
 pub fn run(self: *App) !void {
@@ -238,6 +241,44 @@ pub fn performIpc(
 
 pub fn redrawInspector(_: *App, surface: *Surface) void {
     surface.redrawInspector();
+}
+
+fn initCoreSurface(self: *App) !void {
+    const alloc = self.alloc;
+
+    // Set the app pointer on the surface
+    self.surface.app = self;
+
+    // Create the core surface
+    const core_surface = try alloc.create(CoreSurface);
+    errdefer alloc.destroy(core_surface);
+
+    // Register with the core app
+    try self.core_app.addSurface(&self.surface);
+    errdefer self.core_app.deleteSurface(&self.surface);
+
+    // Create a surface config
+    var config = try apprt.surface.newConfig(
+        self.core_app,
+        self.config,
+        .window,
+    );
+    defer config.deinit();
+
+    // Initialize the core surface
+    core_surface.init(
+        alloc,
+        &config,
+        self.core_app,
+        self,
+        &self.surface,
+    ) catch |err| {
+        log.err("failed to initialize core surface: {}", .{err});
+        return err;
+    };
+
+    self.surface.core_surface = core_surface;
+    log.info("core surface initialized successfully", .{});
 }
 
 fn createWindow(self: *App) !void {

--- a/src/apprt/win32/Surface.zig
+++ b/src/apprt/win32/Surface.zig
@@ -4,6 +4,7 @@
 const Self = @This();
 
 const std = @import("std");
+const win32 = @import("win32").everything;
 const Allocator = std.mem.Allocator;
 const apprt = @import("../../apprt.zig");
 const configpkg = @import("../../config.zig");
@@ -12,71 +13,17 @@ const CoreApp = @import("../../App.zig");
 
 const log = std.log.scoped(.win32_surface);
 
-// Win32 types
-const HWND = std.os.windows.HWND;
-const HINSTANCE = std.os.windows.HINSTANCE;
-const BOOL = i32;
-const HDC = ?*anyopaque;
-const HGLRC = ?*anyopaque;
-
-const PIXELFORMATDESCRIPTOR = extern struct {
-    nSize: u16,
-    nVersion: u16,
-    dwFlags: u32,
-    iPixelType: u8,
-    cColorBits: u8,
-    cRedBits: u8,
-    cRedShift: u8,
-    cGreenBits: u8,
-    cGreenShift: u8,
-    cBlueBits: u8,
-    cBlueShift: u8,
-    cAlphaBits: u8,
-    cAlphaShift: u8,
-    cAccumBits: u8,
-    cAccumRedBits: u8,
-    cAccumGreenBits: u8,
-    cAccumBlueBits: u8,
-    cAccumAlphaBits: u8,
-    cDepthBits: u8,
-    cStencilBits: u8,
-    cAuxBuffers: u8,
-    iLayerType: u8,
-    bReserved: u8,
-    dwLayerMask: u32,
-    dwVisibleMask: u32,
-    dwDamageMask: u32,
-};
-
-// WGL / GDI constants
-const PFD_DRAW_TO_WINDOW = 0x00000004;
-const PFD_SUPPORT_OPENGL = 0x00000020;
-const PFD_DOUBLEBUFFER = 0x00000001;
-const PFD_TYPE_RGBA = 0;
-const PFD_MAIN_PLANE = 0;
-
-// WGL / GDI extern declarations
-extern "user32" fn GetDC(hWnd: ?HWND) callconv(.winapi) HDC;
-extern "user32" fn ReleaseDC(hWnd: ?HWND, hDC: HDC) callconv(.winapi) c_int;
-extern "gdi32" fn ChoosePixelFormat(hdc: HDC, ppfd: *const PIXELFORMATDESCRIPTOR) callconv(.winapi) c_int;
-extern "gdi32" fn SetPixelFormat(hdc: HDC, format: c_int, ppfd: *const PIXELFORMATDESCRIPTOR) callconv(.winapi) BOOL;
-extern "gdi32" fn SwapBuffers(hdc: HDC) callconv(.winapi) BOOL;
-extern "opengl32" fn wglCreateContext(hdc: HDC) callconv(.winapi) HGLRC;
-extern "opengl32" fn wglDeleteContext(hglrc: HGLRC) callconv(.winapi) BOOL;
-extern "opengl32" fn wglMakeCurrent(hdc: HDC, hglrc: HGLRC) callconv(.winapi) BOOL;
-extern "kernel32" fn GetLastError() callconv(.winapi) u32;
-
 /// The window this surface belongs to.
-hwnd: HWND,
+hwnd: win32.HWND,
 
 /// Pointer back to the App.
 app: ?*App = null,
 
 /// GDI device context.
-hdc: HDC = null,
+hdc: ?win32.HDC = null,
 
 /// OpenGL rendering context.
-hglrc: HGLRC = null,
+hglrc: ?win32.HGLRC = null,
 
 /// The core surface, if initialized.
 core_surface: ?*CoreSurface = null,
@@ -95,7 +42,7 @@ pub fn rtApp(self: *Self) *App {
     return self.app.?;
 }
 
-pub fn init(self: *Self, hwnd: HWND) !void {
+pub fn init(self: *Self, hwnd: win32.HWND) !void {
     self.* = .{ .hwnd = hwnd };
     try self.initOpenGL();
 }
@@ -105,51 +52,49 @@ pub fn deinit(self: *Self) void {
         surface.deinit();
         // core_surface is allocated by CoreApp, freed there
     }
-    if (self.hglrc != null) {
-        _ = wglMakeCurrent(null, null);
-        _ = wglDeleteContext(self.hglrc);
+    if (self.hglrc) |hglrc| {
+        _ = win32.wglMakeCurrent(null, null);
+        _ = win32.wglDeleteContext(hglrc);
     }
-    if (self.hdc != null) {
-        _ = ReleaseDC(self.hwnd, self.hdc);
+    if (self.hdc) |hdc| {
+        _ = win32.ReleaseDC(self.hwnd, hdc);
     }
 }
 
 fn initOpenGL(self: *Self) !void {
-    self.hdc = GetDC(self.hwnd);
-    if (self.hdc == null) {
-        log.err("GetDC failed", .{});
+    self.hdc = win32.GetDC(self.hwnd) orelse {
+        log.err("GetDC failed: err={d}", .{@intFromEnum(win32.GetLastError())});
         return error.Win32Error;
-    }
+    };
 
-    var pfd: PIXELFORMATDESCRIPTOR = std.mem.zeroes(PIXELFORMATDESCRIPTOR);
-    pfd.nSize = @sizeOf(PIXELFORMATDESCRIPTOR);
+    var pfd: win32.PIXELFORMATDESCRIPTOR = std.mem.zeroes(win32.PIXELFORMATDESCRIPTOR);
+    pfd.nSize = @sizeOf(win32.PIXELFORMATDESCRIPTOR);
     pfd.nVersion = 1;
-    pfd.dwFlags = PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL | PFD_DOUBLEBUFFER;
-    pfd.iPixelType = PFD_TYPE_RGBA;
+    pfd.dwFlags = .{ .DRAW_TO_WINDOW = 1, .SUPPORT_OPENGL = 1, .DOUBLEBUFFER = 1 };
+    pfd.iPixelType = .RGBA;
     pfd.cColorBits = 32;
     pfd.cDepthBits = 24;
     pfd.cStencilBits = 8;
-    pfd.iLayerType = PFD_MAIN_PLANE;
+    pfd.iLayerType = .MAIN_PLANE;
 
-    const pixel_format = ChoosePixelFormat(self.hdc, &pfd);
+    const pixel_format = win32.ChoosePixelFormat(self.hdc, &pfd);
     if (pixel_format == 0) {
-        log.err("ChoosePixelFormat failed", .{});
+        log.err("ChoosePixelFormat failed: err={d}", .{@intFromEnum(win32.GetLastError())});
         return error.Win32Error;
     }
 
-    if (SetPixelFormat(self.hdc, pixel_format, &pfd) == 0) {
-        log.err("SetPixelFormat failed", .{});
+    if (win32.SetPixelFormat(self.hdc, pixel_format, &pfd) == 0) {
+        log.err("SetPixelFormat failed: err={d}", .{@intFromEnum(win32.GetLastError())});
         return error.Win32Error;
     }
 
-    self.hglrc = wglCreateContext(self.hdc);
-    if (self.hglrc == null) {
-        log.err("wglCreateContext failed", .{});
+    self.hglrc = win32.wglCreateContext(self.hdc) orelse {
+        log.err("wglCreateContext failed: err={d}", .{@intFromEnum(win32.GetLastError())});
         return error.Win32Error;
-    }
+    };
 
-    if (wglMakeCurrent(self.hdc, self.hglrc) == 0) {
-        log.err("wglMakeCurrent failed", .{});
+    if (win32.wglMakeCurrent(self.hdc, self.hglrc) == 0) {
+        log.err("wglMakeCurrent failed: err={d}", .{@intFromEnum(win32.GetLastError())});
         return error.Win32Error;
     }
 
@@ -157,34 +102,36 @@ fn initOpenGL(self: *Self) !void {
 }
 
 pub fn swapBuffers(self: *Self) void {
-    if (self.hdc != null) {
-        if (SwapBuffers(self.hdc) == 0) {
-            log.warn("SwapBuffers failed: err={d}", .{GetLastError()});
+    if (self.hdc) |hdc| {
+        if (win32.SwapBuffers(hdc) == 0) {
+            log.warn("SwapBuffers failed: err={d}", .{@intFromEnum(win32.GetLastError())});
         }
     }
 }
 
 /// Make the WGL context current on the calling thread.
 pub fn makeContextCurrent(self: *Self) void {
-    if (self.hdc != null and self.hglrc != null) {
-        if (wglMakeCurrent(self.hdc, self.hglrc) == 0) {
-            log.warn("wglMakeCurrent failed: err={d}", .{GetLastError()});
+    if (self.hdc) |hdc| {
+        if (self.hglrc) |hglrc| {
+            if (win32.wglMakeCurrent(hdc, hglrc) == 0) {
+                log.warn("wglMakeCurrent failed: err={d}", .{@intFromEnum(win32.GetLastError())});
+            }
         }
     }
 }
 
 /// Release the WGL context from the calling thread.
 pub fn releaseContext() void {
-    if (wglMakeCurrent(null, null) == 0) {
-        log.warn("wglMakeCurrent(null) failed: err={d}", .{GetLastError()});
+    if (win32.wglMakeCurrent(null, null) == 0) {
+        log.warn("wglMakeCurrent(null) failed: err={d}", .{@intFromEnum(win32.GetLastError())});
     }
 }
 
 /// Release context from the main thread before handing off to renderer thread.
 pub fn releaseMainThreadContext(self: *Self) void {
     _ = self;
-    if (wglMakeCurrent(null, null) == 0) {
-        log.warn("wglMakeCurrent(null) failed: err={d}", .{GetLastError()});
+    if (win32.wglMakeCurrent(null, null) == 0) {
+        log.warn("wglMakeCurrent(null) failed: err={d}", .{@intFromEnum(win32.GetLastError())});
     }
 }
 

--- a/src/apprt/win32/Surface.zig
+++ b/src/apprt/win32/Surface.zig
@@ -1,0 +1,11 @@
+/// Win32 surface - represents a terminal surface within a window.
+/// This is a minimal stub for now.
+const Self = @This();
+
+const std = @import("std");
+const apprt = @import("../../apprt.zig");
+const CoreSurface = @import("../../Surface.zig");
+
+pub fn deinit(self: *Self) void {
+    _ = self;
+}

--- a/src/apprt/win32/Surface.zig
+++ b/src/apprt/win32/Surface.zig
@@ -64,6 +64,7 @@ extern "gdi32" fn SwapBuffers(hdc: HDC) callconv(.winapi) BOOL;
 extern "opengl32" fn wglCreateContext(hdc: HDC) callconv(.winapi) HGLRC;
 extern "opengl32" fn wglDeleteContext(hglrc: HGLRC) callconv(.winapi) BOOL;
 extern "opengl32" fn wglMakeCurrent(hdc: HDC, hglrc: HGLRC) callconv(.winapi) BOOL;
+extern "kernel32" fn GetLastError() callconv(.winapi) u32;
 
 /// The window this surface belongs to.
 hwnd: HWND,
@@ -157,26 +158,34 @@ fn initOpenGL(self: *Self) !void {
 
 pub fn swapBuffers(self: *Self) void {
     if (self.hdc != null) {
-        _ = SwapBuffers(self.hdc);
+        if (SwapBuffers(self.hdc) == 0) {
+            log.warn("SwapBuffers failed: err={d}", .{GetLastError()});
+        }
     }
 }
 
 /// Make the WGL context current on the calling thread.
 pub fn makeContextCurrent(self: *Self) void {
     if (self.hdc != null and self.hglrc != null) {
-        _ = wglMakeCurrent(self.hdc, self.hglrc);
+        if (wglMakeCurrent(self.hdc, self.hglrc) == 0) {
+            log.warn("wglMakeCurrent failed: err={d}", .{GetLastError()});
+        }
     }
 }
 
 /// Release the WGL context from the calling thread.
 pub fn releaseContext() void {
-    _ = wglMakeCurrent(null, null);
+    if (wglMakeCurrent(null, null) == 0) {
+        log.warn("wglMakeCurrent(null) failed: err={d}", .{GetLastError()});
+    }
 }
 
 /// Release context from the main thread before handing off to renderer thread.
 pub fn releaseMainThreadContext(self: *Self) void {
     _ = self;
-    _ = wglMakeCurrent(null, null);
+    if (wglMakeCurrent(null, null) == 0) {
+        log.warn("wglMakeCurrent(null) failed: err={d}", .{GetLastError()});
+    }
 }
 
 // --- Interface methods required by CoreSurface ---

--- a/src/apprt/win32/Surface.zig
+++ b/src/apprt/win32/Surface.zig
@@ -1,11 +1,209 @@
 /// Win32 surface - represents a terminal surface within a window.
-/// This is a minimal stub for now.
+/// Manages the WGL OpenGL context and provides the interface
+/// expected by CoreSurface.
 const Self = @This();
 
 const std = @import("std");
+const Allocator = std.mem.Allocator;
 const apprt = @import("../../apprt.zig");
+const configpkg = @import("../../config.zig");
 const CoreSurface = @import("../../Surface.zig");
+const CoreApp = @import("../../App.zig");
+
+const log = std.log.scoped(.win32_surface);
+
+// Win32 types
+const HWND = std.os.windows.HWND;
+const HINSTANCE = std.os.windows.HINSTANCE;
+const BOOL = i32;
+const HDC = ?*anyopaque;
+const HGLRC = ?*anyopaque;
+
+const PIXELFORMATDESCRIPTOR = extern struct {
+    nSize: u16,
+    nVersion: u16,
+    dwFlags: u32,
+    iPixelType: u8,
+    cColorBits: u8,
+    cRedBits: u8,
+    cRedShift: u8,
+    cGreenBits: u8,
+    cGreenShift: u8,
+    cBlueBits: u8,
+    cBlueShift: u8,
+    cAlphaBits: u8,
+    cAlphaShift: u8,
+    cAccumBits: u8,
+    cAccumRedBits: u8,
+    cAccumGreenBits: u8,
+    cAccumBlueBits: u8,
+    cAccumAlphaBits: u8,
+    cDepthBits: u8,
+    cStencilBits: u8,
+    cAuxBuffers: u8,
+    iLayerType: u8,
+    bReserved: u8,
+    dwLayerMask: u32,
+    dwVisibleMask: u32,
+    dwDamageMask: u32,
+};
+
+// WGL / GDI constants
+const PFD_DRAW_TO_WINDOW = 0x00000004;
+const PFD_SUPPORT_OPENGL = 0x00000020;
+const PFD_DOUBLEBUFFER = 0x00000001;
+const PFD_TYPE_RGBA = 0;
+const PFD_MAIN_PLANE = 0;
+
+// WGL / GDI extern declarations
+extern "user32" fn GetDC(hWnd: ?HWND) callconv(.winapi) HDC;
+extern "user32" fn ReleaseDC(hWnd: ?HWND, hDC: HDC) callconv(.winapi) c_int;
+extern "gdi32" fn ChoosePixelFormat(hdc: HDC, ppfd: *const PIXELFORMATDESCRIPTOR) callconv(.winapi) c_int;
+extern "gdi32" fn SetPixelFormat(hdc: HDC, format: c_int, ppfd: *const PIXELFORMATDESCRIPTOR) callconv(.winapi) BOOL;
+extern "gdi32" fn SwapBuffers(hdc: HDC) callconv(.winapi) BOOL;
+extern "opengl32" fn wglCreateContext(hdc: HDC) callconv(.winapi) HGLRC;
+extern "opengl32" fn wglDeleteContext(hglrc: HGLRC) callconv(.winapi) BOOL;
+extern "opengl32" fn wglMakeCurrent(hdc: HDC, hglrc: HGLRC) callconv(.winapi) BOOL;
+
+/// The window this surface belongs to.
+hwnd: HWND,
+
+/// GDI device context.
+hdc: HDC = null,
+
+/// OpenGL rendering context.
+hglrc: HGLRC = null,
+
+/// The core surface, if initialized.
+core_surface: ?*CoreSurface = null,
+
+/// Window dimensions.
+width: u32 = 800,
+height: u32 = 600,
+
+pub fn core(self: *Self) *CoreSurface {
+    return self.core_surface.?;
+}
+
+pub fn init(self: *Self, hwnd: HWND) !void {
+    self.* = .{ .hwnd = hwnd };
+    try self.initOpenGL();
+}
 
 pub fn deinit(self: *Self) void {
-    _ = self;
+    if (self.core_surface) |surface| {
+        surface.deinit();
+        // core_surface is allocated by CoreApp, freed there
+    }
+    if (self.hglrc != null) {
+        _ = wglMakeCurrent(null, null);
+        _ = wglDeleteContext(self.hglrc);
+    }
+    if (self.hdc != null) {
+        _ = ReleaseDC(self.hwnd, self.hdc);
+    }
 }
+
+fn initOpenGL(self: *Self) !void {
+    self.hdc = GetDC(self.hwnd);
+    if (self.hdc == null) {
+        log.err("GetDC failed", .{});
+        return error.Win32Error;
+    }
+
+    var pfd: PIXELFORMATDESCRIPTOR = std.mem.zeroes(PIXELFORMATDESCRIPTOR);
+    pfd.nSize = @sizeOf(PIXELFORMATDESCRIPTOR);
+    pfd.nVersion = 1;
+    pfd.dwFlags = PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL | PFD_DOUBLEBUFFER;
+    pfd.iPixelType = PFD_TYPE_RGBA;
+    pfd.cColorBits = 32;
+    pfd.cDepthBits = 24;
+    pfd.cStencilBits = 8;
+    pfd.iLayerType = PFD_MAIN_PLANE;
+
+    const pixel_format = ChoosePixelFormat(self.hdc, &pfd);
+    if (pixel_format == 0) {
+        log.err("ChoosePixelFormat failed", .{});
+        return error.Win32Error;
+    }
+
+    if (SetPixelFormat(self.hdc, pixel_format, &pfd) == 0) {
+        log.err("SetPixelFormat failed", .{});
+        return error.Win32Error;
+    }
+
+    self.hglrc = wglCreateContext(self.hdc);
+    if (self.hglrc == null) {
+        log.err("wglCreateContext failed", .{});
+        return error.Win32Error;
+    }
+
+    if (wglMakeCurrent(self.hdc, self.hglrc) == 0) {
+        log.err("wglMakeCurrent failed", .{});
+        return error.Win32Error;
+    }
+
+    log.info("WGL OpenGL context created successfully", .{});
+}
+
+pub fn swapBuffers(self: *Self) void {
+    if (self.hdc != null) {
+        _ = SwapBuffers(self.hdc);
+    }
+}
+
+// --- Interface methods required by CoreSurface ---
+
+pub fn getContentScale(_: *const Self) !apprt.ContentScale {
+    // TODO: query DPI from the monitor
+    return .{ .x = 1.0, .y = 1.0 };
+}
+
+pub fn getSize(self: *const Self) !apprt.SurfaceSize {
+    return .{
+        .width = self.width,
+        .height = self.height,
+    };
+}
+
+pub fn getCursorPos(_: *const Self) !apprt.CursorPos {
+    // TODO: track mouse position
+    return .{ .x = 0, .y = 0 };
+}
+
+pub fn getTitle(_: *Self) ?[:0]const u8 {
+    return null;
+}
+
+pub fn close(_: *Self, _: bool) void {
+    // TODO: handle close with confirmation
+}
+
+pub fn supportsClipboard(_: *Self, clipboard: apprt.Clipboard) bool {
+    return clipboard == .standard;
+}
+
+pub fn clipboardRequest(
+    _: *Self,
+    _: apprt.Clipboard,
+    _: apprt.ClipboardRequest,
+) !bool {
+    // TODO: implement clipboard read
+    return false;
+}
+
+pub fn setClipboard(
+    _: *Self,
+    _: apprt.Clipboard,
+    _: []const apprt.ClipboardContent,
+    _: bool,
+) !void {
+    // TODO: implement clipboard write
+}
+
+pub fn defaultTermioEnv(_: *Self) !std.process.EnvMap {
+    // Return an empty env map; the shell will inherit the process env.
+    return std.process.EnvMap.init(std.heap.page_allocator);
+}
+
+pub fn redrawInspector(_: *Self) void {}

--- a/src/apprt/win32/Surface.zig
+++ b/src/apprt/win32/Surface.zig
@@ -68,6 +68,9 @@ extern "opengl32" fn wglMakeCurrent(hdc: HDC, hglrc: HGLRC) callconv(.winapi) BO
 /// The window this surface belongs to.
 hwnd: HWND,
 
+/// Pointer back to the App.
+app: ?*App = null,
+
 /// GDI device context.
 hdc: HDC = null,
 
@@ -81,8 +84,14 @@ core_surface: ?*CoreSurface = null,
 width: u32 = 800,
 height: u32 = 600,
 
+const App = @import("App.zig");
+
 pub fn core(self: *Self) *CoreSurface {
     return self.core_surface.?;
+}
+
+pub fn rtApp(self: *Self) *App {
+    return self.app.?;
 }
 
 pub fn init(self: *Self, hwnd: HWND) !void {
@@ -150,6 +159,24 @@ pub fn swapBuffers(self: *Self) void {
     if (self.hdc != null) {
         _ = SwapBuffers(self.hdc);
     }
+}
+
+/// Make the WGL context current on the calling thread.
+pub fn makeContextCurrent(self: *Self) void {
+    if (self.hdc != null and self.hglrc != null) {
+        _ = wglMakeCurrent(self.hdc, self.hglrc);
+    }
+}
+
+/// Release the WGL context from the calling thread.
+pub fn releaseContext() void {
+    _ = wglMakeCurrent(null, null);
+}
+
+/// Release context from the main thread before handing off to renderer thread.
+pub fn releaseMainThreadContext(self: *Self) void {
+    _ = self;
+    _ = wglMakeCurrent(null, null);
 }
 
 // --- Interface methods required by CoreSurface ---

--- a/src/build/SharedDeps.zig
+++ b/src/build/SharedDeps.zig
@@ -609,6 +609,9 @@ pub fn add(
                 step.linkSystemLibrary2("user32", .{});
                 step.linkSystemLibrary2("gdi32", .{});
                 step.linkSystemLibrary2("opengl32", .{});
+                if (b.lazyDependency("win32", .{})) |dep| {
+                    step.root_module.addImport("win32", dep.module("win32"));
+                }
             },
         }
     }

--- a/src/build/SharedDeps.zig
+++ b/src/build/SharedDeps.zig
@@ -605,6 +605,11 @@ pub fn add(
         switch (self.config.app_runtime) {
             .none => {},
             .gtk => try self.addGtkNg(step),
+            .win32 => {
+                step.linkSystemLibrary2("user32", .{});
+                step.linkSystemLibrary2("gdi32", .{});
+                step.linkSystemLibrary2("opengl32", .{});
+            },
         }
     }
 

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -4625,7 +4625,7 @@ pub fn finalize(self: *Config) !void {
 
     // Apprt-specific defaults
     switch (build_config.app_runtime) {
-        .none => {},
+        .none, .win32 => {},
         .gtk => {
             switch (self.@"gtk-single-instance") {
                 .true, .false => {},

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -169,6 +169,11 @@ pub fn surfaceInit(surface: *apprt.Surface) !void {
         apprt.gtk,
         => try prepareContext(null),
 
+        // Win32: WGL context is already current, load via null (GLAD
+        // uses opengl32.dll + wglGetProcAddress automatically).
+        apprt.win32,
+        => try prepareContext(null),
+
         apprt.embedded => {
             // TODO(mitchellh): this does nothing today to allow libghostty
             // to compile for OpenGL targets but libghostty is strictly
@@ -208,6 +213,11 @@ pub fn threadEnter(self: *const OpenGL, surface: *apprt.Surface) !void {
             // on the main thread. As such, we don't do anything here.
         },
 
+        apprt.win32 => {
+            // Win32: WGL context is managed per-window and is already
+            // current on the renderer thread. Nothing extra needed.
+        },
+
         apprt.embedded => {
             // TODO(mitchellh): this does nothing today to allow libghostty
             // to compile for OpenGL targets but libghostty is strictly
@@ -226,6 +236,10 @@ pub fn threadExit(self: *const OpenGL) void {
         apprt.gtk => {
             // We don't need to do any unloading for GTK because we may
             // be sharing the global bindings with other windows.
+        },
+
+        apprt.win32 => {
+            // Win32: WGL context cleanup handled by the apprt surface.
         },
 
         apprt.embedded => {

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -195,57 +195,39 @@ pub fn surfaceInit(surface: *apprt.Surface) !void {
 /// thread for final main thread setup requirements.
 pub fn finalizeSurfaceInit(self: *const OpenGL, surface: *apprt.Surface) !void {
     _ = self;
-    _ = surface;
+
+    switch (apprt.runtime) {
+        apprt.win32 => {
+            // Release the WGL context from the main thread so the
+            // renderer thread can acquire it.
+            surface.releaseMainThreadContext();
+        },
+        else => {},
+    }
 }
 
 /// Callback called by renderer.Thread when it begins.
 pub fn threadEnter(self: *const OpenGL, surface: *apprt.Surface) !void {
     _ = self;
-    _ = surface;
 
-    switch (apprt.runtime) {
-        else => @compileError("unsupported app runtime for OpenGL"),
-
-        apprt.gtk => {
-            // GTK doesn't support threaded OpenGL operations as far as I can
-            // tell, so we use the renderer thread to setup all the state
-            // but then do the actual draws and texture syncs and all that
-            // on the main thread. As such, we don't do anything here.
-        },
-
-        apprt.win32 => {
-            // Win32: WGL context is managed per-window and is already
-            // current on the renderer thread. Nothing extra needed.
-        },
-
-        apprt.embedded => {
-            // TODO(mitchellh): this does nothing today to allow libghostty
-            // to compile for OpenGL targets but libghostty is strictly
-            // broken for rendering on this platforms.
-        },
+    if (apprt.runtime == apprt.win32) {
+        // Win32: make the WGL context current on this thread and
+        // reload GL function pointers.
+        surface.makeContextCurrent();
+        try prepareContext(null);
     }
+    // GTK and embedded don't need thread-specific GL setup.
 }
 
 /// Callback called by renderer.Thread when it exits.
 pub fn threadExit(self: *const OpenGL) void {
     _ = self;
 
-    switch (apprt.runtime) {
-        else => @compileError("unsupported app runtime for OpenGL"),
-
-        apprt.gtk => {
-            // We don't need to do any unloading for GTK because we may
-            // be sharing the global bindings with other windows.
-        },
-
-        apprt.win32 => {
-            // Win32: WGL context cleanup handled by the apprt surface.
-        },
-
-        apprt.embedded => {
-            // TODO: see threadEnter
-        },
+    if (apprt.runtime == apprt.win32) {
+        // Release the WGL context from this thread.
+        apprt.win32.Surface.releaseContext();
     }
+    // GTK and embedded don't need thread-specific GL cleanup.
 }
 
 pub fn displayRealized(self: *const OpenGL) void {

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -507,6 +507,12 @@ fn drawFrame(self: *Thread, now: bool) void {
     } else {
         self.renderer.drawFrame(false) catch |err|
             log.warn("error drawing err={}", .{err});
+
+        // On Win32, we need to explicitly swap buffers after rendering
+        // since there's no toolkit managing the GL context for us.
+        if (comptime @hasDecl(apprt.runtime.Surface, "swapBuffers")) {
+            self.surface.swapBuffers();
+        }
     }
 }
 


### PR DESCRIPTION
First Tier 2 PR of the win32-apprt upstreaming series. Adds a `.win32` variant to the apprt Runtime enum, defaulting on Windows exe builds, and enough surface/renderer wiring that `zig build -Dtarget=native-native-gnu` produces a `ghostty.exe` which opens a window and runs `cmd.exe` under ConPTY. The result is a working terminal at a basic level -- you can see output and the terminal resizes with the window.

The four commits stack in a straightforward order:

1. **Add minimal Win32 application runtime** -- `src/apprt/win32/App.zig` creates the HWND and runs the message loop, `src/apprt/win32/Surface.zig` is a stub. Window opens, no rendering yet.
2. **Add WGL OpenGL context and surface interface** -- pixel format + WGL context in Surface.zig plus the core `Surface` interface methods (`getContentScale`, `getSize`, etc.) the renderer needs.
3. **Wire up CoreSurface with WGL context threading** -- `App.initCoreSurface`, release/re-acquire GL context between main thread and renderer thread, so the renderer thread can draw. ConPTY successfully launches `cmd.exe` at this point.
4. **Add `SwapBuffers` and `WM_SIZE`** -- `SwapBuffers` after `drawFrame` so rendered frames actually appear, and `WM_SIZE` forwards to `CoreSurface.sizeCallback` so the terminal resizes.

These four commits are bundled into one PR rather than four because each intermediate state would merge a non-functional `ghostty.exe` into `main` -- after commit 1 the window is blank, after commit 2 it's still blank, after commit 3 `cmd.exe` runs but produces no visible output. Only after commit 4 does the binary behave like a terminal. The commit boundaries are preserved inside this PR so the review can be read as a sequence, but the merge itself needs all four.

Intentionally **not** included (each item is its own PR in the series):

- Keyboard, mouse, clipboard, IME input
- DPI awareness, focus events, window title updates
- Font-family config (discovery works but config wiring is separate)
- Dialogs, quit-confirm, child-exit bar
- Splits, tabs, command palette, quick terminal, multi-window
- Single-instance mutex, IPC window args
- Taskbar progress, native scrollbars
- Adjacent conpty.dll load

The tracker (mattn/ghostty#1) lists all the follow-up items.

---

AI usage disclosure: developed with Claude Code (Claude Opus 4.7). The skeleton code comes from my existing win32-apprt branch; Claude assisted with cherry-picking onto upstream main, resolving a merge conflict against the already-merged DllMain change from #12373, and validating the build.

Part of the Win32 apprt upstreaming series (see discussion #2563 / mattn/ghostty#1).