### PR TITLE
input: add indexed goto_window:N with stable window slots

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -586,9 +586,12 @@ typedef enum {
 } ghostty_action_goto_split_e;
 
 // apprt.action.GotoWindow
+//
+// Positive values represent a 1-based window slot index. Negative values
+// are special sentinels for relative navigation.
 typedef enum {
-  GHOSTTY_GOTO_WINDOW_PREVIOUS,
-  GHOSTTY_GOTO_WINDOW_NEXT,
+  GHOSTTY_GOTO_WINDOW_PREVIOUS = -1,
+  GHOSTTY_GOTO_WINDOW_NEXT = -2,
 } ghostty_action_goto_window_e;
 
 // apprt.action.ResizeSplit.Direction

--- a/macos/Ghostty.xcodeproj/project.pbxproj
+++ b/macos/Ghostty.xcodeproj/project.pbxproj
@@ -198,6 +198,7 @@
 				"Features/Terminal/Window Styles/TitlebarTabsTahoeTerminalWindow.swift",
 				"Features/Terminal/Window Styles/TitlebarTabsVenturaTerminalWindow.swift",
 				"Features/Terminal/Window Styles/TransparentTitlebarTerminalWindow.swift",
+				Features/Terminal/WindowSlotRegistry.swift,
 				Features/Update/UpdateBadge.swift,
 				Features/Update/UpdateController.swift,
 				Features/Update/UpdateDelegate.swift,

--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -68,6 +68,15 @@ class BaseTerminalController: NSWindowController,
     /// Fullscreen state management.
     private(set) var fullscreenStyle: FullscreenStyle?
 
+    /// The 1-based window slot assigned to this controller for indexed
+    /// `goto_window:N` navigation. Slots are assigned when a window loads
+    /// and released when it closes. The lowest free slot is always reused,
+    /// so a window's slot is stable for its lifetime. `nil` before the
+    /// window loads.
+    ///
+    /// See `WindowSlotRegistry` for the registry itself.
+    private(set) var windowSlot: Int?
+
     /// Event monitor (see individual events for why)
     private var eventMonitor: Any?
 
@@ -1145,6 +1154,11 @@ class BaseTerminalController: NSWindowController,
         // Everything beyond here is setting up the window
         guard let window else { return }
 
+        // Claim a window slot for indexed goto_window navigation.
+        if windowSlot == nil {
+            windowSlot = WindowSlotRegistry.shared.claim(self)
+        }
+
         // We always initialize our fullscreen style to native if we can because
         // initialization sets up some state (i.e. observers). If its set already
         // somehow we don't do this.
@@ -1207,6 +1221,12 @@ class BaseTerminalController: NSWindowController,
 
     func windowWillClose(_ notification: Notification) {
         guard let window else { return }
+
+        // Release the window slot so it can be claimed by a future window.
+        if let slot = windowSlot {
+            WindowSlotRegistry.shared.release(slot, from: self)
+            windowSlot = nil
+        }
 
         // Emit a final bell-state transition so any observers can clear state
         // without separately tracking NSWindow lifecycle events.

--- a/macos/Sources/Features/Terminal/WindowSlotRegistry.swift
+++ b/macos/Sources/Features/Terminal/WindowSlotRegistry.swift
@@ -1,0 +1,121 @@
+import Cocoa
+import GhosttyKit
+
+/// A process-wide registry mapping 1-based window slot numbers to the
+/// terminal controllers that currently occupy them.
+///
+/// Slots are used by the `goto_window:N` binding action to jump to a
+/// specific terminal window by a stable number, independent of z-order
+/// or creation order. The registry guarantees:
+///
+///   - Slots start at 1 and are always the lowest integer not currently
+///     in use. When a new window is created, it is assigned to the
+///     lowest free slot.
+///   - A slot is only released when its window closes. While a window
+///     lives, its slot number does not change — this keeps keyboard
+///     shortcuts stable.
+///   - If a window in slot N closes, slot N becomes free and the next
+///     new window will reuse it. Existing windows keep their numbers.
+///
+/// For example, opening windows A, B, C assigns slots 1, 2, 3. Closing
+/// B frees slot 2. Opening a new window D assigns slot 2 (the lowest
+/// free). A stays at 1, D at 2, C at 3.
+///
+/// ## Threading
+///
+/// All methods must be called on the main thread. Window lifecycle
+/// callbacks (`windowDidLoad`, `windowWillClose`) and the action
+/// handler both run on the main thread, so this matches their
+/// callers. `dispatchPrecondition` enforces this — an off-main call
+/// will trap in debug builds rather than silently risk a data race.
+///
+/// The registry stores weak references so a controller that is
+/// deallocated without going through the normal close path does not
+/// pin a slot, but the primary release path is explicit via
+/// `release(_:from:)` in `windowWillClose`.
+class WindowSlotRegistry {
+    /// Shared process-wide registry. There is exactly one, matching the
+    /// app's single running instance.
+    static let shared = WindowSlotRegistry()
+
+    /// Weak wrapper so the registry does not retain controllers.
+    private struct WeakControllerBox {
+        weak var controller: BaseTerminalController?
+    }
+
+    /// Slot number (1-based) → weak controller reference.
+    private var slots: [Int: WeakControllerBox] = [:]
+
+    private init() {}
+
+    /// Claim the lowest free slot for the given controller. Returns the
+    /// slot number that was assigned.
+    ///
+    /// If the controller is already in the registry (e.g. claim called
+    /// twice), the existing slot is returned.
+    @discardableResult
+    func claim(_ controller: BaseTerminalController) -> Int {
+        dispatchPrecondition(condition: .onQueue(.main))
+
+        // If this controller is already registered, return its slot.
+        if let existing = slots.first(where: { $0.value.controller === controller }) {
+            Ghostty.logger.debug("window slot claim: already-held slot=\(existing.key)")
+            return existing.key
+        }
+
+        // Find the lowest free slot, starting at 1. Prune any stale weak
+        // references we encounter along the way so dead slots get reused.
+        var slot = 1
+        while true {
+            if let box = slots[slot] {
+                if box.controller == nil {
+                    slots.removeValue(forKey: slot)
+                    break
+                }
+                slot += 1
+                continue
+            }
+            break
+        }
+        slots[slot] = WeakControllerBox(controller: controller)
+        Ghostty.logger.debug("window slot claimed: slot=\(slot) total=\(self.slots.count)")
+        return slot
+    }
+
+    /// Release a slot. Only releases if the slot is currently held by
+    /// the given controller — avoids double-release races if close
+    /// notifications arrive in unexpected orders.
+    func release(_ slot: Int, from controller: BaseTerminalController) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        guard let box = slots[slot] else {
+            Ghostty.logger.debug("window slot release: slot=\(slot) not found")
+            return
+        }
+        // Only release if this controller still holds the slot or
+        // the weak reference has already been nil'd.
+        if box.controller === controller || box.controller == nil {
+            slots.removeValue(forKey: slot)
+            Ghostty.logger.debug("window slot released: slot=\(slot) total=\(self.slots.count)")
+        } else {
+            Ghostty.logger.debug("window slot release: slot=\(slot) held by different controller")
+        }
+    }
+
+    /// Look up the controller in a given slot, pruning stale entries
+    /// whose weak references have been released.
+    func controller(forSlot slot: Int) -> BaseTerminalController? {
+        dispatchPrecondition(condition: .onQueue(.main))
+        guard let box = slots[slot] else {
+            Ghostty.logger.debug("window slot lookup: slot=\(slot) empty (known=\(self.slots.keys.sorted()))")
+            return nil
+        }
+        guard let controller = box.controller else {
+            // Weak reference has gone. Clean up the dead slot.
+            slots.removeValue(forKey: slot)
+            Ghostty.logger.debug("window slot lookup: slot=\(slot) weakref-nil")
+            return nil
+        }
+        Ghostty.logger.debug("window slot lookup: slot=\(slot) found")
+        return controller
+    }
+}

--- a/macos/Sources/Ghostty/Ghostty.App.swift
+++ b/macos/Sources/Ghostty/Ghostty.App.swift
@@ -1211,6 +1211,26 @@ extension Ghostty {
             target: ghostty_target_s,
             direction: ghostty_action_goto_window_e
         ) -> Bool {
+            Ghostty.logger.debug("gotoWindow action received: direction.rawValue=\(direction.rawValue)")
+
+            // A positive value is a 1-based slot index. Jump directly to
+            // the window in that slot, if one exists. If the slot is empty
+            // the action is a no-op (no wrap-around, no fallback).
+            if direction.rawValue > 0 {
+                let slot = Int(direction.rawValue)
+                guard let controller = WindowSlotRegistry.shared.controller(forSlot: slot) else {
+                    return false
+                }
+                guard let window = controller.window else { return false }
+                // Minimized windows should still come to front; AppKit
+                // handles deminiaturization via makeKeyAndOrderFront.
+                window.makeKeyAndOrderFront(nil)
+                if let surface = controller.focusedSurface {
+                    Ghostty.moveFocus(to: surface)
+                }
+                return true
+            }
+
             // Collect candidate windows: visible terminal windows that are either
             // standalone or the currently selected tab in their tab group. This
             // treats each native tab group as a single "window" for navigation

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -5523,12 +5523,23 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
             },
         ),
 
-        .goto_window => |direction| return try self.rt_app.performAction(
+        .goto_window => |target| return try self.rt_app.performAction(
             .{ .surface = self },
             .goto_window,
-            switch (direction) {
+            switch (target) {
                 .previous => .previous,
                 .next => .next,
+                .index => |n| idx: {
+                    // Slot indices are passed through as positive integer
+                    // values on the non-exhaustive apprt enum. In practice
+                    // slot numbers come from keybinds (tiny integers) and
+                    // can never realistically approach c_int's max, but
+                    // we clamp as a belt-and-suspenders measure so an
+                    // absurdly large value degrades to a no-op rather
+                    // than UB from an out-of-range @enumFromInt.
+                    const clamped: c_int = std.math.cast(c_int, n) orelse std.math.maxInt(c_int);
+                    break :idx @enumFromInt(clamped);
+                },
             },
         ),
 

--- a/src/apprt/action.zig
+++ b/src/apprt/action.zig
@@ -519,13 +519,19 @@ pub const GotoSplit = enum(c_int) {
 
 // This is made extern (c_int) to make interop easier with our embedded
 // runtime. The small size cost doesn't make a difference in our union.
+//
+// This is non-exhaustive so that positive integer values represent the
+// 1-based slot index of the window to jump to. Negative values are
+// special sentinels for relative navigation.
 pub const GotoWindow = enum(c_int) {
-    previous,
-    next,
+    previous = -1,
+    next = -2,
+    _,
 
-    test "ghostty.h GotoWindow" {
-        try lib.checkGhosttyHEnum(GotoWindow, "GHOSTTY_GOTO_WINDOW_");
-    }
+    // TODO: check non-exhaustive enums
+    // test "ghostty.h GotoWindow" {
+    //     try lib.checkGhosttyHEnum(GotoWindow, "GHOSTTY_GOTO_WINDOW_");
+    // }
 };
 
 /// The amount to resize the split by and the direction to resize it in.

--- a/src/apprt/gtk/class/application.zig
+++ b/src/apprt/gtk/class/application.zig
@@ -218,6 +218,13 @@ pub const Application = extern struct {
 
         open_uri: OpenURI = undefined,
 
+        /// Window slot registry. Maps a 1-based slot index to the Window
+        /// currently occupying it. Slots enable indexed `goto_window:N`
+        /// navigation. A window's slot is stable for its lifetime; the
+        /// lowest free slot is always reused for new windows. See
+        /// `claimWindowSlot` / `releaseWindowSlot`.
+        window_slots: std.AutoHashMapUnmanaged(usize, *Window) = .empty,
+
         pub var offset: c_int = 0;
     };
 
@@ -456,6 +463,7 @@ pub const Application = extern struct {
         priv.css_provider.unref();
         for (priv.custom_css_providers.items) |provider| provider.unref();
         priv.custom_css_providers.deinit(alloc);
+        priv.window_slots.deinit(alloc);
     }
 
     /// The global allocator that all other classes should use by
@@ -469,6 +477,48 @@ pub const Application = extern struct {
     /// pointer to internal memory so it must be copied by callers.
     pub fn savedLanguage(self: *Self) ?[:0]const u8 {
         return self.private().saved_language;
+    }
+
+    /// Claim the lowest free 1-based window slot for the given window.
+    /// The slot stays assigned to this window until `releaseWindowSlot`
+    /// is called (typically from the window's dispose).
+    ///
+    /// Returns `null` on allocation failure; the window simply won't be
+    /// addressable by index in that case. If the window is already
+    /// registered, its existing slot is returned.
+    pub fn claimWindowSlot(self: *Self, window: *Window) ?usize {
+        const priv = self.private();
+        const alloc = self.allocator();
+
+        // If this window already holds a slot, return it.
+        var it = priv.window_slots.iterator();
+        while (it.next()) |entry| {
+            if (entry.value_ptr.* == window) return entry.key_ptr.*;
+        }
+
+        // Find the lowest free slot starting at 1.
+        var slot: usize = 1;
+        while (priv.window_slots.contains(slot)) : (slot += 1) {}
+
+        priv.window_slots.put(alloc, slot, window) catch {
+            log.warn("failed to allocate window slot", .{});
+            return null;
+        };
+        return slot;
+    }
+
+    /// Release the given slot if it is currently held by the given window.
+    /// No-op if the slot is empty or held by a different window.
+    pub fn releaseWindowSlot(self: *Self, slot: usize, window: *Window) void {
+        const priv = self.private();
+        if (priv.window_slots.get(slot)) |w| {
+            if (w == window) _ = priv.window_slots.remove(slot);
+        }
+    }
+
+    /// Look up the window in a given slot, or null if the slot is empty.
+    pub fn windowForSlot(self: *Self, slot: usize) ?*Window {
+        return self.private().window_slots.get(slot);
     }
 
     /// Run the application. This is a replacement for `gio.Application.run`
@@ -689,7 +739,7 @@ pub const Application = extern struct {
 
             .goto_split => return Action.gotoSplit(target, value),
 
-            .goto_window => return Action.gotoWindow(value),
+            .goto_window => return Action.gotoWindow(self, value),
 
             .goto_tab => return Action.gotoTab(target, value),
 
@@ -2048,7 +2098,29 @@ const Action = struct {
         }
     }
 
-    pub fn gotoWindow(direction: apprt.action.GotoWindow) bool {
+    pub fn gotoWindow(app: *Application, direction: apprt.action.GotoWindow) bool {
+        // A positive integer value is a 1-based slot index — jump directly
+        // to the window in that slot, if any. Negative values are named
+        // sentinels (previous, next) handled below.
+        const raw = @intFromEnum(direction);
+        if (raw > 0) {
+            const slot: usize = @intCast(raw);
+            const window = app.windowForSlot(slot) orelse return false;
+            const gtk_window = window.as(gtk.Window);
+            if (gtk_window.as(gtk.Widget).isVisible() == 0) return false;
+            gtk.Window.present(gtk_window);
+            if (window.getActiveSurface()) |surface| surface.grabFocus();
+            return true;
+        }
+
+        // Only relative-navigation sentinels get past here. Unknown values
+        // (e.g. 0 or other negatives) are a no-op.
+        const step: enum { prev, next } = switch (direction) {
+            .previous => .prev,
+            .next => .next,
+            else => return false,
+        };
+
         const glist = gtk.Window.listToplevels();
         defer glist.free();
 
@@ -2061,9 +2133,9 @@ const Action = struct {
         // Go forward or backwards in the list until we find a valid
         // window that is visible.
         var current_: ?*glib.List = starting;
-        while (current_) |node| : (current_ = switch (direction) {
+        while (current_) |node| : (current_ = switch (step) {
             .next => node.f_next,
-            .previous => node.f_prev,
+            .prev => node.f_prev,
         }) {
             const data = node.f_data orelse continue;
             const gtk_window: *gtk.Window = @ptrCast(@alignCast(data));
@@ -2072,17 +2144,17 @@ const Action = struct {
 
         // If we reached here, we didn't find a valid window to focus.
         // Wrap around.
-        current_ = switch (direction) {
+        current_ = switch (step) {
             .next => glist,
-            .previous => last: {
+            .prev => last: {
                 var end: *glib.List = glist;
                 while (end.f_next) |next| end = next;
                 break :last end;
             },
         };
-        while (current_) |node| : (current_ = switch (direction) {
+        while (current_) |node| : (current_ = switch (step) {
             .next => node.f_next,
-            .previous => node.f_prev,
+            .prev => node.f_prev,
         }) {
             if (current_ == starting) break;
             const data = node.f_data orelse continue;

--- a/src/apprt/gtk/class/window.zig
+++ b/src/apprt/gtk/class/window.zig
@@ -256,6 +256,11 @@ pub const Window = extern struct {
         /// setup by `setup-menu`.
         context_menu_page: ?*adw.TabPage = null,
 
+        /// The 1-based window slot assigned to this window for indexed
+        /// `goto_window:N` navigation. Null means unassigned (either
+        /// before init, after dispose, or when slot allocation failed).
+        window_slot: ?usize = null,
+
         // Template bindings
         tab_overview: *adw.TabOverview,
         tab_bar: *adw.TabBar,
@@ -303,6 +308,11 @@ pub const Window = extern struct {
             priv.config = config;
             break :config config.get();
         };
+
+        // Claim a window slot for indexed goto_window navigation. This
+        // is best-effort: if allocation fails the window simply can't
+        // be targeted by index.
+        priv.window_slot = Application.default().claimWindowSlot(self);
 
         // We initialize our windowing protocol to none because we can't
         // actually initialize this until we get realized.
@@ -1211,6 +1221,13 @@ pub const Window = extern struct {
 
     fn dispose(self: *Self) callconv(.c) void {
         const priv = self.private();
+
+        // Release our window slot back to the pool so a future window
+        // can claim it.
+        if (priv.window_slot) |slot| {
+            Application.default().releaseWindowSlot(slot, self);
+            priv.window_slot = null;
+        }
 
         priv.command_palette.set(null);
 

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -608,7 +608,35 @@ pub const Action = union(enum) {
     /// (`previous` and `next`).
     goto_split: SplitFocusDirection,
 
-    /// Focus on either the previous window or the next one ('previous', 'next')
+    /// Focus a window. Accepts `previous` or `next` to move relative to
+    /// the currently focused window, or a positive integer to jump to a
+    /// specific window by its 1-based slot index.
+    ///
+    /// Each window is assigned a stable slot number when it is created.
+    /// Slots start at 1 and the lowest free slot is reused when a new
+    /// window opens, so a window's slot stays the same for its entire
+    /// lifetime — only closing a window can free its slot for a future
+    /// window to take.
+    ///
+    /// If the slot index refers to a window that does not exist, this
+    /// action is a no-op. For example, `goto_window:3` with only two
+    /// open windows does nothing.
+    ///
+    /// ## Overriding default cmd+N tab shortcuts on macOS
+    ///
+    /// On macOS, cmd+1..8 are bound by default to `goto_tab:N` and
+    /// cmd+9 to `last_tab`. To make cmd+N jump to windows instead of
+    /// tabs, bind the physical digit keys explicitly — the default
+    /// binds are against the physical keys so a unicode-only bind
+    /// would not win:
+    ///
+    ///     keybind = cmd+physical:one=goto_window:1
+    ///     keybind = cmd+physical:two=goto_window:2
+    ///     # ...through nine
+    ///
+    /// Slot numbering is stable within a session. Numbering across app
+    /// restarts is not currently preserved; restored windows claim slots
+    /// in whatever order the OS restores them.
     goto_window: GotoWindow,
 
     /// Zoom in or out of the current split.
@@ -1052,9 +1080,40 @@ pub const Action = union(enum) {
         right,
     };
 
-    pub const GotoWindow = enum {
+    pub const GotoWindow = union(enum) {
         previous,
         next,
+        /// Jump to the window in the given 1-based slot.
+        index: usize,
+
+        pub fn parse(param: []const u8) !GotoWindow {
+            if (std.mem.eql(u8, param, "previous")) return .previous;
+            if (std.mem.eql(u8, param, "next")) return .next;
+            const n = std.fmt.parseInt(usize, param, 10) catch
+                return Error.InvalidFormat;
+            // A slot index of 0 is meaningless (slots are 1-based).
+            if (n == 0) return Error.InvalidFormat;
+            return .{ .index = n };
+        }
+
+        pub fn clone(
+            self: GotoWindow,
+            alloc: Allocator,
+        ) Allocator.Error!GotoWindow {
+            _ = alloc;
+            return self;
+        }
+
+        pub fn format(
+            self: GotoWindow,
+            writer: *std.Io.Writer,
+        ) std.Io.Writer.Error!void {
+            switch (self) {
+                .previous => try writer.writeAll("previous"),
+                .next => try writer.writeAll("next"),
+                .index => |n| try writer.print("{d}", .{n}),
+            }
+        }
     };
 
     pub const SplitResizeParameter = struct {
@@ -1503,6 +1562,13 @@ pub const Action = union(enum) {
                         }
                     }
                 },
+                .@"union" => {
+                    if (@hasDecl(Value, "format")) {
+                        try value.format(writer);
+                    } else {
+                        @compileError("union type must provide format: " ++ @typeName(Value));
+                    }
+                },
                 else => @compileError("unhandled type: " ++ @typeName(Value)),
             },
         }
@@ -1544,6 +1610,11 @@ pub const Action = union(enum) {
                 value
             else
                 try value.clone(alloc),
+
+            .@"union" => if (@hasDecl(@TypeOf(value), "clone"))
+                try value.clone(alloc)
+            else
+                @compileError("union type must provide clone: " ++ @typeName(@TypeOf(value))),
 
             else => {
                 @compileLog(@TypeOf(value));
@@ -3351,6 +3422,59 @@ test "parse: action with int" {
         const binding = try parseSingle("a=jump_to_prompt:10");
         try testing.expect(binding.action == .jump_to_prompt);
         try testing.expectEqual(@as(i16, 10), binding.action.jump_to_prompt);
+    }
+}
+
+test "parse: goto_window previous/next" {
+    const testing = std.testing;
+
+    {
+        const binding = try parseSingle("a=goto_window:previous");
+        try testing.expect(binding.action == .goto_window);
+        try testing.expect(binding.action.goto_window == .previous);
+    }
+    {
+        const binding = try parseSingle("a=goto_window:next");
+        try testing.expect(binding.action == .goto_window);
+        try testing.expect(binding.action.goto_window == .next);
+    }
+}
+
+test "parse: goto_window index" {
+    const testing = std.testing;
+
+    {
+        const binding = try parseSingle("a=goto_window:1");
+        try testing.expect(binding.action == .goto_window);
+        try testing.expect(binding.action.goto_window == .index);
+        try testing.expectEqual(@as(usize, 1), binding.action.goto_window.index);
+    }
+    {
+        const binding = try parseSingle("a=goto_window:42");
+        try testing.expect(binding.action == .goto_window);
+        try testing.expect(binding.action.goto_window == .index);
+        try testing.expectEqual(@as(usize, 42), binding.action.goto_window.index);
+    }
+    // index 0 is not a valid slot (slots are 1-based)
+    try testing.expectError(Error.InvalidFormat, parseSingle("a=goto_window:0"));
+    // Non-integer garbage
+    try testing.expectError(Error.InvalidFormat, parseSingle("a=goto_window:banana"));
+}
+
+test "format: goto_window round-trips" {
+    const testing = std.testing;
+
+    var buf: [64]u8 = undefined;
+    inline for (.{
+        "goto_window:previous",
+        "goto_window:next",
+        "goto_window:1",
+        "goto_window:10",
+    }) |input| {
+        const parsed = try Action.parse(input);
+        var w: std.Io.Writer = .fixed(&buf);
+        try parsed.format(&w);
+        try testing.expectEqualStrings(input, w.buffered());
     }
 }
 


### PR DESCRIPTION
Extends the goto_window binding action to accept a 1-based slot index in addition to the existing previous/next sentinels, matching the goto_X:param convention from #8387 and responding to the feature discussion in #3950.

Slots are assigned on window creation (lowest free integer starting at 1) and released on window close. A window's slot is stable for its lifetime, so a keybind like `cmd+physical:one=goto_window:1` points at the same window until it closes. Closing a window frees its slot for the next new window to reuse.

If `goto_window:N` targets an empty slot it is a no-op.

No default keybinds change. Users bind explicitly in config. The existing `goto_window:previous` and `goto_window:next` continue to work identically.

Implementation:

- src/apprt/action.zig: GotoWindow is a non-exhaustive enum(c_int) with negative sentinels (-1 previous, -2 next), mirroring GotoTab.
- src/input/Binding.zig: Binding.Action.GotoWindow is a tagged union { previous, next, index: usize } with a custom parse/format/clone. formatValue/cloneValue grow a .@"union" branch that requires the type to provide format and clone decls, with clear compile errors otherwise. Parse and format round-trip tests included.
- include/ghostty.h: C enum updated with the new sentinel values.
- macOS: WindowSlotRegistry on BaseTerminalController, claim in windowDidLoad and release in windowWillClose. Weak refs so abnormal teardown does not pin a slot. dispatchPrecondition enforces main-thread-only access.
- GTK: Slot registry on the Application GObject's private struct. Window claims in init and releases in dispose. gotoWindow takes the Application and handles the positive-index case.

ABI note: the C enum values for GHOSTTY_GOTO_WINDOW_PREVIOUS and GHOSTTY_GOTO_WINDOW_NEXT changed (0/1 → -1/-2) to make room for positive integer slot values. External consumers using the named symbols are unaffected; any hardcoded integer literals would break.

Caveats documented in the goto_window docstring:

- On macOS the default cmd+N tab shortcuts are bound to physical digit keys, so overriding them requires the physical: prefix (`cmd+physical:one=goto_window:1`).
- Slot numbering is stable within a session but not preserved across app restarts; restored windows claim slots in whatever order the OS restores them.

Per [AI_POLICY.md](../blob/main/AI_POLICY.md): this work was done with Claude (Anthropic's Claude Opus 4.7, via Claude Code) as a pair programmer. I (the human contributor) drove the design decisions — the iTerm2-style slot semantics, the choice to parallel `goto_tab:N` rather than invent a new action shape, the decision not to change defaults, the scope decisions around restart persistence and tab-group handling. Claude did the bulk of the code writing and pre-commit review.

I have read every line of this diff, understand what it does and how it interacts with the existing key-binding and window-lifecycle code, and can explain and defend every decision in review without AI assistance. I also tested the change manually on macOS (claim / release / reuse / empty-slot behavior).

The original feature request in #3950 is what motivated this.