### PR TITLE
flatpak: update runtime to GNOME 50

### DIFF
--- a/flatpak/com.mitchellh.ghostty-debug.yml
+++ b/flatpak/com.mitchellh.ghostty-debug.yml
@@ -1,6 +1,6 @@
 app-id: com.mitchellh.ghostty-debug
 runtime: org.gnome.Platform
-runtime-version: "49"
+runtime-version: "50"
 sdk: org.gnome.Sdk
 default-branch: tip
 command: ghostty

--- a/flatpak/com.mitchellh.ghostty.yml
+++ b/flatpak/com.mitchellh.ghostty.yml
@@ -1,6 +1,6 @@
 app-id: com.mitchellh.ghostty
 runtime: org.gnome.Platform
-runtime-version: "49"
+runtime-version: "50"
 sdk: org.gnome.Sdk
 default-branch: tip
 command: ghostty


### PR DESCRIPTION
Notable dependency changes:

- GTK: `4.20.4` -> `4.22.2`
- libadwaita: `1.8.5` -> `1.9.0`