### PR TITLE
macOS: remove manual invalidateRestorableState()

### DIFF
--- a/macos/Sources/Features/Update/UpdateDelegate.swift
+++ b/macos/Sources/Features/Update/UpdateDelegate.swift
@@ -31,12 +31,4 @@ extension UpdateDriver: SPUUpdaterDelegate {
         ))
         return true
     }
-
-    func updaterWillRelaunchApplication(_ updater: SPUUpdater) {
-        // When the updater is relaunching the application we want to get macOS
-        // to invalidate and re-encode all of our restorable state so that when
-        // we relaunch it uses it.
-        NSApp.invalidateRestorableState()
-        for window in NSApp.windows { window.invalidateRestorableState() }
-    }
 }


### PR DESCRIPTION
This should be safe to delete now after #12461.

I tested saving 27 tabs, 4 with 2 splits, `TerminalRestorable.encode(with:` finished successfully. 

And I check the breakpoints when the Sparkle sends `-[NSRunningApplication treminate]`. The call stack at `-[NSResponder invalidateRestorableState]` is pretty much the same as quitting via `cmd+q`.