### PR TITLE
macos: expose tab color via AppleScript

### DIFF
--- a/macos/Ghostty.sdef
+++ b/macos/Ghostty.sdef
@@ -69,6 +69,9 @@
       </property>
       <property name="index" code="pidx" type="integer" access="r" description="1-based index of this tab in its window."/>
       <property name="selected" code="GTsl" type="boolean" access="r" description="Whether this tab is selected in its window."/>
+      <property name="color" code="GTcl" type="tab color" access="rw" description="The color of the tab.">
+        <cocoa key="color"/>
+      </property>
       <property name="focused terminal" code="GTfT" type="terminal" access="r" description="The currently focused terminal surface in this tab.">
         <cocoa key="focusedTerminal"/>
       </property>
@@ -122,6 +125,19 @@
         <cocoa key="environmentVariables"/>
       </property>
     </record-type>
+
+    <enumeration name="tab color" code="GTbC" description="The color of a Ghostty tab.">
+      <enumerator name="none" code="GTcN" description="No color."/>
+      <enumerator name="blue" code="GTcB" description="Blue."/>
+      <enumerator name="purple" code="GTcP" description="Purple."/>
+      <enumerator name="pink" code="GTcK" description="Pink."/>
+      <enumerator name="red" code="GTcR" description="Red."/>
+      <enumerator name="orange" code="GTcO" description="Orange."/>
+      <enumerator name="yellow" code="GTcY" description="Yellow."/>
+      <enumerator name="green" code="GTcG" description="Green."/>
+      <enumerator name="teal" code="GTcT" description="Teal."/>
+      <enumerator name="graphite" code="GTcX" description="Graphite."/>
+    </enumeration>
 
     <enumeration name="split direction" code="GSpD" description="Direction for a new split.">
       <enumerator name="right" code="GSrt" description="Split to the right."/>

--- a/macos/Ghostty.sdef
+++ b/macos/Ghostty.sdef
@@ -69,7 +69,7 @@
       </property>
       <property name="index" code="pidx" type="integer" access="r" description="1-based index of this tab in its window."/>
       <property name="selected" code="GTsl" type="boolean" access="r" description="Whether this tab is selected in its window."/>
-      <property name="color" code="GTcl" type="tab color" access="rw" description="The color of the tab.">
+      <property name="color" code="colr" type="tab color" access="rw" description="The color of the tab.">
         <cocoa key="color"/>
       </property>
       <property name="focused terminal" code="GTfT" type="terminal" access="r" description="The currently focused terminal surface in this tab.">

--- a/macos/Ghostty.sdef
+++ b/macos/Ghostty.sdef
@@ -69,6 +69,9 @@
       </property>
       <property name="index" code="pidx" type="integer" access="r" description="1-based index of this tab in its window."/>
       <property name="selected" code="GTsl" type="boolean" access="r" description="Whether this tab is selected in its window."/>
+      <property name="color" code="GTcl" type="tab color" access="rw" description="The color of the tab.">
+        <cocoa key="color"/>
+      </property>
       <property name="focused terminal" code="GTfT" type="terminal" access="r" description="The currently focused terminal surface in this tab.">
         <cocoa key="focusedTerminal"/>
       </property>
@@ -124,6 +127,19 @@
         <cocoa key="environmentVariables"/>
       </property>
     </record-type>
+
+    <enumeration name="tab color" code="GTbC" description="The color of a Ghostty tab.">
+      <enumerator name="none" code="GTcN" description="No color."/>
+      <enumerator name="blue" code="GTcB" description="Blue."/>
+      <enumerator name="purple" code="GTcP" description="Purple."/>
+      <enumerator name="pink" code="GTcK" description="Pink."/>
+      <enumerator name="red" code="GTcR" description="Red."/>
+      <enumerator name="orange" code="GTcO" description="Orange."/>
+      <enumerator name="yellow" code="GTcY" description="Yellow."/>
+      <enumerator name="green" code="GTcG" description="Green."/>
+      <enumerator name="teal" code="GTcT" description="Teal."/>
+      <enumerator name="graphite" code="GTcX" description="Graphite."/>
+    </enumeration>
 
     <enumeration name="split direction" code="GSpD" description="Direction for a new split.">
       <enumerator name="right" code="GSrt" description="Split to the right."/>

--- a/macos/Ghostty.sdef
+++ b/macos/Ghostty.sdef
@@ -129,16 +129,23 @@
     </record-type>
 
     <enumeration name="tab color" code="GTbC" description="The color of a Ghostty tab.">
-      <enumerator name="none" code="GTcN" description="No color."/>
-      <enumerator name="blue" code="GTcB" description="Blue."/>
-      <enumerator name="purple" code="GTcP" description="Purple."/>
-      <enumerator name="pink" code="GTcK" description="Pink."/>
-      <enumerator name="red" code="GTcR" description="Red."/>
-      <enumerator name="orange" code="GTcO" description="Orange."/>
-      <enumerator name="yellow" code="GTcY" description="Yellow."/>
-      <enumerator name="green" code="GTcG" description="Green."/>
-      <enumerator name="teal" code="GTcT" description="Teal."/>
-      <enumerator name="graphite" code="GTcX" description="Graphite."/>
+      <!-- Color enumerators use a 4-bit-per-channel ASCII hex RGBA as their code
+           (one hex digit per channel: R, G, B, A). Values are the nearest 4-bit
+           rounding of Apple's published Human Interface Guidelines light-mode
+           system color hex (https://developer.apple.com/design/human-interface-guidelines/color).
+           They serve as stable identifiers; the actual rendered color comes from
+           the corresponding system color and may shift between OS releases.
+           The "none" enumerator uses a literal code. -->
+      <enumerator name="none" code="none" description="No color."/>
+      <enumerator name="blue" code="08FF" description="Blue."/>
+      <enumerator name="purple" code="C3DF" description="Purple."/>
+      <enumerator name="pink" code="F35F" description="Pink."/>
+      <enumerator name="red" code="F34F" description="Red."/>
+      <enumerator name="orange" code="F82F" description="Orange."/>
+      <enumerator name="yellow" code="FC0F" description="Yellow."/>
+      <enumerator name="green" code="3C5F" description="Green."/>
+      <enumerator name="teal" code="0CBF" description="Teal."/>
+      <enumerator name="graphite" code="889F" description="Graphite."/>
     </enumeration>
 
     <enumeration name="split direction" code="GSpD" description="Direction for a new split.">

--- a/macos/Sources/Features/AppleScript/ScriptTab.swift
+++ b/macos/Sources/Features/AppleScript/ScriptTab.swift
@@ -67,6 +67,23 @@ final class ScriptTab: NSObject {
         return window?.tabIsSelected(controller) ?? false
     }
 
+    /// Exposed as the AppleScript `color` property.
+    ///
+    /// The value is a `tab color` enumeration constant defined in `Ghostty.sdef`.
+    /// Cocoa scripting passes enumerator FourCharCodes as `UInt32` via KVC.
+    @objc(color)
+    var color: UInt32 {
+        get {
+            guard NSApp.isAppleScriptEnabled else { return TerminalTabColor.none.appleScriptCode }
+            return ((controller?.window as? TerminalWindow)?.tabColor ?? .none).appleScriptCode
+        }
+        set {
+            guard NSApp.isAppleScriptEnabled else { return }
+            guard let terminalWindow = controller?.window as? TerminalWindow else { return }
+            terminalWindow.tabColor = TerminalTabColor(appleScriptCode: newValue)
+        }
+    }
+
     /// Exposed as the AppleScript `focused terminal` property.
     ///
     /// Uses the currently focused surface for this tab.
@@ -182,5 +199,29 @@ extension ScriptTab {
     /// lookups in `ScriptWindow` call this helper.
     static func stableID(controller: BaseTerminalController) -> String {
         "tab-\(ObjectIdentifier(controller).hexString)"
+    }
+}
+
+/// Maps `TerminalTabColor` to and from the `tab color` enumeration in `Ghostty.sdef`.
+///
+/// Cocoa scripting passes enumerator FourCharCodes as integers via KVC.
+private extension TerminalTabColor {
+    var appleScriptCode: UInt32 {
+        switch self {
+        case .none:     "GTcN".fourCharCode
+        case .blue:     "GTcB".fourCharCode
+        case .purple:   "GTcP".fourCharCode
+        case .pink:     "GTcK".fourCharCode
+        case .red:      "GTcR".fourCharCode
+        case .orange:   "GTcO".fourCharCode
+        case .yellow:   "GTcY".fourCharCode
+        case .green:    "GTcG".fourCharCode
+        case .teal:     "GTcT".fourCharCode
+        case .graphite: "GTcX".fourCharCode
+        }
+    }
+
+    init(appleScriptCode: UInt32) {
+        self = Self.allCases.first(where: { $0.appleScriptCode == appleScriptCode }) ?? .none
     }
 }

--- a/macos/Sources/Features/AppleScript/ScriptTab.swift
+++ b/macos/Sources/Features/AppleScript/ScriptTab.swift
@@ -203,21 +203,20 @@ extension ScriptTab {
 }
 
 /// Maps `TerminalTabColor` to and from the `tab color` enumeration in `Ghostty.sdef`.
-///
-/// Cocoa scripting passes enumerator FourCharCodes as integers via KVC.
+/// See `Ghostty.sdef` for how the codes are derived.
 private extension TerminalTabColor {
     var appleScriptCode: UInt32 {
         switch self {
-        case .none:     "GTcN".fourCharCode
-        case .blue:     "GTcB".fourCharCode
-        case .purple:   "GTcP".fourCharCode
-        case .pink:     "GTcK".fourCharCode
-        case .red:      "GTcR".fourCharCode
-        case .orange:   "GTcO".fourCharCode
-        case .yellow:   "GTcY".fourCharCode
-        case .green:    "GTcG".fourCharCode
-        case .teal:     "GTcT".fourCharCode
-        case .graphite: "GTcX".fourCharCode
+        case .none:     "none".fourCharCode
+        case .blue:     "08FF".fourCharCode
+        case .purple:   "C3DF".fourCharCode
+        case .pink:     "F35F".fourCharCode
+        case .red:      "F34F".fourCharCode
+        case .orange:   "F82F".fourCharCode
+        case .yellow:   "FC0F".fourCharCode
+        case .green:    "3C5F".fourCharCode
+        case .teal:     "0CBF".fourCharCode
+        case .graphite: "889F".fourCharCode
         }
     }
 

--- a/macos/Sources/Features/Terminal/TerminalTabColor.swift
+++ b/macos/Sources/Features/Terminal/TerminalTabColor.swift
@@ -1,6 +1,7 @@
 import AppKit
 import SwiftUI
 
+/// When adding cases, also update the `tab color` enumeration in `Ghostty.sdef`.
 enum TerminalTabColor: Int, CaseIterable, Codable {
     case none
     case blue


### PR DESCRIPTION
Exposes tab color on macos as a readable/writeable AppleScript `color` property.

Based on Discussions requests:

https://github.com/ghostty-org/ghostty/discussions/11590 (just name was implemented)
https://github.com/ghostty-org/ghostty/discussions/12314 (more recent request)

Claude code was used to generate initial .sdef binding, but I spent some time myself making it (hopefully) more maintainable, including some compile time garantuees if updates the the palette are made in future.
