### PR TITLE
Fix speedy high-resolution scrolling on Linux

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -3438,8 +3438,7 @@ pub fn scrollCallback(
                     @min(yoff, -1);
 
                 break :yoff_adjusted yoff_max * cell_size * self.config.mouse_scroll_multiplier.discrete;
-            }
-            else {
+            } else {
                 break :yoff_adjusted yoff * cell_size * self.config.mouse_scroll_multiplier.discrete;
             }
         };

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -3424,19 +3424,24 @@ pub fn scrollCallback(
         const yoff_adjusted: f64 = if (scroll_mods.precision)
             yoff * self.config.mouse_scroll_multiplier.precision
         else yoff_adjusted: {
-            // Round out the yoff to an absolute minimum of 1. macos tries to
-            // simulate precision scrolling with non precision events by
-            // ramping up the magnitude of the offsets as it detects faster
-            // scrolling. Single click (very slow) scrolls are reported with a
-            // magnitude of 0.1 which would normally require a few clicks
-            // before we register an actual scroll event (depending on cell
-            // height and the mouse_scroll_multiplier setting).
-            const yoff_max: f64 = if (yoff > 0)
-                @max(yoff, 1)
-            else
-                @min(yoff, -1);
+            if (comptime builtin.target.os.tag.isDarwin()) {
+                // Round out the yoff to an absolute minimum of 1. macos tries to
+                // simulate precision scrolling with non precision events by
+                // ramping up the magnitude of the offsets as it detects faster
+                // scrolling. Single click (very slow) scrolls are reported with a
+                // magnitude of 0.1 which would normally require a few clicks
+                // before we register an actual scroll event (depending on cell
+                // height and the mouse_scroll_multiplier setting).
+                const yoff_max: f64 = if (yoff > 0)
+                    @max(yoff, 1)
+                else
+                    @min(yoff, -1);
 
-            break :yoff_adjusted yoff_max * cell_size * self.config.mouse_scroll_multiplier.discrete;
+                break :yoff_adjusted yoff_max * cell_size * self.config.mouse_scroll_multiplier.discrete;
+            }
+            else {
+                break :yoff_adjusted yoff * cell_size * self.config.mouse_scroll_multiplier.discrete;
+            }
         };
 
         // Add our previously saved pending amount to the offset to get the


### PR DESCRIPTION
Enforcing an absolute minimum of 1 for scroll events causes differing scroll speeds between high-resolution and standard scroll wheels on Linux. Since this was added to handle MacOS's precision scrolling emulation, this patch alters the behaviour so that the absolute minimum is only enforced on MacOS.

NB: This can't just be fixed by adjusting `mouse-scroll-multiplier` since that affects *all* scroll events whether they're high-resolution or not. Reducing `mouse-scroll-multiplier` to handle high-res scroll events better makes scrolling unusably slow for regular scroll wheels connected to the same machine.

Fixes #11648.