### PR TITLE
fix: update Se terminfo entry to reset cursor to configured default

### DIFF
--- a/src/terminfo/ghostty.zig
+++ b/src/terminfo/ghostty.zig
@@ -112,8 +112,8 @@ pub const ghostty: Source = .{
         // Cursor styles
         .{ .name = "Ss", .value = .{ .string = "\\E[%p1%d q" } },
 
-        // Cursor style reset
-        .{ .name = "Se", .value = .{ .string = "\\E[2 q" } },
+        // Cursor style reset (to user configured default)
+        .{ .name = "Se", .value = .{ .string = "\\E[0 q" } },
 
         // OSC 52 Clipboard
         .{ .name = "Ms", .value = .{ .string = "\\E]52;%p1%s;%p2%s\\007" } },


### PR DESCRIPTION
## Problem

Current `Se` sequence (reset cursor style) is `\E[2 q`, which always sets steady block, regardless of user config.

## Solution

Update sequence to `\E[0 q`, which sets the cursor style to the user configured default cursor.

fix https://github.com/ghostty-org/ghostty/issues/12482
Helps with neovim issue: https://github.com/neovim/neovim/issues/38987

## AI Disclosure

I didn't use AI for this, haha. Unless you count random questions to learn about terminfo beforehand, but I relied on [legit resources](https://invisible-island.net/xterm/terminfo.html) for real info. It says:

>  Se resets the cursor style to the terminal power-on default.

I think the useful interpretation is to set the user configured default.