### PR TITLE
macos: add `move_tab_to_split` keybinding action

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -888,6 +888,7 @@ typedef enum {
   GHOSTTY_ACTION_NEW_TAB,
   GHOSTTY_ACTION_CLOSE_TAB,
   GHOSTTY_ACTION_NEW_SPLIT,
+  GHOSTTY_ACTION_MOVE_TAB_TO_SPLIT,
   GHOSTTY_ACTION_CLOSE_ALL_WINDOWS,
   GHOSTTY_ACTION_TOGGLE_MAXIMIZE,
   GHOSTTY_ACTION_TOGGLE_FULLSCREEN,
@@ -952,6 +953,7 @@ typedef enum {
 
 typedef union {
   ghostty_action_split_direction_e new_split;
+  ghostty_action_split_direction_e move_tab_to_split;
   ghostty_action_fullscreen_e toggle_fullscreen;
   ghostty_action_move_tab_s move_tab;
   ghostty_action_goto_tab_e goto_tab;

--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -185,6 +185,11 @@ class BaseTerminalController: NSWindowController,
             object: nil)
         center.addObserver(
             self,
+            selector: #selector(ghosttyDidMoveTabToSplit(_:)),
+            name: Ghostty.Notification.ghosttyMoveTabToSplit,
+            object: nil)
+        center.addObserver(
+            self,
             selector: #selector(ghosttyDidEqualizeSplits(_:)),
             name: Ghostty.Notification.didEqualizeSplits,
             object: nil)
@@ -614,6 +619,41 @@ class BaseTerminalController: NSWindowController,
         newSplit(at: oldView, direction: splitDirection, baseConfig: config)
     }
 
+    @objc private func ghosttyDidMoveTabToSplit(_ notification: Notification) {
+        // The source surface must be within our tree.
+        guard let sourceView = notification.object as? Ghostty.SurfaceView else { return }
+        guard surfaceTree.root?.node(view: sourceView) != nil else { return }
+
+        // Map the direction to a drop zone.
+        guard let directionAny = notification.userInfo?["direction"] else { return }
+        guard let direction = directionAny as? ghostty_action_split_direction_e else { return }
+        let zone: TerminalSplitDropZone
+        switch direction {
+        case GHOSTTY_SPLIT_DIRECTION_RIGHT: zone = .right
+        case GHOSTTY_SPLIT_DIRECTION_LEFT:  zone = .left
+        case GHOSTTY_SPLIT_DIRECTION_DOWN:  zone = .bottom
+        case GHOSTTY_SPLIT_DIRECTION_UP:    zone = .top
+        default: return
+        }
+
+        // Require a tab group with at least two tabs.
+        guard let window = self.window else { return }
+        guard let tabGroup = window.tabGroup else { return }
+        let tabbedWindows = tabGroup.windows
+        guard tabbedWindows.count > 1 else { return }
+        guard let currentIndex = tabbedWindows.firstIndex(where: { $0 == window }) else { return }
+
+        // Prefer the previous tab; fall back to the next tab.
+        let targetIndex = currentIndex > 0 ? currentIndex - 1 : currentIndex + 1
+        let targetWindow = tabbedWindows[targetIndex]
+
+        // Delegate to splitDidDrop on the target controller — the same cross-window
+        // path used by the grab-handle drag. destination: nil uses focusedSurface.
+        guard let targetController = targetWindow.windowController as? BaseTerminalController else { return }
+        targetController.splitDidDrop(source: sourceView, zone: zone)
+        targetWindow.makeKeyAndOrderFront(nil)
+    }
+
     @objc private func ghosttyDidEqualizeSplits(_ notification: Notification) {
         guard let target = notification.object as? Ghostty.SurfaceView else { return }
 
@@ -890,11 +930,17 @@ class BaseTerminalController: NSWindowController,
         }
     }
 
-    private func splitDidDrop(
+    /// Move `source` into this window's split tree beside `destination` in `zone`.
+    /// If `destination` is nil the focused surface of this controller is used.
+    /// The source may live in this tree (same-window rearrange) or in another
+    /// window's tree (cross-window/tab move).
+    func splitDidDrop(
         source: Ghostty.SurfaceView,
-        destination: Ghostty.SurfaceView,
+        destination: Ghostty.SurfaceView? = nil,
         zone: TerminalSplitDropZone
     ) {
+        guard let destination = destination ?? focusedSurface else { return }
+
         // Map drop zone to split direction
         let direction: SplitTree<Ghostty.SurfaceView>.NewDirection = switch zone {
         case .top: .up

--- a/macos/Sources/Ghostty/Ghostty.App.swift
+++ b/macos/Sources/Ghostty/Ghostty.App.swift
@@ -503,6 +503,9 @@ extension Ghostty {
             case GHOSTTY_ACTION_NEW_SPLIT:
                 newSplit(app, target: target, direction: action.action.new_split)
 
+            case GHOSTTY_ACTION_MOVE_TAB_TO_SPLIT:
+                moveTabToSplit(app, target: target, direction: action.action.move_tab_to_split)
+
             case GHOSTTY_ACTION_CLOSE_TAB:
                 closeTab(app, target: target, mode: action.action.close_tab_mode)
 
@@ -840,6 +843,32 @@ extension Ghostty {
                     object: surfaceView,
                     userInfo: [
                         Notification.NewSurfaceConfigKey: SurfaceConfiguration(from: ghostty_surface_inherited_config(surface, GHOSTTY_SURFACE_CONTEXT_TAB)),
+                    ]
+                )
+
+            default:
+                assertionFailure()
+            }
+        }
+
+        private static func moveTabToSplit(
+            _ app: ghostty_app_t,
+            target: ghostty_target_s,
+            direction: ghostty_action_split_direction_e) {
+            switch target.tag {
+            case GHOSTTY_TARGET_APP:
+                Ghostty.logger.warning("move tab to split does nothing with an app target")
+                return
+
+            case GHOSTTY_TARGET_SURFACE:
+                guard let surface = target.target.surface else { return }
+                guard let surfaceView = self.surfaceView(from: surface) else { return }
+
+                NotificationCenter.default.post(
+                    name: Ghostty.Notification.ghosttyMoveTabToSplit,
+                    object: surfaceView,
+                    userInfo: [
+                        "direction": direction,
                     ]
                 )
 

--- a/macos/Sources/Ghostty/GhosttyPackage.swift
+++ b/macos/Sources/Ghostty/GhosttyPackage.swift
@@ -386,6 +386,11 @@ extension Ghostty.Notification {
     /// userdata has one key "direction" with the direction to split to.
     static let ghosttyNewSplit = Notification.Name("com.mitchellh.ghostty.newSplit")
 
+    /// Posted when the focused surface should be moved from its current tab into an adjacent tab
+    /// as a split pane. The sending object is the source SurfaceView. userInfo key "direction"
+    /// carries the ghostty_action_split_direction_e value for the split placement in the target tab.
+    static let ghosttyMoveTabToSplit = Notification.Name("com.mitchellh.ghostty.moveTabToSplit")
+
     /// Close the calling surface.
     static let ghosttyCloseSurface = Notification.Name("com.mitchellh.ghostty.closeSurface")
 

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -5532,6 +5532,21 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
             },
         ),
 
+        .move_tab_to_split => |direction| return try self.rt_app.performAction(
+            .{ .surface = self },
+            .move_tab_to_split,
+            switch (direction) {
+                .right => .right,
+                .left => .left,
+                .down => .down,
+                .up => .up,
+                .auto => if (self.size.screen.width > self.size.screen.height)
+                    .right
+                else
+                    .down,
+            },
+        ),
+
         .goto_split => |direction| return try self.rt_app.performAction(
             .{ .surface = self },
             .goto_split,

--- a/src/apprt/action.zig
+++ b/src/apprt/action.zig
@@ -96,6 +96,11 @@ pub const Action = union(Key) {
     /// relative to the target.
     new_split: SplitDirection,
 
+    /// Move the focused surface from the current tab into an adjacent tab as
+    /// a split pane in the given direction. Previous tab is preferred; falls
+    /// back to next. No-op when only one tab exists.
+    move_tab_to_split: SplitDirection,
+
     /// Close all open windows.
     close_all_windows,
 
@@ -350,6 +355,7 @@ pub const Action = union(Key) {
         new_tab,
         close_tab,
         new_split,
+        move_tab_to_split,
         close_all_windows,
         toggle_maximize,
         toggle_fullscreen,

--- a/src/apprt/gtk/class/application.zig
+++ b/src/apprt/gtk/class/application.zig
@@ -706,6 +706,8 @@ pub const Application = extern struct {
 
             .move_tab => return Action.moveTab(target, value),
 
+            .move_tab_to_split => return Action.moveTabToSplit(target, value),
+
             .new_split => return Action.newSplit(target, value),
 
             .new_tab => return Action.newTab(target),
@@ -2185,6 +2187,19 @@ const Action = struct {
                 );
             },
         }
+    }
+
+    pub fn moveTabToSplit(
+        target: apprt.Target,
+        direction: apprt.action.SplitDirection,
+    ) bool {
+        _ = target;
+        _ = direction;
+        // TODO: implement cross-tab surface movement for GTK.
+        // This requires reparenting GTK Surface widgets across SplitTree widgets,
+        // which is non-trivial. Tracked as a follow-up.
+        log.warn("move_tab_to_split is not yet implemented on GTK", .{});
+        return false;
     }
 
     pub fn newSplit(

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -1,17 +1,19 @@
 //! A binding maps some input trigger to an action. When the trigger
 //! occurs, the action is performed.
-const Binding = @This();
-
 const std = @import("std");
 const Allocator = std.mem.Allocator;
-const assert = @import("../quirks.zig").inlineAssert;
-const build_config = @import("../build_config.zig");
+
 const uucode = @import("uucode");
+
+const build_config = @import("../build_config.zig");
 const EntryFormatter = @import("../config/formatter.zig").EntryFormatter;
 const deepEqual = @import("../datastruct/comparison.zig").deepEqual;
+const assert = @import("../quirks.zig").inlineAssert;
 const key = @import("key.zig");
-const key_mods = @import("key_mods.zig");
 const KeyEvent = key.KeyEvent;
+const key_mods = @import("key_mods.zig");
+
+const Binding = @This();
 
 /// The trigger that needs to be performed to execute the action.
 trigger: Trigger,
@@ -602,6 +604,19 @@ pub const Action = union(enum) {
     ///     then a left-right split would be created, and vice versa.
     ///
     new_split: SplitDirection,
+
+    /// Move the focused surface from the current tab into an adjacent tab as
+    /// a split pane. The argument specifies the direction of the split within
+    /// the target tab.
+    ///
+    /// The target tab is the previous tab; if no previous tab exists, the next
+    /// tab is used. If only one tab exists this action is a no-op.
+    ///
+    /// If the source tab had only one surface, it is closed after the move.
+    ///
+    /// Valid arguments: `right`, `down`, `left`, `up`
+    ///
+    move_tab_to_split: SplitDirection,
 
     /// Focus on a split either in the specified direction (`right`, `down`,
     /// `left` and `up`), or in the adjacent split in the order of creation
@@ -1384,6 +1399,7 @@ pub const Action = union(enum) {
             .move_tab,
             .toggle_tab_overview,
             .new_split,
+            .move_tab_to_split,
             .goto_split,
             .goto_window,
             .toggle_split_zoom,
@@ -3324,6 +3340,12 @@ test "parse: action with enum" {
         try testing.expect(binding.action == .new_split);
         try testing.expectEqual(Action.SplitDirection.right, binding.action.new_split);
     }
+
+    {
+        const binding = try parseSingle("a=move_tab_to_split:right");
+        try testing.expect(binding.action == .move_tab_to_split);
+        try testing.expectEqual(Action.SplitDirection.right, binding.action.move_tab_to_split);
+    }
 }
 
 test "parse: action with enum with default" {
@@ -3334,6 +3356,12 @@ test "parse: action with enum with default" {
         const binding = try parseSingle("a=new_split");
         try testing.expect(binding.action == .new_split);
         try testing.expectEqual(Action.SplitDirection.auto, binding.action.new_split);
+    }
+
+    {
+        const binding = try parseSingle("a=move_tab_to_split");
+        try testing.expect(binding.action == .move_tab_to_split);
+        try testing.expectEqual(Action.SplitDirection.auto, binding.action.move_tab_to_split);
     }
 }
 


### PR DESCRIPTION
## Summary

Adds a new bindable action `move_tab_to_split:direction` that moves the focused
surface out of its current tab and into an adjacent tab as a split pane. There
is no default keybind; users opt in via config:

```
keybind = ctrl+shift+enter = move_tab_to_split:right
```

`direction` accepts `right`, `left`, `up`, `down`, or `auto` (resolves to
`right` or `down` based on aspect ratio). The previous tab is preferred as
the destination; the next tab is used as a fallback. When only one tab is open
the action is a no-op.

## Platform support

- **macOS**: implemented. The action reuses `splitDidDrop()`, the same code path
  invoked by the grab-handle drag, so undo, cross-window surface removal, and
  focus transfer behave identically to a drag.
- **GTK**: not yet implemented (stub returns `false`).

## Changes

- `Binding.zig`, `apprt/action.zig`, `Surface.zig`, `ghostty.h`: wire the action through the full apprt stack
- `Ghostty.App.swift`, `BaseTerminalController.swift`: macOS dispatch via notification → `splitDidDrop()`
- `gtk/application.zig`: stub (not yet implemented)

## Test plan

- [ ] `zig build` succeeds
- [ ] `zig build test -Dtest-filter="parse: action with enum"` passes
- [ ] Bind `move_tab_to_split:right` in config; verify surface moves into a right split of the adjacent tab
- [ ] Verify undo (`cmd+z`) restores both tabs to their original state
- [ ] Verify action is a no-op with only one tab open
- [ ] Verify `auto` direction resolves based on surface aspect ratio
- [ ] Verify macOS grab-handle drag still works (unchanged code path)

---

> **AI disclosure:** This implementation was developed with AI assistance
> (GitHub Copilot / Claude). I have reviewed and understand all code changes in
> this PR.