### PR TITLE
macOS: enable copy only when there’s actual selected text

### DIFF
--- a/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
@@ -2121,6 +2121,14 @@ extension Ghostty.SurfaceView: NSMenuItemValidation {
             item.state = readonly ? .on : .off
             return true
 
+        case #selector(copy(_:)):
+            // We only enable copy menu item when there're actual selected text
+            if let text = self.accessibilitySelectedText(), text.count > 0 {
+                return true
+            } else {
+                return false
+            }
+
         default:
             return true
         }


### PR DESCRIPTION
This matches the `peformable` definition and the default behaviors of text editing on macOS.