### PR TITLE
macOS: fix focus state when toggling command palette from inline title editor

### DIFF
--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -1396,6 +1396,21 @@ class BaseTerminalController: NSWindowController,
 
     @IBAction func toggleCommandPalette(_ sender: Any?) {
         commandPaletteIsShowing.toggle()
+        if commandPaletteIsShowing {
+            // Fix the incorrect focus when toggling from InlineTitleEditor
+            // When toggling the command palette from the inline title editor,
+            // the first responder state of the surface is changed quickly from true to false.
+
+            // `makeFirstResponder:` is called by the title editor when finishing,
+            // but it happens **after** the command palette is shown,
+            // so the `focused` is set to `true` while the command palette is shown.
+            // (Could be an AppKit issue as well, since the resign is not called after but the command palette is receiving `keyDown`).
+
+            // Since `performKeyEquivalent(with:)` is called on all of the subviews
+            // until one of the return `true` so the paste action is consumed by the surface
+            // instead of the first responder (command palette).
+            _ = focusedSurface?.resignFirstResponder()
+        }
     }
 
     @IBAction func find(_ sender: Any) {


### PR DESCRIPTION
A bug found while recording that menu fix.
> ~~Will link to an open issue if there is one.~~

When toggling the command palette from the inline title editor, the first responder state of the surface is changed quickly from true to false.

`makeFirstResponder:` is called by the title editor when finishing, but it happens **after** the command palette is shown, so the `focused` is set to `true` while the command palette is shown. (Could be an AppKit issue as well, since the resign is not called after but the command palette is receiving `keyDown`.)

Since `performKeyEquivalent(with:)` is called on all of the subviews until one of the return `true` so the paste action is consumed by the surface instead of the first responder (command palette).