### PR TITLE
Fall back to Zig-bundled Darwin headers when an SDK can't be found

### DIFF
--- a/pkg/apple-sdk/build.zig
+++ b/pkg/apple-sdk/build.zig
@@ -49,15 +49,15 @@ pub fn addPaths(
     });
 
     if (!gop.found_existing) init: {
-        if (comptime builtin.os.tag.isDarwin()) {
+        if (comptime builtin.os.tag.isDarwin()) darwin: {
             // Detect our SDK using the "findNative" Zig stdlib function.
             // This is really important because it forces using `xcrun` to
             // find the SDK path.
-            const libc = try std.zig.LibCInstallation.findNative(.{
+            const libc = std.zig.LibCInstallation.findNative(.{
                 .allocator = b.allocator,
                 .target = &step.rootModuleTarget(),
                 .verbose = false,
-            });
+            }) catch break :darwin;
 
             // Render the file compatible with the `--libc` Zig flag.
             var stream: std.io.Writer.Allocating = .init(b.allocator);


### PR DESCRIPTION
Currently, cross to Darwin uses the Darwin headers bundled with Zig. However, if you're running a build _on_ Darwin, an error is thrown if the SDK can't be found, even though the bundled headers are still available.

Now, we continue to search for and prefer the installed SDK, but if it can't be found, we fall back to the bundled headers rather than failing the build.