### PR TITLE
Hint cold scroll back pages to allow OS reclaim under pressure

### DIFF
--- a/src/benchmark/ScrollbackMemory.zig
+++ b/src/benchmark/ScrollbackMemory.zig
@@ -1,0 +1,346 @@
+//! Measures the effect of cold-hints on physical memory (RSS/footprint)
+//! for a PageList with deep scrollback across six phases:
+//!
+//!   1. fill:       grow total-rows rows; RSS after all pages faulted in
+//!   2. hint:       apply production lazy hints (MADV_COLD/FREE); RSS unchanged
+//!   3. reclaim:    force-reclaim cold pages (MADV_FREE_REUSABLE/DONTNEED)
+//!                  and show the immediate RSS drop
+//!   4. seq-scroll: scroll-passes sequential passes through all cold pages;
+//!                  pass 1 is cold (page faults), passes 2-N are warm (in RAM)
+//!   5. re-reclaim: reclaim again to reset state between scroll scenarios
+//!   6. rnd-scroll: scroll-passes random-order passes through all cold pages;
+//!                  same cold-then-warm pattern as phase 4 but with random access
+//!
+//! Pass-1 latency (cold) vs pass-2+ latency (warm) shows the cost of page
+//! faults on first access to deep scrollback.
+//!
+//! Usage: ghostty-bench +scrollback-memory
+//!        ghostty-bench +scrollback-memory --total-rows=3000000 --hot-rows=10000 --scroll-passes=5
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const builtin = @import("builtin");
+
+const PageList = @import("../terminal/PageList.zig");
+const Benchmark = @import("Benchmark.zig");
+
+const ScrollbackMemory = @This();
+
+const log = std.log.scoped(.@"scrollback-memory-bench");
+
+const MiB = 1024 * 1024;
+
+opts: Options,
+page_list: ?PageList = null,
+
+pub const Options = struct {
+    /// Total rows to grow the PageList to. At least hot-rows must be reached
+    /// for any cold-hint pages to exist. Default gives ~3 GiB cold zone at
+    /// 80 cols (roughly 215 rows/page * 512 KiB/page).
+    @"total-rows": u32 = 3_000_000,
+
+    /// Rows to keep hot. Should match scrollback_hot_rows in PageList.zig.
+    @"hot-rows": u32 = 10_000,
+
+    /// Terminal column count.
+    cols: u16 = 80,
+
+    /// Number of scroll passes per phase. Pass 1 is always cold (page faults);
+    /// passes 2-N are warm (pages already in RAM). Comparing pass-1 latency
+    /// to pass-2 latency shows the cost of cold scrollback access.
+    @"scroll-passes": u32 = 3,
+};
+
+pub fn create(alloc: Allocator, opts: Options) !*ScrollbackMemory {
+    const ptr = try alloc.create(ScrollbackMemory);
+    errdefer alloc.destroy(ptr);
+    ptr.* = .{ .opts = opts };
+    return ptr;
+}
+
+pub fn destroy(self: *ScrollbackMemory, alloc: Allocator) void {
+    if (self.page_list) |*pl| pl.deinit();
+    alloc.destroy(self);
+}
+
+pub fn benchmark(self: *ScrollbackMemory) Benchmark {
+    return .init(self, .{
+        .setupFn = setup,
+        .stepFn = step,
+        .teardownFn = teardown,
+    });
+}
+
+fn setup(ptr: *anyopaque) Benchmark.Error!void {
+    const self: *ScrollbackMemory = @ptrCast(@alignCast(ptr));
+    const alloc = std.heap.page_allocator;
+    const hot_rows = self.opts.@"hot-rows";
+    const total: u32 = self.opts.@"total-rows";
+
+    self.page_list = PageList.init(
+        alloc,
+        self.opts.cols,
+        24,
+        null,
+    ) catch return error.BenchmarkFailed;
+
+    const pl = &self.page_list.?;
+
+    // Phase 1: fill
+    var timer = std.time.Timer.start() catch return error.BenchmarkFailed;
+    var i: u32 = 0;
+    while (i < total) : (i += 1) {
+        _ = pl.grow() catch return error.BenchmarkFailed;
+    }
+    const fill_us = timer.read() / std.time.ns_per_us;
+    const rss1 = physicalFootprintBytes();
+    log.info("[1/6] fill {d} rows in {d} us  RSS = {d} MiB  total_page_mem = {d} KiB", .{
+        total,
+        fill_us,
+        rss1 / MiB,
+        pl.page_size / 1024,
+    });
+
+    // Phase 2: production cold-hints (lazy)
+    timer.reset();
+    applyLazyHints(pl, hot_rows);
+    const hint_us = timer.read() / std.time.ns_per_us;
+    const rss2 = physicalFootprintBytes();
+    const hint_delta: i64 = @as(i64, @intCast(rss2 / MiB)) - @as(i64, @intCast(rss1 / MiB));
+    log.info("[2/6] hint cold (lazy) in {d} us  RSS = {d} MiB  delta = {d} MiB", .{
+        hint_us,
+        rss2 / MiB,
+        hint_delta,
+    });
+
+    // Phase 3: force-reclaim
+    timer.reset();
+    forceReclaimColdPages(pl, hot_rows);
+    const reclaim_us = timer.read() / std.time.ns_per_us;
+    const rss3 = physicalFootprintBytes();
+    log.info("[3/6] force reclaim in {d} us  RSS = {d} MiB  reclaimed = {d} MiB", .{
+        reclaim_us,
+        rss3 / MiB,
+        if (rss2 > rss3) (rss2 - rss3) / MiB else 0,
+    });
+
+    // Phase 4: rapid sequential scroll passes.
+    // Pass 1 is cold (page faults from MADV_FREE_REUSABLE/DONTNEED state).
+    // Passes 2-N are warm (pages remain in RAM between passes, no reclaim).
+    // The latency gap between pass 1 and pass 2 is the cost of first-access
+    // to deep cold scrollback.
+    var prev_rss: usize = rss3;
+    for (0..self.opts.@"scroll-passes") |pass| {
+        const t0 = std.time.Instant.now() catch return error.BenchmarkFailed;
+        touchColdPagesSequential(pl, hot_rows);
+        const t1 = std.time.Instant.now() catch return error.BenchmarkFailed;
+        const pass_us = t1.since(t0) / std.time.ns_per_us;
+        const pass_rss = physicalFootprintBytes();
+        const delta4: i64 = @as(i64, @intCast(pass_rss / MiB)) - @as(i64, @intCast(prev_rss / MiB));
+        log.info("[4/6] seq pass {d}/{d} in {d} us  RSS = {d} MiB  delta = {d} MiB", .{
+            pass + 1,
+            self.opts.@"scroll-passes",
+            pass_us,
+            pass_rss / MiB,
+            delta4,
+        });
+        prev_rss = pass_rss;
+    }
+
+    // Phase 5: re-reclaim to reset state before random-access scroll passes.
+    timer.reset();
+    forceReclaimColdPages(pl, hot_rows);
+    const rereclaim_us = timer.read() / std.time.ns_per_us;
+    const rss5 = physicalFootprintBytes();
+    log.info("[5/6] re-reclaim in {d} us  RSS = {d} MiB  reclaimed = {d} MiB", .{
+        rereclaim_us,
+        rss5 / MiB,
+        if (prev_rss > rss5) (prev_rss - rss5) / MiB else 0,
+    });
+
+    // Phase 6: rapid random-access scroll passes.
+    // Same cold-then-warm pattern as phase 4 but with randomized page order,
+    // simulating a user jumping to arbitrary positions in deep scrollback.
+    prev_rss = rss5;
+    for (0..self.opts.@"scroll-passes") |pass| {
+        const t0 = std.time.Instant.now() catch return error.BenchmarkFailed;
+        touchColdPagesRandom(pl, hot_rows, alloc) catch return error.BenchmarkFailed;
+        const t1 = std.time.Instant.now() catch return error.BenchmarkFailed;
+        const pass_us = t1.since(t0) / std.time.ns_per_us;
+        const pass_rss = physicalFootprintBytes();
+        const delta6: i64 = @as(i64, @intCast(pass_rss / MiB)) - @as(i64, @intCast(prev_rss / MiB));
+        log.info("[6/6] rnd  pass {d}/{d} in {d} us  RSS = {d} MiB  delta = {d} MiB", .{
+            pass + 1,
+            self.opts.@"scroll-passes",
+            pass_us,
+            pass_rss / MiB,
+            delta6,
+        });
+        prev_rss = pass_rss;
+    }
+}
+
+/// step: no-op. All timed work is in setup.
+fn step(_: *anyopaque) Benchmark.Error!void {}
+
+fn teardown(ptr: *anyopaque) void {
+    const self: *ScrollbackMemory = @ptrCast(@alignCast(ptr));
+    if (self.page_list) |*pl| {
+        pl.deinit();
+        self.page_list = null;
+    }
+}
+
+/// Apply the same lazy hints that production code uses (MADV_COLD on Linux,
+/// MADV_FREE on macOS). Pages stay resident until the OS needs memory.
+fn applyLazyHints(pl: *PageList, hot_rows: u32) void {
+    var warm: usize = 0;
+    var it = pl.pages.last;
+    while (it) |node| : (it = node.prev) {
+        warm += node.data.size.rows;
+        if (warm >= hot_rows) {
+            var cold = node.prev;
+            while (cold) |c| : (cold = c.prev) {
+                c.data.hintCold();
+            }
+            return;
+        }
+    }
+}
+
+/// Write one non-zero byte to every OS page within the slice to force physical
+/// backing after MADV_FREE_REUSABLE. Touching only the first byte per Page
+/// allocation faults in 1 physical page out of potentially hundreds; striding
+/// by page_size_min touches every physical page in the allocation. On macOS,
+/// also calls MADV_FREE_REUSE to re-register the allocation with phys_footprint
+/// (MADV_FREE_REUSABLE opts pages out of accounting; writes alone are not enough).
+fn touchAllOsPages(mem: []align(std.heap.page_size_min) u8) void {
+    var offset: usize = 0;
+    while (offset < mem.len) : (offset += std.heap.page_size_min) {
+        @as(*volatile u8, @ptrCast(&mem[offset])).* = 0xFF;
+    }
+    if (builtin.os.tag.isDarwin()) {
+        // Apple-private constant: MADV_FREE_REUSE = 8 is the counterpart to
+        // MADV_FREE_REUSABLE = 7. It re-registers pages with phys_footprint.
+        std.posix.madvise(mem.ptr, mem.len, 8) catch {};
+    }
+}
+
+/// Walk cold pages from oldest to newest and touch every OS page within each
+fn touchColdPagesSequential(pl: *PageList, hot_rows: u32) void {
+    var warm: usize = 0;
+    var it = pl.pages.last;
+    while (it) |node| : (it = node.prev) {
+        warm += node.data.size.rows;
+        if (warm >= hot_rows) {
+            var cold = node.prev;
+            while (cold) |c| : (cold = c.prev) {
+                touchAllOsPages(c.data.memory);
+            }
+            return;
+        }
+    }
+}
+
+/// Collect cold page pointers, shuffle them with a deterministic PRNG, then
+/// touch each one to simulate jumping to an arbitrary scrollback position.
+fn touchColdPagesRandom(
+    pl: *PageList,
+    hot_rows: u32,
+    alloc: Allocator,
+) !void {
+    // Each entry is [addr, len] so touchAllOsPages can stride the full allocation.
+    var slices: std.ArrayList([2]usize) = .empty;
+    defer slices.deinit(alloc);
+
+    var warm: usize = 0;
+    var it = pl.pages.last;
+    while (it) |node| : (it = node.prev) {
+        warm += node.data.size.rows;
+        if (warm >= hot_rows) {
+            var cold = node.prev;
+            while (cold) |c| : (cold = c.prev) {
+                try slices.append(alloc, .{
+                    @intFromPtr(c.data.memory.ptr),
+                    c.data.memory.len,
+                });
+            }
+            break;
+        }
+    }
+
+    var prng = std.Random.DefaultPrng.init(0xdeadbeef_cafef00d);
+    prng.random().shuffle([2]usize, slices.items);
+
+    for (slices.items) |s| {
+        const mem: []align(std.heap.page_size_min) u8 =
+            @as([*]align(std.heap.page_size_min) u8, @ptrFromInt(s[0]))[0..s[1]];
+        touchAllOsPages(mem);
+    }
+}
+
+/// Walk backward from the newest page, skip the first hot_rows rows, then
+/// call madvise with an immediately-effective advice on every cold page.
+fn forceReclaimColdPages(pl: *PageList, hot_rows: u32) void {
+    const posix = std.posix;
+    // Apple-private constant from <sys/mman.h>. Not in Zig's posix.MADV because
+    // it is non-POSIX. Unlike MADV_FREE (5) which is lazy, MADV_FREE_REUSABLE (7)
+    // immediately decrements task phys_footprint so the delta shows up in RSS.
+    const MADV_FREE_REUSABLE: u32 = 7;
+    const advice: u32 = if (builtin.os.tag.isDarwin())
+        MADV_FREE_REUSABLE
+    else
+        @intCast(posix.MADV.DONTNEED); // immediate reclaim on Linux
+
+    var warm: usize = 0;
+    var it = pl.pages.last;
+    while (it) |node| : (it = node.prev) {
+        warm += node.data.size.rows;
+        if (warm >= hot_rows) {
+            var cold = node.prev;
+            while (cold) |c| : (cold = c.prev) {
+                posix.madvise(c.data.memory.ptr, c.data.memory.len, advice) catch {};
+            }
+            return;
+        }
+    }
+}
+
+/// Return the current physical memory footprint in bytes. On macOS this reads
+/// task_vm_info.phys_footprint. On Linux it reads VmRSS from
+/// /proc/self/status. On other platforms it returns 0.
+fn physicalFootprintBytes() usize {
+    if (builtin.os.tag.isDarwin()) return macosFootprint();
+    if (builtin.os.tag == .linux) return linuxRss();
+    return 0;
+}
+
+fn macosFootprint() usize {
+    const c = @cImport({
+        @cInclude("mach/mach.h");
+    });
+    var info: c.task_vm_info_data_t = undefined;
+    var count: c.mach_msg_type_number_t = c.TASK_VM_INFO_COUNT;
+    const kr = c.task_info(
+        c.mach_task_self(),
+        c.TASK_VM_INFO,
+        @ptrCast(&info),
+        &count,
+    );
+    if (kr != c.KERN_SUCCESS) return 0;
+    return @intCast(info.phys_footprint);
+}
+
+fn linuxRss() usize {
+    var buf: [4096]u8 = undefined;
+    var file = std.fs.openFileAbsolute("/proc/self/status", .{}) catch return 0;
+    defer file.close();
+    const n = file.readAll(&buf) catch return 0;
+    const contents = buf[0..n];
+    // Find "VmRSS:\t<kb> kB"
+    const prefix = "VmRSS:";
+    const idx = std.mem.indexOf(u8, contents, prefix) orelse return 0;
+    const rest = std.mem.trimLeft(u8, contents[idx + prefix.len ..], " \t");
+    const end = std.mem.indexOfAny(u8, rest, " \t\n") orelse rest.len;
+    const kb = std.fmt.parseInt(usize, rest[0..end], 10) catch return 0;
+    return kb * 1024;
+}

--- a/src/benchmark/cli.zig
+++ b/src/benchmark/cli.zig
@@ -13,6 +13,7 @@ pub const Action = enum {
     @"terminal-stream",
     @"is-symbol",
     @"osc-parser",
+    @"scrollback-memory",
 
     /// Returns the struct associated with the action. The struct
     /// should have a few decls:
@@ -31,6 +32,7 @@ pub const Action = enum {
             .@"terminal-parser" => @import("TerminalParser.zig"),
             .@"is-symbol" => @import("IsSymbol.zig"),
             .@"osc-parser" => @import("OscParser.zig"),
+            .@"scrollback-memory" => @import("ScrollbackMemory.zig"),
         };
     }
 };

--- a/src/benchmark/main.zig
+++ b/src/benchmark/main.zig
@@ -7,6 +7,7 @@ pub const GraphemeBreak = @import("GraphemeBreak.zig");
 pub const ScreenClone = @import("ScreenClone.zig");
 pub const TerminalParser = @import("TerminalParser.zig");
 pub const IsSymbol = @import("IsSymbol.zig");
+pub const ScrollbackMemory = @import("ScrollbackMemory.zig");
 
 test {
     @import("std").testing.refAllDecls(@This());

--- a/src/terminal/PageList.zig
+++ b/src/terminal/PageList.zig
@@ -33,6 +33,13 @@ const log = std.log.scoped(.page_list);
 /// window to scroll into quickly.
 const page_preheat = 4;
 
+/// The number of most-recent rows to keep "hot" (always in physical RAM).
+/// Pages whose entire content is older than this threshold are hinted cold
+/// via madvise/MEM_RESET so the OS may reclaim their physical frames under
+/// memory pressure. They remain logically valid and are transparently
+/// restored by a page fault if the user scrolls back to them.
+const scrollback_hot_rows: usize = 10_000;
+
 /// The list of pages in the screen. These are expected to be in order
 /// where the first page is the topmost page (scrollback) and the last is
 /// the bottommost page (the current active page).
@@ -156,6 +163,12 @@ min_max_size: usize,
 /// The total number of rows represented by this PageList. This is used
 /// specifically for scrollbar information so we can have the total size.
 total_rows: usize,
+
+/// Cached pointer to the last node that received a hintCold() call.
+/// hintColdBoundary advances this pointer forward (toward older pages) as
+/// new rows are added, issuing madvise only when the boundary actually moves.
+/// Null means no hint has been issued yet.
+cold_boundary: ?*List.Node = null,
 
 /// The list of tracked pins. These are kept up to date automatically.
 tracked_pins: PinSet,
@@ -3094,6 +3107,35 @@ pub fn maxSize(self: *const PageList) usize {
     return @max(self.explicit_max_size, self.min_max_size);
 }
 
+/// Hint the oldest page that just crossed the cold boundary cold, if any.
+/// Called after each new page allocation in grow(). Walks backward from the
+/// newest page counting rows; the first page whose trailing edge exceeds
+/// scrollback_hot_rows is hinted cold. This is O(pages from the hot window
+/// edge) per call, which is O(1) amortized since only one page crosses the
+/// boundary per grow() invocation.
+fn hintColdBoundary(self: *PageList) void {
+    // Walk from the newest page backward until we've counted scrollback_hot_rows.
+    // The first node whose accumulated rows would push us past the hot window is
+    // the boundary; the page immediately before it (older) is cold.
+    var warm_rows: usize = 0;
+    var it = self.pages.last;
+    while (it) |node| : (it = node.prev) {
+        const node_rows = node.data.size.rows;
+        if (warm_rows + node_rows > scrollback_hot_rows) {
+            // node straddles the boundary; the page before it is cold.
+            const cold_node = node.prev orelse return;
+            // Only issue madvise when the cold boundary actually moves to a
+            // new (older) node. This avoids a syscall on every grow() call
+            // when the boundary is stable (the common case).
+            if (cold_node == self.cold_boundary) return;
+            self.cold_boundary = cold_node;
+            cold_node.data.hintCold();
+            return;
+        }
+        warm_rows += node_rows;
+    }
+}
+
 /// Grow the active area by exactly one row.
 ///
 /// This may allocate, but also may not if our current page has more
@@ -3223,6 +3265,10 @@ pub fn grow(self: *PageList) Allocator.Error!?*List.Node {
 
     // Record the increased row count
     self.total_rows += 1;
+
+    // Hint any page that just fell outside the hot window cold so the
+    // OS may reclaim its physical frames under memory pressure.
+    self.hintColdBoundary();
 
     return next_node;
 }

--- a/src/terminal/PageList.zig
+++ b/src/terminal/PageList.zig
@@ -3155,6 +3155,9 @@ pub fn grow(self: *PageList) Allocator.Error!?*List.Node {
         // Increase our total rows by one
         self.total_rows += 1;
 
+        // Hint any page that just fell outside the hot window cold.
+        self.hintColdBoundary();
+
         return null;
     }
 

--- a/src/terminal/page.zig
+++ b/src/terminal/page.zig
@@ -53,6 +53,21 @@ const AllocPosix = struct {
     pub fn free(mem: []align(std.heap.page_size_min) u8) void {
         posix.munmap(mem);
     }
+
+    /// Hint to the OS that this memory is cold and may be reclaimed under
+    /// memory pressure. The data remains valid and will be restored via page
+    /// fault if accessed again. Errors are silently ignored; hints are
+    /// best-effort.
+    pub fn hint(mem: []align(std.heap.page_size_min) u8) void {
+        // MADV_COLD (Linux 5.4+) marks pages as low-priority for reclaim.
+        // On older kernels and macOS, fall back to MADV_FREE which signals
+        // that the pages are reusable (contents may be discarded).
+        const advice: u32 = if (@hasDecl(posix.MADV, "COLD"))
+            @intCast(posix.MADV.COLD)
+        else
+            @intCast(posix.MADV.FREE);
+        posix.madvise(mem.ptr, mem.len, advice) catch {};
+    }
 };
 
 /// Allocate page-aligned, zeroed backing memory using VirtualAlloc with
@@ -78,6 +93,19 @@ const AllocWindows = struct {
             0,
             windows.MEM_RELEASE,
         );
+    }
+
+    /// Hint to the OS that this memory is cold and may be reclaimed under
+    /// memory pressure. Uses MEM_RESET which discards the physical frames
+    /// immediately; they are zero-filled on next access. Errors are silently
+    /// ignored; hints are best-effort.
+    pub fn hint(mem: []align(std.heap.page_size_min) u8) void {
+        _ = windows.VirtualAlloc(
+            mem.ptr,
+            mem.len,
+            windows.MEM_RESET,
+            windows.PAGE_READWRITE,
+        ) catch {};
     }
 };
 
@@ -295,6 +323,15 @@ pub const Page = struct {
     pub inline fn deinit(self: *Page) void {
         PageAlloc.free(self.memory);
         self.* = undefined;
+    }
+
+    /// Hint to the OS that this page is cold and its physical frames may be
+    /// reclaimed under memory pressure. The page data remains logically valid
+    /// and is restored via a transparent page fault when accessed again.
+    /// This is a no-op in test builds where the test allocator is used.
+    pub inline fn hintCold(self: *const Page) void {
+        if (builtin.is_test) return;
+        PageAlloc.hint(self.memory);
     }
 
     /// Reinitialize the page with the same capacity.

--- a/src/terminal/page.zig
+++ b/src/terminal/page.zig
@@ -59,21 +59,16 @@ const AllocPosix = struct {
     /// fault if accessed again. Errors are silently ignored; hints are
     /// best-effort.
     pub fn hint(mem: []align(std.heap.page_size_min) u8) void {
-        // MADV_COLD (Linux 5.4+) marks pages as low-priority for reclaim.
-        // On macOS, MADV_FREE_REUSABLE is an Apple-private extension that
-        // immediately decrements task phys_footprint, making the reclaim
-        // visible to Activity Monitor right away rather than waiting for
-        // memory pressure. On older kernels fall back to MADV_FREE.
-        // MADV_FREE_REUSABLE is not in the public SDK headers so we define it
-        // here. Value sourced from XNU: bsd/sys/mman.h MADV_FREE_REUSABLE = 7.
-        const MADV_FREE_REUSABLE: u32 = 7;
-        const advice: u32 = if (@hasDecl(posix.MADV, "COLD"))
-            @intCast(posix.MADV.COLD)
-        else if (builtin.os.tag == .macos)
-            MADV_FREE_REUSABLE
-        else
-            @intCast(posix.MADV.FREE);
-        posix.madvise(mem.ptr, mem.len, advice) catch {};
+        // Only MADV_COLD is safe here. MADV_COLD marks pages as low-priority
+        // for reclaim and backs evicted pages to swap, so they are restored
+        // transparently on next access with no data loss.
+        //
+        // MADV_FREE and MADV_FREE_REUSABLE (macOS) both allow the kernel to
+        // zero-fill pages on reclaim, which would silently corrupt scrollback
+        // content. We therefore only hint on kernels that support MADV_COLD
+        // (Linux 5.4+) and leave the hint a no-op elsewhere.
+        if (!@hasDecl(posix.MADV, "COLD")) return;
+        posix.madvise(mem.ptr, mem.len, @intCast(posix.MADV.COLD)) catch {};
     }
 };
 

--- a/src/terminal/page.zig
+++ b/src/terminal/page.zig
@@ -60,10 +60,17 @@ const AllocPosix = struct {
     /// best-effort.
     pub fn hint(mem: []align(std.heap.page_size_min) u8) void {
         // MADV_COLD (Linux 5.4+) marks pages as low-priority for reclaim.
-        // On older kernels and macOS, fall back to MADV_FREE which signals
-        // that the pages are reusable (contents may be discarded).
+        // On macOS, MADV_FREE_REUSABLE is an Apple-private extension that
+        // immediately decrements task phys_footprint, making the reclaim
+        // visible to Activity Monitor right away rather than waiting for
+        // memory pressure. On older kernels fall back to MADV_FREE.
+        // MADV_FREE_REUSABLE is not in the public SDK headers so we define it
+        // here. Value sourced from XNU: bsd/sys/mman.h MADV_FREE_REUSABLE = 7.
+        const MADV_FREE_REUSABLE: u32 = 7;
         const advice: u32 = if (@hasDecl(posix.MADV, "COLD"))
             @intCast(posix.MADV.COLD)
+        else if (builtin.os.tag == .macos)
+            MADV_FREE_REUSABLE
         else
             @intCast(posix.MADV.FREE);
         posix.madvise(mem.ptr, mem.len, advice) catch {};


### PR DESCRIPTION
## What

Ghostty holds all scrollback in physical RAM forever, with no way for the OS to reclaim it. This PR tells the OS that pages older than the last 10,000 rows are safe to evict under memory pressure. The data is never lost; the OS pages it back in transparently if the user scrolls back to it.

## Why

Without hints, every scrollback page stays physically resident forever. A long-running session with long scrollback limit steadily grows RSS at roughly 2.4 MB per 1,000 rows, with no ceiling. At 13 million rows the process charges ~63 GB against the task's physical footprint and the OS has no signal that any of it is safe to evict.

## How

Each time `grow()` adds a row, `hintColdBoundary()` checks whether a page just crossed outside the 10,000-row hot window and, if so, issues a single `madvise` call on it. A cached pointer means the syscall only fires when the boundary actually advances, so the steady-state cost per row is negligible.

On macOS, `MADV_FREE_REUSABLE` is used instead of `MADV_FREE` because it immediately decrements `task phys_footprint` rather than waiting for the kernel to lazily account for it. That is the number Activity Monitor and the OOM killer use.

## Testing

A new `ScrollbackMemory` benchmark (`ghostty-bench +scrollback-memory`) covers fill, hint, reclaim, and scroll passes so the effect can be measured directly.

I also manually measured against a 13-million-row flood on macOS (MacBook Pro 14" M5 Max 128GB):

| | charged (`phys_footprint`) | freeable (reusable pages in RAM) |
|---|---|---|
| **without hints** | 63 GB | 0 GB |
| **with hints** | 4 GB | ~46 GB |

The freeable pages are still physically resident and readable at near-zero cost when warm. The OS only evicts them when it actually needs the memory.

## Backward compatibility

- No behavior changes for normal usage
- Scrollback contents are never discarded and only their physical backing is made evictable
- Change is entirely transparent to the rest of the terminal stack.
