### PR TITLE
MacOS: add terminal default restore action

### DIFF
--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -65,6 +65,7 @@ class AppDelegate: NSObject,
     @IBOutlet private var menuFloatOnTop: NSMenuItem?
     @IBOutlet private var menuUseAsDefault: NSMenuItem?
     @IBOutlet private var menuSetAsDefaultTerminal: NSMenuItem?
+    @IBOutlet private var menuRestoreMacOSTerminalAsDefault: NSMenuItem?
 
     @IBOutlet private var menuIncreaseFontSize: NSMenuItem?
     @IBOutlet private var menuDecreaseFontSize: NSMenuItem?
@@ -1123,6 +1124,7 @@ extension AppDelegate {
         self.menuTerminalInspector?.setImageIfDesired(systemSymbolName: "scope")
         self.menuReadonly?.setImageIfDesired(systemSymbolName: "eye.fill")
         self.menuSetAsDefaultTerminal?.setImageIfDesired(systemSymbolName: "star.fill")
+        self.menuRestoreMacOSTerminalAsDefault?.setImageIfDesired(systemSymbolName: "arrow.uturn.backward.circle")
         self.menuToggleFullScreen?.setImageIfDesired(systemSymbolName: "square.arrowtriangle.4.outward")
         self.menuToggleVisibility?.setImageIfDesired(systemSymbolName: "eye")
         self.menuZoomSplit?.setImageIfDesired(systemSymbolName: "arrow.up.left.and.arrow.down.right")
@@ -1267,6 +1269,34 @@ extension AppDelegate {
             }
         }
     }
+
+    @IBAction func restoreMacOSTerminalAsDefault(_ sender: NSMenuItem) {
+        guard let terminalURL = NSWorkspace.shared.macOSTerminal else {
+            let alert = NSAlert()
+            alert.messageText = "Failed to Restore Default Terminal"
+            alert.informativeText = """
+            macOS Terminal could not be found on this system.
+            """
+            alert.alertStyle = .warning
+            alert.runModal()
+            return
+        }
+
+        NSWorkspace.shared.setDefaultApplication(at: terminalURL, toOpen: .unixExecutable) { error in
+            guard let error else { return }
+            Task { @MainActor in
+                let alert = NSAlert()
+                alert.messageText = "Failed to Restore Default Terminal"
+                alert.informativeText = """
+                macOS Terminal could not be restored as the default terminal application.
+
+                Error: \(error.localizedDescription)
+                """
+                alert.alertStyle = .warning
+                alert.runModal()
+            }
+        }
+    }
 }
 
 // MARK: NSMenuItemValidation
@@ -1275,7 +1305,11 @@ extension AppDelegate: NSMenuItemValidation {
     func validateMenuItem(_ item: NSMenuItem) -> Bool {
         switch item.action {
         case #selector(setAsDefaultTerminal(_:)):
-            return NSWorkspace.shared.defaultTerminal != Bundle.main.bundleURL
+            return !NSWorkspace.shared.isGhosttyDefaultTerminal
+
+        case #selector(restoreMacOSTerminalAsDefault(_:)):
+            return NSWorkspace.shared.macOSTerminal != nil &&
+                !NSWorkspace.shared.isMacOSTerminalDefaultTerminal
 
         case #selector(floatOnTop(_:)),
             #selector(useAsDefault(_:)):

--- a/macos/Sources/App/macOS/MainMenu.xib
+++ b/macos/Sources/App/macOS/MainMenu.xib
@@ -60,6 +60,7 @@
                 <outlet property="menuSelectSplitLeft" destination="cTK-oy-KuV" id="Jpr-5q-dqz"/>
                 <outlet property="menuSelectSplitRight" destination="upj-mc-L7X" id="nLY-o1-lky"/>
                 <outlet property="menuSelectionForFind" destination="TDN-42-Bu7" id="zya-wG-CDo"/>
+                <outlet property="menuRestoreMacOSTerminalAsDefault" destination="6JX-8T-4ae" id="NVp-lL-RvJ"/>
                 <outlet property="menuServices" destination="aQe-vS-j8Q" id="uWQ-Wo-T1L"/>
                 <outlet property="menuSetAsDefaultTerminal" destination="b1t-oB-7MI" id="6Eu-5G-OPo"/>
                 <outlet property="menuSplitDown" destination="UDZ-4y-6xL" id="ptr-mj-Azh"/>
@@ -115,6 +116,12 @@
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="setAsDefaultTerminal:" target="bbz-4X-AYv" id="QHh-CA-Qho"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Restore macOS Terminal as Default" id="6JX-8T-4ae" userLabel="Restore macOS Terminal as Default">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="restoreMacOSTerminalAsDefault:" target="bbz-4X-AYv" id="z6S-0K-iJ9"/>
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="4je-JR-u6R"/>

--- a/macos/Sources/Helpers/Extensions/NSWorkspace+Extension.swift
+++ b/macos/Sources/Helpers/Extensions/NSWorkspace+Extension.swift
@@ -2,6 +2,8 @@ import AppKit
 import UniformTypeIdentifiers
 
 extension NSWorkspace {
+    private static let macOSTerminalBundleIdentifier = "com.apple.Terminal"
+
     /// Returns the URL of the default text editor application.
     /// - Returns: The URL of the default text editor, or nil if no default text editor is found.
     var defaultTextEditor: URL? {
@@ -12,6 +14,21 @@ extension NSWorkspace {
     /// - Returns: The URL of the default terminal, or nil if no default terminal is found.
     var defaultTerminal: URL? {
         defaultApplicationURL(forContentType: UTType.unixExecutable.identifier)
+    }
+
+    /// Returns the URL of the macOS Terminal application.
+    var macOSTerminal: URL? {
+        urlForApplication(withBundleIdentifier: Self.macOSTerminalBundleIdentifier)
+    }
+
+    /// Returns true when Ghostty is the default terminal application.
+    var isGhosttyDefaultTerminal: Bool {
+        defaultTerminal == Bundle.main.bundleURL
+    }
+
+    /// Returns true when macOS Terminal is the default terminal application.
+    var isMacOSTerminalDefaultTerminal: Bool {
+        defaultTerminal == macOSTerminal
     }
 
     /// Returns the URL of the default application for opening files with the specified content type.


### PR DESCRIPTION
  ## Summary

  Add a macOS-only menu action to restore Terminal.app as the default
  terminal application.

  ## Changes

  - add `Restore macOS Terminal as Default` to the macOS app menu
  - restore the default terminal handler to `com.apple.Terminal`
  - add `NSWorkspace` helpers for resolving Terminal.app and checking the
    current default terminal
  - disable each default-terminal menu action when it already matches the
    current system state
  - disable the restore action if Terminal.app cannot be found

  ## Context

  PR #10810 added `Make Ghostty the Default Terminal` on macOS, but there
  was no matching way to switch back from the menu. This change adds the
  reverse path a