### PR TITLE
feat(splits): add auto-equalize-splits config option

### DIFF
--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -260,8 +260,12 @@ class BaseTerminalController: NSWindowController,
             return nil
         }
 
+        // If auto-equalize-splits is enabled, equalize the new tree before
+        // committing it so all splits in the window become evenly sized.
+        let finalTree = derivedConfig.autoEqualizeSplits ? newTree.equalized() : newTree
+
         replaceSurfaceTree(
-            newTree,
+            finalTree,
             moveFocusTo: newView,
             moveFocusFrom: oldView,
             undoAction: "New Split")
@@ -456,8 +460,13 @@ class BaseTerminalController: NSWindowController,
             nil
         }
 
+        // If auto-equalize-splits is enabled, equalize the post-removal tree
+        // so the surviving splits in the window become evenly sized.
+        let removed = surfaceTree.removing(node)
+        let finalTree = derivedConfig.autoEqualizeSplits ? removed.equalized() : removed
+
         replaceSurfaceTree(
-            surfaceTree.removing(node),
+            finalTree,
             moveFocusTo: nextFocus,
             moveFocusFrom: focusedSurface,
             undoAction: "Close Terminal"
@@ -1447,12 +1456,14 @@ class BaseTerminalController: NSWindowController,
         let windowStepResize: Bool
         let focusFollowsMouse: Bool
         let splitPreserveZoom: Ghostty.Config.SplitPreserveZoom
+        let autoEqualizeSplits: Bool
 
         init() {
             self.macosTitlebarProxyIcon = .visible
             self.windowStepResize = false
             self.focusFollowsMouse = false
             self.splitPreserveZoom = .init()
+            self.autoEqualizeSplits = false
         }
 
         init(_ config: Ghostty.Config) {
@@ -1460,6 +1471,7 @@ class BaseTerminalController: NSWindowController,
             self.windowStepResize = config.windowStepResize
             self.focusFollowsMouse = config.focusFollowsMouse
             self.splitPreserveZoom = config.splitPreserveZoom
+            self.autoEqualizeSplits = config.autoEqualizeSplits
         }
     }
 }

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -181,6 +181,14 @@ extension Ghostty {
             return .milliseconds(v)
         }
 
+        var autoEqualizeSplits: Bool {
+            guard let config = self.config else { return false }
+            var v = false
+            let key = "auto-equalize-splits"
+            _ = ghostty_config_get(config, &v, key, UInt(key.lengthOfBytes(using: .utf8)))
+            return v
+        }
+
         var splitPreserveZoom: SplitPreserveZoom {
             guard let config = self.config else { return .init() }
             var v: CUnsignedInt = 0

--- a/src/apprt/gtk/class/split_tree.zig
+++ b/src/apprt/gtk/class/split_tree.zig
@@ -273,6 +273,10 @@ pub const SplitTree = extern struct {
             .{ handle, direction, old_tree, &new_tree },
         );
 
+        // Auto-equalize the whole tree if the user opted in. We do this
+        // before publishing the tree so the resize is invisible to listeners.
+        autoEqualize(&new_tree, alloc);
+
         // Replace our tree
         self.setTree(&new_tree);
     }
@@ -646,6 +650,25 @@ pub const SplitTree = extern struct {
         self.setTree(&new_tree);
     }
 
+    /// If `auto-equalize-splits` is enabled, replace `tree` in place with an
+    /// equalized version. On allocation failure we log and leave `tree`
+    /// untouched so the create/close operation still succeeds with the
+    /// non-equalized layout.
+    fn autoEqualize(tree: *Surface.Tree, alloc: Allocator) void {
+        const app = Application.default();
+        const config_obj = app.getConfig();
+        defer config_obj.unref();
+        const config = config_obj.get();
+        if (!config.@"auto-equalize-splits") return;
+
+        const equalized = tree.equalize(alloc) catch |err| {
+            log.warn("unable to auto-equalize tree: {}", .{err});
+            return;
+        };
+        tree.deinit();
+        tree.* = equalized;
+    }
+
     pub fn actionZoom(
         _: *gio.SimpleAction,
         _: ?*glib.Variant,
@@ -744,6 +767,10 @@ pub const SplitTree = extern struct {
             return;
         };
         defer new_tree.deinit();
+
+        // Auto-equalize the surviving splits if the user opted in.
+        autoEqualize(&new_tree, Application.default().allocator());
+
         self.setTree(&new_tree);
 
         // Grab focus. We have to set this on the "last focused" because our

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2027,6 +2027,20 @@ keybind: Keybinds = .{},
 /// working directory will be used (the `working-directory` option).
 @"split-inherit-working-directory": bool = true,
 
+/// If true, all splits in the current window are automatically resized to
+/// be equal whenever a split is created or closed. This is equivalent to
+/// invoking the `equalize_splits` action after every split create/close.
+///
+/// Because the equalization runs over the entire split tree of the window,
+/// any prior manual resizes (e.g., via `resize_split`) within that tree are
+/// reset by this option whenever any split in the same window is created or
+/// closed.
+///
+/// Default is `false` to preserve existing behavior. Users who want every
+/// split to always be evenly sized (similar to iTerm2's default) should set
+/// this to `true`.
+@"auto-equalize-splits": bool = false,
+
 /// If true, new windows and tabs will inherit the font size of the previously
 /// focused window. If no window was previously focused, the default font size
 /// will be used. If this is false, the default font size specified in the


### PR DESCRIPTION
## Summary

Adds a new bool config option `auto-equalize-splits` (default `false`)
that, when enabled, automatically equalizes all splits in the current
window whenever a split is created or closed. Equivalent to invoking
`equalize_splits` immediately after every create/close, but unlike a
chained keybind it works across `close_surface` too.

Closes #3861.

## Motivation

Issue #3861 asks for iTerm2-style auto-equalize on every split. Today
the only way to get this is to chain `equalize_splits` after every
split-creating keybind (works fine post #10015), and there is **no**
way to do it after `close_surface`: chained keybinds containing a
closing action exit the chain immediately because the `Surface` `self`
pointer is freed (see `src/Surface.zig` `closingAction` guard, and
the discussion with @jcollie in #11040).

Rather than reaching across the apprt boundary from inside the
freed-Surface code path, this PR plumbs a single config flag down to
the runtime layer that already owns the split tree, and equalizes
in place there - on macOS in `BaseTerminalController`, on GTK in
`SplitTree`. No use-after-free, no chain-machinery changes, no new
actions.

## Approach

- **`src/config/Config.zig`**: new `@\"auto-equalize-splits\": bool = false`
  field with doc comment. Auto-wired by the existing reflective config
  parser, so CLI flag and `+show-config --default --docs` pick it up
  for free.
- **macOS** (`Ghostty.Config.swift`, `BaseTerminalController.swift`):
  add accessor and `DerivedConfig` field. When the flag is true,
  `newSplit()` and `removeSurfaceNode()` pass `tree.equalized()`
  (instead of the raw inserted/removed tree) to `replaceSurfaceTree`.
  Because equalization runs on a value-typed copy before publishing,
  it's invisible to listeners and undo/redo restores exactly the
  pre-operation tree.
- **GTK** (`src/apprt/gtk/class/split_tree.zig`): new `autoEqualize`
  helper centralizes the config check and the equalize/deinit/replace
  dance. Called from `newSplit` and the surface-removal path right
  before `setTree`.

## Behavior change

Default: zero behavior change. Off by default.

With `auto-equalize-splits = true`:

- Creating a split anywhere in the window resizes every split in
  that window so all leaves are weighted equally (same algorithm as
  the existing `equalize_splits` action / divider double-click).
- Closing a split does the same on the surviving tree.
- Manual resizes elsewhere in the same window are reset by any
  subsequent create/close. This is documented in the doc comment;
  it matches the user-requested 'always equalize' semantics and is
  consistent with how the existing `equalize_splits` action behaves.

## Tests performed

- `zig build -Demit-macos-app=false` clean on the latest tip of `main`.
- `macos/build.nu --configuration ReleaseLocal --action build` clean
  on Xcode 26.4 + macOS Tahoe 26.4.1 arm64 with Zig 0.15.2 (Homebrew
  `zig@0.15`, contains the patch noted in HACKING.md for the Xcode
  26.4 linking bug).
- `zig build test -Dtest-filter=Config` and `-Dtest-filter=split` clean.
- Resulting binary's `+show-config --default` shows
  `auto-equalize-splits = false`; `--docs` renders the new doc comment.
- Manual UI verification of create/close auto-equalize is pending on
  this PR; happy to extend the SplitTree Swift tests if reviewers want
  a programmatic regression there.

## Risks / open questions

1. **Whole-tree scope.** `equalized()` is recursive, so the option
   resets manual resizes in the whole window on any create/close.
   Could be scoped to the affected sub-split only; chose whole-window
   to match user intent ('always equal') and the existing PR #9524
   double-click behavior. Happy to narrow it if you'd prefer.
2. **GTK parity.** Implemented the GTK side too so the option isn't
   a half-feature, but I didn't add Linux end-to-end tests. The Swift
   side is the platform I actually run.
3. **Default value.** I left it `false` for safety; if you'd rather
   ship it `true` as the new default I can flip it in a follow-up
   commit.

## AI disclosure (per AI_POLICY.md)

This PR was authored with AI assistance via OpenCode + Claude
(opencode.ai, model `claude-opus-4-7`) used for codebase research,
design discussion, and code drafting. The patch is small (~50 lines)
and the human author has read every changed line, understands the
ownership of `surfaceTree` / `Surface.Tree`, and can explain why
equalizing before `replaceSurfaceTree` / `setTree` rather than after
is the right call (avoids touching the `closingAction` guard, keeps
undo blocks consistent).