### PR TITLE
macOS: normalize working directory paths with FilePath

### DIFF
--- a/macos/Sources/Ghostty/Surface View/SurfaceView.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import UserNotifications
 import GhosttyKit
+import System
 
 extension Ghostty {
     /// Render a terminal for the active app in the environment.
@@ -611,8 +612,20 @@ extension Ghostty {
         /// Explicit font size to use in points
         var fontSize: Float32?
 
+        private var normalizedWorkingDirectory: String?
         /// Explicit working directory to set
-        var workingDirectory: String?
+        var workingDirectory: String? {
+            get { normalizedWorkingDirectory }
+            set {
+                guard let newValue else {
+                    normalizedWorkingDirectory = nil
+                    return
+                }
+                // We use FilePath to normalize separators by removing redundant intermediary separators
+                // and stripping any trailing separators.
+                normalizedWorkingDirectory = FilePath(newValue).string
+            }
+        }
 
         /// Explicit command to set
         var command: String?


### PR DESCRIPTION
This fixes for [Nushell](https://github.com/nushell/nushell/blob/f342d8acfa81bd9543bb38e3e08b1a93ecafe5d1/crates/nu-protocol/src/engine/engine_state.rs#L1012) when opening Ghostty via Finder service and Shortcuts, also makes path parsing more robust in AppleScript.

<img width="976" height="690" alt="image" src="https://github.com/user-attachments/assets/d3c19481-39ce-4797-ba31-d431af16651d" />
