### PR TITLE
macos: wrap spatial goto around edges

### DIFF
--- a/macos/Sources/Features/Splits/SplitTree.swift
+++ b/macos/Sources/Features/Splits/SplitTree.swift
@@ -202,7 +202,7 @@ extension SplitTree {
         case .spatial(let spatialDirection):
             // Get spatial representation and find best candidate
             let spatial = root.spatial()
-            let nodes = spatial.slots(in: spatialDirection, from: currentNode)
+            let nodes = spatial.slotsWrapped(in: spatialDirection, from: currentNode)
 
             // If we have no nodes in the direction specified then we don't do
             // anything.
@@ -1069,6 +1069,75 @@ extension SplitTree.Spatial {
         }
 
         return result
+    }
+
+    /// Same as `slots(in:from:)` but wraps around the grid edges when no slots
+    /// exist in the requested direction.
+    ///
+    /// When wrapping, the reference frame is virtually shifted by the overall
+    /// grid extent in the opposite direction, so every slot in the actual grid
+    /// appears on the requested side of that virtual reference. Distances are
+    /// computed against the shifted reference, which makes the closest result
+    /// the slot on the far edge — i.e. the wrap target.
+    func slotsWrapped(in direction: Direction, from referenceNode: SplitTree.Node) -> [Slot] {
+        // First try without wrapping. If we have any slots in the direction,
+        // wrapping isn't needed.
+        let direct = slots(in: direction, from: referenceNode)
+        if !direct.isEmpty { return direct }
+
+        guard let refSlot = slots.first(where: { $0.node == referenceNode }) else { return [] }
+
+        // Compute the overall bounds of the spatial grid so we know how far to
+        // shift the virtual reference frame.
+        let overall = slots.reduce(CGRect.null) { result, slot in
+            result.union(slot.bounds)
+        }
+
+        // Shift the reference in the opposite direction by the full grid extent.
+        // This makes every actual slot fall on the requested side, and the
+        // distance ordering naturally selects the slot at the far edge.
+        let shifted: CGRect = switch direction {
+        case .left: refSlot.bounds.offsetBy(dx: overall.width, dy: 0)
+        case .right: refSlot.bounds.offsetBy(dx: -overall.width, dy: 0)
+        case .up: refSlot.bounds.offsetBy(dx: 0, dy: overall.height)
+        case .down: refSlot.bounds.offsetBy(dx: 0, dy: -overall.height)
+        }
+
+        func distance(from rect1: CGRect, to rect2: CGRect) -> Double {
+            let dx = rect2.minX - rect1.minX
+            let dy = rect2.minY - rect1.minY
+            return sqrt(dx * dx + dy * dy)
+        }
+
+        return switch direction {
+        case .left:
+            slots.filter {
+                $0.node != referenceNode && $0.bounds.maxX <= shifted.minX
+            }.sorted {
+                distance(from: shifted, to: $0.bounds) < distance(from: shifted, to: $1.bounds)
+            }
+
+        case .right:
+            slots.filter {
+                $0.node != referenceNode && $0.bounds.minX >= shifted.maxX
+            }.sorted {
+                distance(from: shifted, to: $0.bounds) < distance(from: shifted, to: $1.bounds)
+            }
+
+        case .up:
+            slots.filter {
+                $0.node != referenceNode && $0.bounds.maxY <= shifted.minY
+            }.sorted {
+                distance(from: shifted, to: $0.bounds) < distance(from: shifted, to: $1.bounds)
+            }
+
+        case .down:
+            slots.filter {
+                $0.node != referenceNode && $0.bounds.minY >= shifted.maxY
+            }.sorted {
+                distance(from: shifted, to: $0.bounds) < distance(from: shifted, to: $1.bounds)
+            }
+        }
     }
 
     /// Returns whether the given node borders the specified side of the spatial bounds.

--- a/macos/Tests/Splits/SplitTreeTests.swift
+++ b/macos/Tests/Splits/SplitTreeTests.swift
@@ -171,6 +171,40 @@ struct SplitTreeTests {
         #expect(target === view1)
     }
 
+    // Wrap: from the leftmost view, .spatial(.left) should wrap to the rightmost.
+    @Test func focusTargetSpatialWrapsLeftFromLeftEdge() throws {
+        let (tree, view1, view2) = try makeHorizontalSplit()
+        let target = tree.focusTarget(for: .spatial(.left), from: .leaf(view: view1))
+        #expect(target === view2)
+    }
+
+    // Wrap: from the rightmost view, .spatial(.right) should wrap to the leftmost.
+    @Test func focusTargetSpatialWrapsRightFromRightEdge() throws {
+        let (tree, view1, view2) = try makeHorizontalSplit()
+        let target = tree.focusTarget(for: .spatial(.right), from: .leaf(view: view2))
+        #expect(target === view1)
+    }
+
+    // Wrap: from the top view, .spatial(.up) should wrap to the bottom.
+    @Test func focusTargetSpatialWrapsUpFromTopEdge() throws {
+        let view1 = MockView()
+        let view2 = MockView()
+        var tree = SplitTree<MockView>(view: view1)
+        tree = try tree.inserting(view: view2, at: view1, direction: .down)
+        let target = tree.focusTarget(for: .spatial(.up), from: .leaf(view: view1))
+        #expect(target === view2)
+    }
+
+    // Wrap: from the bottom view, .spatial(.down) should wrap to the top.
+    @Test func focusTargetSpatialWrapsDownFromBottomEdge() throws {
+        let view1 = MockView()
+        let view2 = MockView()
+        var tree = SplitTree<MockView>(view: view1)
+        tree = try tree.inserting(view: view2, at: view1, direction: .down)
+        let target = tree.focusTarget(for: .spatial(.down), from: .leaf(view: view2))
+        #expect(target === view1)
+    }
+
     // MARK: - Equalized
 
     @Test func equalizedAdjustsRatioByLeafCount() throws {
@@ -621,6 +655,52 @@ struct SplitTreeTests {
         #expect(spatial.slots(in: .right, from: .leaf(view: view2)).isEmpty)
         #expect(spatial.slots(in: .up, from: .leaf(view: view1)).isEmpty)
         #expect(spatial.slots(in: .down, from: .leaf(view: view2)).isEmpty)
+    }
+
+    // slotsWrapped should match slots() when the direction has results without wrapping.
+    @Test func slotsWrappedMatchesSlotsWhenNotAtEdge() throws {
+        let (tree, view1, _) = try makeHorizontalSplit()
+        let spatial = tree.root!.spatial(within: CGSize(width: 1000, height: 500))
+
+        let direct = spatial.slots(in: .right, from: .leaf(view: view1))
+        let wrapped = spatial.slotsWrapped(in: .right, from: .leaf(view: view1))
+        #expect(wrapped.map { $0.bounds } == direct.map { $0.bounds })
+    }
+
+    @Test func slotsWrappedWrapsHorizontally() throws {
+        let (tree, view1, view2) = try makeHorizontalSplit()
+        let spatial = tree.root!.spatial(within: CGSize(width: 1000, height: 500))
+
+        let leftFromA = spatial.slotsWrapped(in: .left, from: .leaf(view: view1))
+        #expect(leftFromA.contains { $0.node == .leaf(view: view2) })
+
+        let rightFromB = spatial.slotsWrapped(in: .right, from: .leaf(view: view2))
+        #expect(rightFromB.contains { $0.node == .leaf(view: view1) })
+    }
+
+    @Test func slotsWrappedWrapsVertically() throws {
+        let view1 = MockView()
+        let view2 = MockView()
+        var tree = SplitTree<MockView>(view: view1)
+        tree = try tree.inserting(view: view2, at: view1, direction: .down)
+        let spatial = tree.root!.spatial(within: CGSize(width: 500, height: 1000))
+
+        let upFromTop = spatial.slotsWrapped(in: .up, from: .leaf(view: view1))
+        #expect(upFromTop.contains { $0.node == .leaf(view: view2) })
+
+        let downFromBottom = spatial.slotsWrapped(in: .down, from: .leaf(view: view2))
+        #expect(downFromBottom.contains { $0.node == .leaf(view: view1) })
+    }
+
+    @Test func slotsWrappedReturnsEmptyForSingleNode() {
+        let view1 = MockView()
+        let tree = SplitTree<MockView>(view: view1)
+        let spatial = tree.root!.spatial(within: CGSize(width: 500, height: 500))
+
+        #expect(spatial.slotsWrapped(in: .left, from: .leaf(view: view1)).isEmpty)
+        #expect(spatial.slotsWrapped(in: .right, from: .leaf(view: view1)).isEmpty)
+        #expect(spatial.slotsWrapped(in: .up, from: .leaf(view: view1)).isEmpty)
+        #expect(spatial.slotsWrapped(in: .down, from: .leaf(view: view1)).isEmpty)
     }
 
     // Set/Dictionary usage is the only path that exercises StructuralIdentity.hash(into:)


### PR DESCRIPTION
fixes #8406. mirrors #10811 for macos.

spatial split navigation now wraps at the edges. first attempts the
nearest target using the existing slot geometry. if there is no
candidate in the requested direction, synthesizes a wrapped target
by shifting the current slot by one full grid in the opposite
direction and reuses the same nearest-distance logic.

verified locally: 8 new tests pass, full GhosttyTests suite green
(macos/build.nu --action test, xcode 26.4.1).

ai-assistance: partial use of claude code during implementation; i
reviewed and understand the change.