### PR TITLE
feat: expose toggle-quick-terminal as a D-Bus action

### DIFF
--- a/src/apprt/gtk/class/application.zig
+++ b/src/apprt/gtk/class/application.zig
@@ -1419,6 +1419,7 @@ pub const Application = extern struct {
             .init("present-surface", actionPresentSurface, t_variant_type),
             .init("quit", actionQuit, null),
             .init("reload-config", actionReloadConfig, null),
+            .init("toggle-quick-terminal", actionToggleQuickTerminal, null),
         };
 
         ext.actions.add(Self, self, &actions);
@@ -1666,6 +1667,17 @@ pub const Application = extern struct {
         const priv = self.private();
         priv.core_app.performAction(self.rt(), .reload_config) catch |err| {
             log.warn("error reloading config err={}", .{err});
+        };
+    }
+
+    fn actionToggleQuickTerminal(
+        _: *gio.SimpleAction,
+        _: ?*glib.Variant,
+        self: *Self,
+    ) callconv(.c) void {
+        const priv = self.private();
+        priv.core_app.performAction(self.rt(), .toggle_quick_terminal) catch |err| {
+            log.warn("error toggling quick terminal err={}", .{err});
         };
     }
 


### PR DESCRIPTION
Expose `toggle-quick-terminal` as a D-Bus action on GApplication's standard bus (`com.mitchellh.ghostty`), allowing external tools to trigger Ghostty's quick terminal remotely.

## Background

On Linux/Wayland (especially KDE), the `global:` keybind prefix relies on XDG Desktop Portal GlobalShortcuts, which has a broken pipeline on KDE (kglobalacceld lacks a Wayland platform plugin). This makes it impossible to trigger the quick terminal globally without window focus.

## Changes

Add one line to `startupActionMap()` in `src/apprt/gtk/class/application.zig`:

```zig
.init("toggle-quick-terminal", actionToggleQuickTerminal, null),
```

This exports the action via GApplication's D-Bus at `org.gtk.Actions.Activate`, alongside the existing 6 actions (present-surface, quit, new-window, etc.).

Also adds the handler function `actionToggleQuickTerminal`, following the same pattern as the other action handlers (e.g. `actionReloadConfig`).

## Usage

After this change, the quick terminal can be toggled from any process:

```bash
gdbus call --session \\
  -d com.mitchellh.ghostty \\
  -o /com/mitchellh/ghostty \\
  -m org.gtk.Actions.Activate \\
  "toggle-quick-terminal" "@av []" "@a{sv} {}"
```

This enables workarounds like evdev-based key capture daemons, KWin scripts, or any D-Bus client to implement global quick terminal toggling on platforms where `global:` keybindings do not work.

## Testing

Verified on KDE Plasma 6.6.4 / Wayland / Ubuntu 26.04:
- Debug build: action appears on D-Bus and toggles the quick terminal
- Release build: same behavior, no performance warning

## Related

- Discussion #2888 (Quick terminal tabs)
- Discussion #3192 (Quick terminal shortcut does not work globally on Linux)