### PR TITLE
libghostty-vt: handle OSC color queries

### DIFF
--- a/src/terminal/osc/parsers/color.zig
+++ b/src/terminal/osc/parsers/color.zig
@@ -42,6 +42,66 @@ pub const Operation = enum {
     osc_119,
 };
 
+/// The color precision to use when formatting OSC color responses.
+pub const ReportFormat = enum {
+    @"16-bit",
+    @"8-bit",
+};
+
+/// Encode an OSC color query response for a palette or dynamic color.
+pub fn formatReport(
+    writer: anytype,
+    format: ReportFormat,
+    kind: Target,
+    color: RGB,
+) !void {
+    switch (format) {
+        .@"16-bit" => switch (kind) {
+            .palette => |i| try writer.print(
+                "\x1b]4;{d};rgb:{x:0>4}/{x:0>4}/{x:0>4}",
+                .{
+                    i,
+                    @as(u16, color.r) * 257,
+                    @as(u16, color.g) * 257,
+                    @as(u16, color.b) * 257,
+                },
+            ),
+            .dynamic => |dynamic| try writer.print(
+                "\x1b]{d};rgb:{x:0>4}/{x:0>4}/{x:0>4}",
+                .{
+                    @intFromEnum(dynamic),
+                    @as(u16, color.r) * 257,
+                    @as(u16, color.g) * 257,
+                    @as(u16, color.b) * 257,
+                },
+            ),
+            .special => unreachable,
+        },
+
+        .@"8-bit" => switch (kind) {
+            .palette => |i| try writer.print(
+                "\x1b]4;{d};rgb:{x:0>2}/{x:0>2}/{x:0>2}",
+                .{
+                    i,
+                    @as(u16, color.r),
+                    @as(u16, color.g),
+                    @as(u16, color.b),
+                },
+            ),
+            .dynamic => |dynamic| try writer.print(
+                "\x1b]{d};rgb:{x:0>2}/{x:0>2}/{x:0>2}",
+                .{
+                    @intFromEnum(dynamic),
+                    @as(u16, color.r),
+                    @as(u16, color.g),
+                    @as(u16, color.b),
+                },
+            ),
+            .special => unreachable,
+        },
+    }
+}
+
 /// Parse OSCs 4, 5, 10-19, 104, 110-119
 pub fn parse(parser: *Parser, terminator_ch: ?u8) ?*Command {
     const alloc = parser.alloc orelse {

--- a/src/terminal/stream_terminal.zig
+++ b/src/terminal/stream_terminal.zig
@@ -9,7 +9,6 @@ const device_status = @import("device_status.zig");
 const stream = @import("stream.zig");
 const Action = stream.Action;
 const Screen = @import("Screen.zig");
-const color = @import("color.zig");
 const modes = @import("modes.zig");
 const osc = @import("osc.zig");
 const osc_color = @import("osc/parsers/color.zig");
@@ -749,7 +748,8 @@ pub const Handler = struct {
                 .query => |target| {
                     if (self.effects.write_pty == null) continue;
                     const c = self.terminal.colorForXterm(target) orelse continue;
-                    try writeXtermColorReport(writer, target, c, terminator);
+                    try osc_color.formatReport(writer, .@"16-bit", target, c);
+                    try writer.writeAll(terminator.string());
                 },
 
                 .reset_special => {},
@@ -760,40 +760,6 @@ pub const Handler = struct {
             const resp = try response.toOwnedSliceSentinel(0);
             defer alloc.free(resp);
             self.writePty(resp);
-        }
-    }
-
-    fn writeXtermColorReport(
-        writer: *std.Io.Writer,
-        target: osc_color.Target,
-        c: color.RGB,
-        terminator: osc.Terminator,
-    ) !void {
-        switch (target) {
-            .palette => |i| {
-                try writer.print("\x1b]4;{d};", .{i});
-                try c.encodeRgb16(writer);
-                try writer.writeAll(terminator.string());
-            },
-            .dynamic => |dynamic| switch (dynamic) {
-                .foreground,
-                .background,
-                .cursor,
-                => {
-                    try writer.print("\x1b]{d};", .{@intFromEnum(dynamic)});
-                    try c.encodeRgb16(writer);
-                    try writer.writeAll(terminator.string());
-                },
-                .pointer_foreground,
-                .pointer_background,
-                .tektronix_foreground,
-                .tektronix_background,
-                .highlight_background,
-                .tektronix_cursor,
-                .highlight_foreground,
-                => {},
-            },
-            .special => {},
         }
     }
 

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -1327,53 +1327,17 @@ pub const StreamHandler = struct {
                         },
                     };
 
-                    switch (self.osc_color_report_format) {
-                        .@"16-bit" => switch (kind) {
-                            .palette => |i| try response.writer.print(
-                                "\x1b]4;{d};rgb:{x:0>4}/{x:0>4}/{x:0>4}",
-                                .{
-                                    i,
-                                    @as(u16, color.r) * 257,
-                                    @as(u16, color.g) * 257,
-                                    @as(u16, color.b) * 257,
-                                },
-                            ),
-                            .dynamic => |dynamic| try response.writer.print(
-                                "\x1b]{d};rgb:{x:0>4}/{x:0>4}/{x:0>4}",
-                                .{
-                                    @intFromEnum(dynamic),
-                                    @as(u16, color.r) * 257,
-                                    @as(u16, color.g) * 257,
-                                    @as(u16, color.b) * 257,
-                                },
-                            ),
-                            .special => unreachable,
-                        },
-
-                        .@"8-bit" => switch (kind) {
-                            .palette => |i| try response.writer.print(
-                                "\x1b]4;{d};rgb:{x:0>2}/{x:0>2}/{x:0>2}",
-                                .{
-                                    i,
-                                    @as(u16, color.r),
-                                    @as(u16, color.g),
-                                    @as(u16, color.b),
-                                },
-                            ),
-                            .dynamic => |dynamic| try response.writer.print(
-                                "\x1b]{d};rgb:{x:0>2}/{x:0>2}/{x:0>2}",
-                                .{
-                                    @intFromEnum(dynamic),
-                                    @as(u16, color.r),
-                                    @as(u16, color.g),
-                                    @as(u16, color.b),
-                                },
-                            ),
-                            .special => unreachable,
-                        },
-
+                    const report_format: terminal.osc.color.ReportFormat = switch (self.osc_color_report_format) {
+                        .@"16-bit" => .@"16-bit",
+                        .@"8-bit" => .@"8-bit",
                         .none => unreachable,
-                    }
+                    };
+                    try terminal.osc.color.formatReport(
+                        &response.writer,
+                        report_format,
+                        kind,
+                        color,
+                    );
 
                     try response.writer.writeAll(terminator.string());
                 },


### PR DESCRIPTION
This PR enables libghostty-vt to handle the OSC 10/11/12 queries, extracting the formatting of the corresponding resposes from `stream_terminal.zig` into `color.zig` in the process.