### PR TITLE
terminal: report DECECM as permanently reset

### DIFF
--- a/src/terminal/modes.zig
+++ b/src/terminal/modes.zig
@@ -10,8 +10,6 @@
 const std = @import("std");
 const testing = std.testing;
 
-const dececm_mode: u15 = 117;
-
 /// A struct that maintains the state of all the settable modes.
 pub const ModeState = struct {
     /// The values of the current modes.
@@ -81,7 +79,9 @@ pub const ModeState = struct {
     /// Return a DECRPM report for the given mode tag. If the tag does
     /// not correspond to a known mode, the report state is .not_recognized.
     pub fn getReport(self: *const ModeState, tag: ModeTag) Report {
-        if (!tag.ansi and tag.value == dececm_mode) {
+        // DECECM (Erase Color Mode) is DEC private mode 117. Ghostty behaves as
+        // if it is permanently reset and does not implement it as a mutable mode.
+        if (!tag.ansi and tag.value == 117) {
             return .{ .tag = tag, .state = .permanently_reset };
         }
         const mode = modeFromInt(tag.value, tag.ansi) orelse return .{

--- a/src/terminal/modes.zig
+++ b/src/terminal/modes.zig
@@ -79,8 +79,16 @@ pub const ModeState = struct {
     /// Return a DECRPM report for the given mode tag. If the tag does
     /// not correspond to a known mode, the report state is .not_recognized.
     pub fn getReport(self: *const ModeState, tag: ModeTag) Report {
-        // DECECM (Erase Color Mode) is DEC private mode 117. Ghostty behaves as
-        // if it is permanently reset and does not implement it as a mutable mode.
+        // DECECM (Erase Color Mode, DEC private mode 117) controls whether erasing
+        // and scrolling use the default background or the active background color.
+        // Ghostty's behavior is fixed equivalent to DECECM reset, and DECRQM has a
+        // "permanently reset" response for recognized modes that cannot be changed.
+        // Report that instead of "not recognized" so applications can query and adapt
+        // to Ghostty's erase-color behavior.
+        //
+        // See VT520/VT525 Programmer Information, "Erase Color" and DECRQM/DECRPM:
+        // https://web.mit.edu/dosathena/doc/www/ek-vt520-rm.pdf
+
         if (!tag.ansi and tag.value == 117) {
             return .{ .tag = tag, .state = .permanently_reset };
         }

--- a/src/terminal/modes.zig
+++ b/src/terminal/modes.zig
@@ -10,6 +10,8 @@
 const std = @import("std");
 const testing = std.testing;
 
+const dececm_mode: u15 = 117;
+
 /// A struct that maintains the state of all the settable modes.
 pub const ModeState = struct {
     /// The values of the current modes.
@@ -79,6 +81,9 @@ pub const ModeState = struct {
     /// Return a DECRPM report for the given mode tag. If the tag does
     /// not correspond to a known mode, the report state is .not_recognized.
     pub fn getReport(self: *const ModeState, tag: ModeTag) Report {
+        if (!tag.ansi and tag.value == dececm_mode) {
+            return .{ .tag = tag, .state = .permanently_reset };
+        }
         const mode = modeFromInt(tag.value, tag.ansi) orelse return .{
             .tag = tag,
             .state = .not_recognized,
@@ -345,6 +350,13 @@ test "getReport known ANSI mode" {
     const report = state.getReport(.{ .value = 4, .ansi = true });
     try testing.expectEqual(Report.State.set, report.state);
     try testing.expectEqual(true, report.tag.ansi);
+}
+
+test "getReport DECECM permanently reset" {
+    const state: ModeState = .{};
+    const report = state.getReport(.{ .value = 117, .ansi = false });
+    try testing.expectEqual(Report.State.permanently_reset, report.state);
+    try testing.expectEqual(false, report.tag.ansi);
 }
 
 test "getReport unknown mode" {

--- a/src/terminal/stream_terminal.zig
+++ b/src/terminal/stream_terminal.zig
@@ -1366,6 +1366,10 @@ test "request mode DECRQM with write_pty callback" {
         // Query an unknown mode
         s.nextSlice("\x1B[?9999$p");
         try testing.expectEqualStrings("\x1B[?9999;0$y", S.last_response.?);
+
+        // Query DECECM, which Ghostty recognizes but does not allow changing
+        s.nextSlice("\x1B[?117$p");
+        try testing.expectEqualStrings("\x1B[?117;4$y", S.last_response.?);
     }
 }
 


### PR DESCRIPTION
Closes #12505 

This PR allows Ghostty to respond to DECRQM queries for DECECM with the "permanently reset".

AI disclosure: I used Codex to help inspect the relevant code path and explain the issue, but I reviewed and made the code changes myself.