### PR TITLE
snap: export TERMINFO_DIRS so child shells find xterm-ghostty

### DIFF
--- a/snap/local/launcher
+++ b/snap/local/launcher
@@ -50,6 +50,7 @@ export XLOCALEDIR="${SNAP}/usr/share/X11/locale"
 export GTK_PATH="$SNAP/usr/lib/$ARCH/gtk-4.0"
 export GIO_MODULE_DIR="$SNAP/usr/lib/$ARCH/gio/modules"
 unset GIO_EXTRA_MODULES
+export TERMINFO_DIRS="${SNAP}/share/terminfo${TERMINFO_DIRS:+:$TERMINFO_DIRS}"
 
 # Gdk-pixbuf loaders
 mkdir -p "$SNAP_USER_COMMON/.cache"


### PR DESCRIPTION
## Summary

When Ghostty is installed via snap on Ubuntu, programs running inside Ghostty (e.g. `clear`) fail with:

```
terminals database is inaccessible
```

The snap ships terminfo at `${SNAP}/share/terminfo` but the launcher never exports `TERMINFO_DIRS`, so ncurses in child shells falls back to the host's system database. On Ubuntu 24.04 (ncurses 6.4) the system database predates the `xterm-ghostty` entry, so the lookup fails.

This is the same fix as the auto-closed #12303 and resolves #12304.

## Fix

Export `TERMINFO_DIRS` in `snap/local/launcher` so all child processes can resolve the bundled entry without manual setup.

## Local build (how this PR was verified)

Remix the installed store snap by swapping `app/launcher` with the patched one:

```sh
sudo unsquashfs -d /tmp/g \
  /var/lib/snapd/snaps/ghostty_$(readlink /snap/ghostty/current).snap
sudo cp snap/local/launcher /tmp/g/app/launcher
sudo mksquashfs /tmp/g /tmp/ghostty-test.snap -comp xz -noappend
sudo snap install --dangerous --classic /tmp/ghostty-test.snap
```

Then launch `/snap/bin/ghostty` and run `clear`.

## Test plan

Verified locally on Ubuntu 24.04 / arm64.

- [x] In default `zsh` / `bash` inside Ghostty, `clear` succeeds.
- [x] `infocmp xterm-ghostty` resolves to `/snap/ghostty/current/share/terminfo/x/xterm-ghostty`.
- [x] No manual copying of terminfo entries into `~/.terminfo/` required.

## AI Disclosure

Claude Code was used to investigate the root cause and to draft this single-line launcher change. The fix is identical to the proposal in the linked discussion (#12304). I manually verified by remixing the installed snap with the patched launcher and confirming `clear` and `infocmp xterm-ghostty` work without manually copying terminfo entries into `~/.terminfo/` (original workaround shared in the discussion).