### PR TITLE
Add ability to disable focusIn call to fix OSK popping up always on steam deck

### DIFF
--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -2717,8 +2717,10 @@ pub const Surface = extern struct {
         priv.focused = focused;
 
         const ctx = priv.im_context.as(gtk.IMContext);
-        if (!focused or self.shouldAllowFocusInOnScreenKeyboard()) {
-            if (focused) ctx.focusIn() else ctx.focusOut();
+        if (focused) {
+            if (self.shouldAllowFocusInOnScreenKeyboard()) ctx.focusIn();
+        } else {
+            ctx.focusOut();
         }
 
         _ = glib.idleAddOnce(idleFocus, self.ref());

--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -957,6 +957,13 @@ pub const Surface = extern struct {
         return priv.im_context.as(gtk.IMContext).activateOsk(event) != 0;
     }
 
+    fn shouldAllowFocusInOnScreenKeyboard(self: *Self) bool {
+        const priv = self.private();
+        const config = priv.config orelse return true;
+        const cfg = config.get();
+        return cfg.@"gtk-on-screen-keyboard-focus-on-focus-in";
+    }
+
     /// Set the scrollbar state for this surface. This will setup the
     /// properties for our Gtk.Scrollable interface properly.
     pub fn setScrollbar(self: *Self, scrollbar: terminal.Scrollbar) void {
@@ -2710,7 +2717,9 @@ pub const Surface = extern struct {
         priv.focused = focused;
 
         const ctx = priv.im_context.as(gtk.IMContext);
-        if (focused) ctx.focusIn() else ctx.focusOut();
+        if (!focused or self.shouldAllowFocusInOnScreenKeyboard()) {
+            if (focused) ctx.focusIn() else ctx.focusOut();
+        }
 
         _ = glib.idleAddOnce(idleFocus, self.ref());
         self.as(gobject.Object).notifyByPspec(properties.focused.impl.param_spec);

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -3618,6 +3618,13 @@ else
 /// Available since: 1.1.0
 @"gtk-titlebar-hide-when-maximized": bool = false,
 
+/// If `true` (default), Ghostty will allow GTK input method focus-in events
+/// to happen when a surface gains focus. Some environments may show an
+/// on-screen keyboard when this occurs.
+///
+/// Set this to `false` to avoid focus-driven on-screen keyboard activation.
+@"gtk-on-screen-keyboard-focus-on-focus-in": bool = true,
+
 /// Determines the appearance of the top and bottom bars tab bar.
 ///
 /// Valid values are:


### PR DESCRIPTION
As per https://github.com/ghostty-org/ghostty/discussions/9302 when using ghostty on steam deck the On-Screen-Keyboard is always opened on every focus. This disables this behaviour.