### PR TITLE
snap: bundle gstreamer plugins so audio bell works

### DIFF
--- a/snap/local/launcher
+++ b/snap/local/launcher
@@ -50,6 +50,9 @@ export XLOCALEDIR="${SNAP}/usr/share/X11/locale"
 export GTK_PATH="$SNAP/usr/lib/$ARCH/gtk-4.0"
 export GIO_MODULE_DIR="$SNAP/usr/lib/$ARCH/gio/modules"
 unset GIO_EXTRA_MODULES
+export GST_PLUGIN_SYSTEM_PATH="${SNAP}/usr/lib/${ARCH}/gstreamer-1.0"
+export GST_PLUGIN_SCANNER="${SNAP}/usr/lib/${ARCH}/gstreamer1.0/gstreamer-1.0/gst-plugin-scanner"
+export GST_REGISTRY="${SNAP_USER_COMMON}/.cache/gstreamer-1.0-registry.bin"
 
 # Gdk-pixbuf loaders
 mkdir -p "$SNAP_USER_COMMON/.cache"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -96,6 +96,9 @@ parts:
       - libglib2.0-0t64
       - libgtk-4-1
       - libgtk-4-media-gstreamer
+      - gstreamer1.0-plugins-base
+      - gstreamer1.0-plugins-good
+      - gstreamer1.0-pulseaudio
       - ibus-gtk4
       - libpciaccess0
       - libtinfo6


### PR DESCRIPTION
## Summary

With `bell-features = audio` and a valid `bell-audio-path` configured, no sound plays in the snap build of Ghostty.

The snap stages `libgtk-4-media-gstreamer` and the core GStreamer libraries but ships only `libgstcoreelements.so` and `libgstcoretracers.so` — none of the playback, decode, or audio-sink plugins that the GTK media backend needs to build a pipeline. The bell therefore silently fails.

`bell-features = system` (compositor sound, routed via `gdk_surface_beep()`) already works and is unchanged.

## Fix

- Stage `gstreamer1.0-plugins-base`, `gstreamer1.0-plugins-good`, and `gstreamer1.0-pulseaudio` so the snap ships `typefind`, `decodebin`, `vorbis`, `audioconvert`, `autoaudiosink`, `pulsesink`, etc.
- Export `GST_PLUGIN_SYSTEM_PATH`, `GST_PLUGIN_SCANNER`, and `GST_REGISTRY` in `snap/local/launcher` so GStreamer finds the bundled plugins and writes a per-user registry cache under `SNAP_USER_COMMON`.

## Local build (how this PR was verified)

Official snap CI builds from a release tarball, so the committed `snapcraft.yaml` assumes pre-generated `.ui` resources are present. Building from a git checkout requires two extra things that are *not* part of this PR (they would belong in a separate change to make `snap/snapcraft.yaml` git-source-buildable):

1. A `VERSION` file at the repo root (release tarballs include one):
   ```sh
   echo 1.3.2-dev > VERSION
   ```

2. A `blueprint-compiler` part plus PyGObject build deps so the GTK UI resources can be generated at build time. Apply this diff on top of the PR before running `snapcraft pack`:

   ```diff
    parts:
      ...
   +  blueprint-compiler:
   +    source: https://gitlab.gnome.org/jwestman/blueprint-compiler.git
   +    source-tag: v0.18.0
   +    plugin: meson
   +    meson-parameters: [--prefix=/usr]
   +    build-packages:
   +      - meson
   +      - python3
   +      - python3-jinja2
   +    prime:
   +      - -*
   +
      ghostty:
        source: .
   -    after: [zig]
   +    after: [zig, blueprint-compiler]
        plugin: nil
        build-attributes: [enable-patchelf]
        build-packages:
          - libgtk-4-dev
          - libadwaita-1-dev
          - libxml2-utils
          - git
          - patchelf
          - gettext
   +      - python3-gi
   +      - gir1.2-gtk-4.0
   +      - gir1.2-adw-1
        override-build: |
          craftctl set version=$(cat VERSION)
   +      export PATH="$CRAFT_PART_SRC/../../zig/src:$CRAFT_STAGE/usr/bin:$PATH"
   +      cp -r "$CRAFT_STAGE/usr/lib/python3/dist-packages/blueprintcompiler" \
   +        /usr/lib/python3/dist-packages/
          $CRAFT_PART_SRC/../../zig/src/zig build \
   ```

   The `cp` is needed because `blueprint-compiler.py` hard-codes the meson-configured module path (`/usr/lib/python3/dist-packages`) into the installed script; making the staged copy importable means putting it on that exact path inside the build container.

With those in place:

```sh
snapcraft pack
sudo snap install --dangerous --classic ./ghostty_1.3.2-dev_*.snap
```

## Test plan

Verified locally on Ubuntu 24.04 / arm64 using the build above.

- [x] With config
  ```
  bell-features = system,audio
  bell-audio-path = /usr/share/sounds/freedesktop/stereo/bell.oga
  ```
  `printf '\a'` rings both the compositor system bell and plays the audio file.
- [x] No new warnings in Ghostty startup logs related to GStreamer plugin discovery.

## AI Disclosure

Claude Code was used throughout: diagnosing why `bell-features = audio` produced silence in the snap (no playback/decode/sink plugins bundled despite `libgtk-4-media-gstreamer` being staged), drafting the `snapcraft.yaml` and `snap/local/launcher` changes, and driving the `snapcraft pack` build iteration that uncovered the temporary git-source build requirements documented above (which are *not* part of this PR).

I reviewed every line of the diff and understand the role of each change: the three GStreamer plugin packages provide the pipeline elements GTK media needs (`typefind`, `decodebin`, `vorbis`, `audioconvert`, `autoaudiosink`, `pulsesink`), and the three new env vars in the launcher point GStreamer at the bundled plugin directory and a user-writable registry cache. I rebuilt the snap, installed it, and confirmed both system and audio bell fire when configured.