### PR TITLE
build(highway): require `apple_sdk` for darwin builds

### DIFF
--- a/pkg/highway/build.zig
+++ b/pkg/highway/build.zig
@@ -37,6 +37,13 @@ pub fn build(b: *std.Build) !void {
         try android_ndk.addPaths(b, lib);
     }
 
+    // Mainly for iOS simulators, but we add for all Darwin target for
+    // consistency.
+    if (target.result.os.tag.isDarwin()) {
+        const apple_sdk = @import("apple_sdk");
+        try apple_sdk.addPaths(b, lib);
+    }
+
     var flags: std.ArrayList([]const u8) = .empty;
     defer flags.deinit(b.allocator);
     try flags.appendSlice(b.allocator, &.{

--- a/pkg/highway/build.zig.zon
+++ b/pkg/highway/build.zig.zon
@@ -12,5 +12,6 @@
         },
 
         .android_ndk = .{ .path = "../android-ndk" },
+        .apple_sdk = .{ .path = "../apple-sdk" },
     },
 }


### PR DESCRIPTION
Noticed this was removed in another PR, but `apple_sdk` is required to build libghsotty for the iOS simulator, specifically for the x86 version (see the error log [here](https://github.com/elias8/libghostty/actions/runs/26075576793/job/76666498246)). Figured it'd be better to include the SDK in all darwin builds for consistency.