### PR TITLE
macOS: check the resource the URL refers to

### DIFF
--- a/macos/Sources/Features/Services/ServiceProvider.swift
+++ b/macos/Sources/Features/Services/ServiceProvider.swift
@@ -52,6 +52,11 @@ class ServiceProvider: NSObject {
             }
         )
 
+        guard !directoryURLs.isEmpty else {
+            error.pointee = Self.errorNoString
+            return
+        }
+
         for url in directoryURLs {
             var config = Ghostty.SurfaceConfiguration()
             config.workingDirectory = url.path(percentEncoded: false)

--- a/macos/Sources/Features/Services/ServiceProvider.swift
+++ b/macos/Sources/Features/Services/ServiceProvider.swift
@@ -42,7 +42,13 @@ class ServiceProvider: NSObject {
         // to their directories because that's the only thing we can open.
         let directoryURLs = Set(
             pathURLs.map { url -> URL in
-                url.hasDirectoryPath ? url : url.deletingLastPathComponent()
+                /// We check file system resources here because
+                /// NSURL doesn't append `/` when reading string contents from pasteboard
+                ///     ```
+                ///     NSURL(pasteboardPropertyList: "/System/Library".propertyList(), ofType: .fileURL)?.hasDirectoryPath
+                ///     ```
+                let isDirectory = (try? url.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory ?? url.hasDirectoryPath
+                return isDirectory ? url : url.deletingLastPathComponent()
             }
         )
 


### PR DESCRIPTION
- Fixes https://github.com/ghostty-org/ghostty/issues/12727. [`NSURL.hasDirectoryPath` doesn't do this](https://developer.apple.com/documentation/foundation/nsurl/hasdirectorypath).

<img width="977" height="177" alt="image" src="https://github.com/user-attachments/assets/94f77277-8ef0-4573-8ae1-0e54f810463f" />

> We don't need to check this in NewTerminalIntent since AppIntent already appends `/` to the directory.

- Set error when there is no directory to open with