### PR TITLE
macOS: fix search bar Enter key blocking IME composition

### DIFF
--- a/macos/Sources/Ghostty/Surface View/SurfaceView.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView.swift
@@ -420,7 +420,6 @@ extension Ghostty {
                     .onSubmit {
                         _ = surfaceView.navigateSearchToNext()
                     }
-                    }
 #if canImport(AppKit)
                     .onExitCommand {
                         if searchState.needle.isEmpty {

--- a/macos/Sources/Ghostty/Surface View/SurfaceView.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView.swift
@@ -417,6 +417,10 @@ extension Ghostty {
                         // to our synced needle.
                         searchState.readPasteboardNeedle()
                     }
+                    .onSubmit {
+                        _ = surfaceView.navigateSearchToNext()
+                    }
+                    }
 #if canImport(AppKit)
                     .onExitCommand {
                         if searchState.needle.isEmpty {
@@ -429,10 +433,9 @@ extension Ghostty {
                     .backport.onKeyPress(.return) { modifiers in
                         if modifiers.contains(.shift) {
                             _ = surfaceView.navigateSearchToPrevious()
-                        } else {
-                            _ = surfaceView.navigateSearchToNext()
+                            return .handled
                         }
-                        return .handled
+                        return .ignored
                     }
 
                     Button(action: {


### PR DESCRIPTION
Closes https://github.com/ghostty-org/ghostty/discussions/12774

`.onKeyPress(.return)` unconditionally returns `.handled`, so when IME is composing the return key never reaches the IME to confirm the candidate. The search bar gets stuck.

The fix: use `.onSubmit` for the next-match navigation — it only fires when there is no composing text. In `.onKeyPress` only intercept shift+return (previous match), return `.ignored` otherwise.

Tested on macOS 26.5, Ghostty 1.3.1, built from source. Chinese Pinyin input in the search bar works correctly after the fix.