### PR TITLE
feat(macos): native per-split title bar with inline rename

### DIFF
--- a/macos/Sources/Ghostty/Surface View/SurfaceTitleBar.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceTitleBar.swift
@@ -7,13 +7,17 @@ struct SurfaceTitleBar: View {
 
     @State private var isEditing = false
     @State private var editText = ""
+    @State private var isCancelling = false
     @FocusState private var fieldFocused: Bool
 
     private var displayTitle: String {
         if surfaceView.isUserSetTitle {
             return surfaceView.title
         }
-        return URL(fileURLWithPath: surfaceView.pwd ?? "/").lastPathComponent
+        if let pwd = surfaceView.pwd, !pwd.isEmpty, pwd != "/" {
+            return URL(fileURLWithPath: pwd).lastPathComponent
+        }
+        return surfaceView.title.isEmpty ? "terminal" : surfaceView.title
     }
 
     var body: some View {
@@ -26,28 +30,41 @@ struct SurfaceTitleBar: View {
                     .textFieldStyle(.plain)
                     .multilineTextAlignment(.center)
                     .focused($fieldFocused)
-                    .onSubmit { commit() }
-                    .onExitCommand { cancel() }
+                    .onSubmit { fieldFocused = false }
+                    .onExitCommand { isCancelling = true; fieldFocused = false }
                     .onChange(of: fieldFocused) { focused in
-                        if !focused { commit() }
+                        guard !focused else { return }
+                        if isCancelling {
+                            isCancelling = false
+                            cancel()
+                        } else {
+                            commit()
+                        }
                     }
+                    .onAppear { fieldFocused = true }
                     .padding(.horizontal, 8)
+                    .font(.system(size: 11))
             } else {
                 Text(displayTitle)
                     .lineLimit(1)
                     .truncationMode(.middle)
                     .foregroundStyle(.secondary)
+                    .font(.system(size: 11))
                     .onTapGesture(count: 2) { startEditing() }
+                    .accessibilityLabel("Pane title: \(displayTitle)")
             }
         }
         .frame(height: 22)
         .frame(maxWidth: .infinity)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(isEditing ? "Title editor" : "Pane title: \(displayTitle)")
     }
 
     private func startEditing() {
         editText = surfaceView.isUserSetTitle ? surfaceView.title : ""
+        isCancelling = false
         isEditing = true
-        fieldFocused = true
+        // Focus is set via .onAppear on the TextField
     }
 
     private func commit() {

--- a/macos/Sources/Ghostty/Surface View/SurfaceTitleBar.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceTitleBar.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+
+#if canImport(AppKit)
+
+struct SurfaceTitleBar: View {
+    @ObservedObject var surfaceView: Ghostty.SurfaceView
+
+    @State private var isEditing = false
+    @State private var editText = ""
+    @FocusState private var fieldFocused: Bool
+
+    private var displayTitle: String {
+        if surfaceView.isUserSetTitle {
+            return surfaceView.title
+        }
+        return URL(fileURLWithPath: surfaceView.pwd ?? "/").lastPathComponent
+    }
+
+    var body: some View {
+        ZStack {
+            Rectangle()
+                .fill(.ultraThinMaterial)
+
+            if isEditing {
+                TextField("", text: $editText)
+                    .textFieldStyle(.plain)
+                    .multilineTextAlignment(.center)
+                    .focused($fieldFocused)
+                    .onSubmit { commit() }
+                    .onExitCommand { cancel() }
+                    .onChange(of: fieldFocused) { focused in
+                        if !focused { commit() }
+                    }
+                    .padding(.horizontal, 8)
+            } else {
+                Text(displayTitle)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .foregroundStyle(.secondary)
+                    .onTapGesture(count: 2) { startEditing() }
+            }
+        }
+        .frame(height: 22)
+        .frame(maxWidth: .infinity)
+    }
+
+    private func startEditing() {
+        editText = surfaceView.isUserSetTitle ? surfaceView.title : ""
+        isEditing = true
+        fieldFocused = true
+    }
+
+    private func commit() {
+        surfaceView.setPinnedTitle(editText.isEmpty ? nil : editText)
+        isEditing = false
+    }
+
+    private func cancel() {
+        isEditing = false
+    }
+}
+
+#endif

--- a/macos/Sources/Ghostty/Surface View/SurfaceView.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView.swift
@@ -63,7 +63,14 @@ extension Ghostty {
         var body: some View {
             let center = NotificationCenter.default
 
-            ZStack {
+            VStack(spacing: 0) {
+                #if canImport(AppKit)
+                if isSplit {
+                    SurfaceTitleBar(surfaceView: surfaceView)
+                }
+                #endif
+
+                ZStack {
                 // We use a GeometryReader to get the frame bounds so that our metal surface
                 // is up to date. See TerminalSurfaceView for why we don't use the NSView
                 // resize callback.
@@ -207,7 +214,8 @@ extension Ghostty {
                 // This is disabled except on macOS because it uses AppKit drag/drop APIs.
                 SurfaceGrabHandle(surfaceView: surfaceView)
                 #endif
-            }
+            } // closes ZStack
+            } // closes VStack
         }
     }
 

--- a/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
@@ -206,6 +206,27 @@ extension Ghostty {
         // by the user, this is set to the prior value (which may be empty, but non-nil).
         private var titleFromTerminal: String?
 
+        /// True when the user has manually pinned the title.
+        /// `SurfaceTitleBar` reads this to decide whether to show the OSC title or CWD.
+        var isUserSetTitle: Bool { titleFromTerminal != nil }
+
+        /// Set or clear the pinned title.
+        /// - Parameter newTitle: Non-empty string to pin; nil or empty to clear and restore OSC behavior.
+        func setPinnedTitle(_ newTitle: String?) {
+            if let newTitle = newTitle, !newTitle.isEmpty {
+                // Save current OSC title for restoration only on first pin.
+                if titleFromTerminal == nil {
+                    titleFromTerminal = title
+                }
+                title = newTitle
+            } else {
+                // Clear pin — restore the last OSC-provided title.
+                let prevTitle = titleFromTerminal ?? "👻"
+                titleFromTerminal = nil
+                setTitle(prevTitle)
+            }
+        }
+
         // The cached contents of the screen.
         private(set) var cachedScreenContents: CachedValue<String>
         private(set) var cachedVisibleContents: CachedValue<String>

--- a/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
@@ -204,11 +204,10 @@ extension Ghostty {
         // This is the title from the terminal. This is nil if we're currently using
         // the terminal title as the main title property. If the title is set manually
         // by the user, this is set to the prior value (which may be empty, but non-nil).
-        @Published private var titleFromTerminal: String?
+        private var titleFromTerminal: String?
 
-        /// True when the user has manually pinned the title.
-        /// `SurfaceTitleBar` reads this to decide whether to show the OSC title or CWD.
-        var isUserSetTitle: Bool { titleFromTerminal != nil }
+        /// True when the user has manually pinned the title. @Published so SurfaceTitleBar re-renders on pin state changes.
+        @Published private(set) var isUserSetTitle: Bool = false
 
         /// Set or clear the pinned title.
         /// - Parameter newTitle: Non-empty string to pin; nil or empty to clear and restore OSC behavior.
@@ -218,11 +217,15 @@ extension Ghostty {
                 if titleFromTerminal == nil {
                     titleFromTerminal = title
                 }
+                isUserSetTitle = true
                 title = newTitle
             } else {
+                // No-op if nothing is pinned.
+                guard isUserSetTitle else { return }
                 // Clear pin — restore the last OSC-provided title immediately.
                 let prevTitle = titleFromTerminal ?? "👻"
                 titleFromTerminal = nil
+                isUserSetTitle = false
                 title = prevTitle
             }
         }
@@ -569,24 +572,8 @@ extension Ghostty {
 
             let completionHandler: (NSApplication.ModalResponse) -> Void = { [weak self] response in
                 guard let self else { return }
-
-                // Check if the user clicked "OK"
-                guard response == .alertFirstButtonReturn  else { return }
-
-                // Get the input text
-                let newTitle = textField.stringValue
-                if newTitle.isEmpty {
-                    // Empty means that user wants the title to be set automatically
-                    // We also need to reload the config for the "title" property to be
-                    // used again by this tab.
-                    let prevTitle = titleFromTerminal ?? "👻"
-                    titleFromTerminal = nil
-                    setTitle(prevTitle)
-                } else {
-                    // Set the title and prevent it from being changed automatically
-                    titleFromTerminal = title
-                    title = newTitle
-                }
+                guard response == .alertFirstButtonReturn else { return }
+                self.setPinnedTitle(textField.stringValue.isEmpty ? nil : textField.stringValue)
             }
 
             // We prefer to run our alert in a sheet modal if we have a window.
@@ -1851,6 +1838,7 @@ extension Ghostty {
                 // If this was a user-set title, we need to prevent it from being overwritten
                 if isUserSetTitle {
                     self.titleFromTerminal = title
+                    self.isUserSetTitle = true
                 }
             }
         }
@@ -1860,7 +1848,7 @@ extension Ghostty {
             try container.encode(pwd, forKey: .pwd)
             try container.encode(id.uuidString, forKey: .uuid)
             try container.encode(title, forKey: .title)
-            try container.encode(titleFromTerminal != nil, forKey: .isUserSetTitle)
+            try container.encode(isUserSetTitle, forKey: .isUserSetTitle)
         }
     }
 }

--- a/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
@@ -213,7 +213,9 @@ extension Ghostty {
         /// - Parameter newTitle: Non-empty string to pin; nil or empty to clear and restore OSC behavior.
         func setPinnedTitle(_ newTitle: String?) {
             if let newTitle = newTitle, !newTitle.isEmpty {
-                // Save current OSC title for restoration only on first pin.
+                // Save the pre-pin OSC title for restoration, but only on first pin.
+                // On re-pin (changing an already-pinned title), titleFromTerminal already
+                // holds the original OSC title — don't overwrite it or we lose the restore point.
                 if titleFromTerminal == nil {
                     titleFromTerminal = title
                 }
@@ -1837,6 +1839,9 @@ extension Ghostty {
                 self.title = title
                 // If this was a user-set title, we need to prevent it from being overwritten
                 if isUserSetTitle {
+                    // Known limitation: after session restore, titleFromTerminal holds the pinned
+                    // string (not the original pre-pin OSC title). Un-pinning post-restore will
+                    // show the pinned title briefly until the shell emits its next OSC sequence.
                     self.titleFromTerminal = title
                     self.isUserSetTitle = true
                 }

--- a/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
@@ -204,7 +204,7 @@ extension Ghostty {
         // This is the title from the terminal. This is nil if we're currently using
         // the terminal title as the main title property. If the title is set manually
         // by the user, this is set to the prior value (which may be empty, but non-nil).
-        private var titleFromTerminal: String?
+        @Published private var titleFromTerminal: String?
 
         /// True when the user has manually pinned the title.
         /// `SurfaceTitleBar` reads this to decide whether to show the OSC title or CWD.
@@ -220,10 +220,10 @@ extension Ghostty {
                 }
                 title = newTitle
             } else {
-                // Clear pin — restore the last OSC-provided title.
+                // Clear pin — restore the last OSC-provided title immediately.
                 let prevTitle = titleFromTerminal ?? "👻"
                 titleFromTerminal = nil
-                setTitle(prevTitle)
+                title = prevTitle
             }
         }
 


### PR DESCRIPTION
Closes #1541

Adds a native per-split title bar to the macOS app — a 22px strip above each split surface showing the current working directory. Double-clicking the strip opens an inline text field to pin a custom name; pressing Enter commits it, Esc cancels, and clicking away commits.

## What changes

**`SurfaceView_AppKit.swift`** — exposes `isUserSetTitle: Bool` and `setPinnedTitle(_:)` over the existing `titleFromTerminal` pin mechanism. The pin guard was already there (it blocks OSC sequences from overwriting a user-set title); this just makes it accessible.

**`SurfaceTitleBar.swift`** (new) — SwiftUI view. Observes `SurfaceView` via `@ObservedObject` so it re-renders on title/pwd changes. Uses a `isCancelling` flag to distinguish Esc (cancel) from blur (commit) since both fire `onChange(of: fieldFocused)`. Focus is applied via `.onAppear` on the `TextField` rather than synchronously, because the view isn't in the tree yet when `startEditing()` runs.

**`SurfaceView.swift`** — wraps `SurfaceWrapper.body`'s `ZStack` in a `VStack(spacing: 0)` and prepends `SurfaceTitleBar` when `isSplit == true`. Single-pane windows are unaffected.

## AI disclosure

Implemented with Claude Code assistance (Anthropic). All code reviewed and understood by the author.