### PR TITLE
elvish: remove community maintenance note

### DIFF
--- a/src/shell-integration/README.md
+++ b/src/shell-integration/README.md
@@ -61,12 +61,6 @@ if (eq $E:TERM "xterm-ghostty") {
 }
 ```
 
-The [Elvish](https://elv.sh) shell integration is supported by
-the community and is not officially supported by Ghostty. We distribute
-it for ease of access and use but do not provide support for it.
-If you experience issues with the Elvish shell integration, I welcome
-any contributions to fix them. Thank you!
-
 ### Fish
 
 For [Fish](https://fishshell.com/), Ghostty prepends to the


### PR DESCRIPTION
The Elvish integration is currently actively maintained by the Ghostty maintainers. Contributions are of course still welcome.