### PR TITLE
macOS: clear stale OSC 11 background cache on config change

### DIFF
--- a/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
@@ -725,7 +725,19 @@ extension Ghostty {
 
             // Update our derived config
             DispatchQueue.main.async { [weak self] in
-                self?.derivedConfig = DerivedConfig(config)
+                guard let self else { return }
+                self.derivedConfig = DerivedConfig(config)
+
+                // If the cached OSC 11 background color disagrees with the new
+                // config-derived background, drop it so window chrome follows
+                // the new config (e.g., on light/dark theme auto-switch). The
+                // cached value is restored next time the terminal emits a
+                // color_change.
+                if let cached = self.backgroundColor,
+                   cached != self.derivedConfig.backgroundColor
+                {
+                    self.backgroundColor = nil
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

`SurfaceView` caches the background color set by OSC 11 in `backgroundColor`. `TerminalWindow.preferredBackgroundColor` consults that cache before falling back to `derivedConfig.backgroundColor`, so once OSC 11 has fired the cached value masks any later config change.

After a light/dark theme auto-switch (e.g. `theme = light:my-light,dark:my-dark`) this leaves the window chrome on the previous theme's color until the application next emits OSC 11.

In `ghosttyConfigDidChange`, after updating `derivedConfig`, drop the cache when it no longer matches the new config-derived background. A subsequent `ghosttyColorDidChange` repopulates it as before, so within-config OSC 11 behavior is unchanged.

## Reproduction

1. Configure `theme = light:SomeLight,dark:SomeDark` where the two themes have visibly different background colors.
2. Open a terminal session where any application (e.g. a shell startup script) has sent OSC 11 to set a custom background color.
3. Switch macOS appearance (System Settings → Appearance).
4. **Before**: window chrome stays the previous theme's color until the terminal next emits OSC 11.
5. **After**: window chrome immediately updates to the new theme's background color.

## Changes

- `SurfaceView_AppKit.swift` — one guard: if the cached `backgroundColor` disagrees with the new `derivedConfig.backgroundColor`, set it to `nil`.