### PR TITLE
macOS: improve logging experience for developers

### DIFF
--- a/src/App.zig
+++ b/src/App.zig
@@ -16,7 +16,7 @@ const BlockingQueue = @import("datastruct/main.zig").BlockingQueue;
 const renderer = @import("renderer.zig");
 const font = @import("font/main.zig");
 
-const log = std.log.scoped(.app);
+const log = @import("log.zig").scoped(.app);
 
 const SurfaceList = std.ArrayListUnmanaged(*apprt.Surface);
 

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -38,7 +38,7 @@ const inspectorpkg = @import("inspector/main.zig");
 const SurfaceMouse = @import("surface_mouse.zig");
 const ProcessInfo = @import("pty.zig").ProcessInfo;
 
-const log = std.log.scoped(.surface);
+const log = @import("log.zig").scoped(.surface);
 
 // The renderer implementation to use.
 const Renderer = rendererpkg.Renderer;

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -22,7 +22,7 @@ const configpkg = @import("../config.zig");
 const Config = configpkg.Config;
 const String = @import("../main_c.zig").String;
 
-const log = std.log.scoped(.embedded_window);
+const log = @import("../log.zig").scoped(.embedded_window);
 
 pub const resourcesDir = internal_os.resourcesDir;
 

--- a/src/benchmark/CApi.zig
+++ b/src/benchmark/CApi.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const cli = @import("cli.zig");
 const state = &@import("../global.zig").state;
 
-const log = std.log.scoped(.benchmark);
+const log = @import("../log.zig").scoped(.benchmark);
 
 /// Run the Ghostty benchmark CLI with the given action and arguments.
 export fn ghostty_benchmark_cli(

--- a/src/benchmark/CodepointWidth.zig
+++ b/src/benchmark/CodepointWidth.zig
@@ -15,7 +15,7 @@ const UTF8Decoder = @import("../terminal/UTF8Decoder.zig");
 const simd = @import("../simd/main.zig");
 const table = @import("../unicode/main.zig").table;
 
-const log = std.log.scoped(.@"terminal-stream-bench");
+const log = @import("../log.zig").scoped(.@"terminal-stream-bench");
 
 opts: Options,
 

--- a/src/benchmark/GraphemeBreak.zig
+++ b/src/benchmark/GraphemeBreak.zig
@@ -12,7 +12,7 @@ const UTF8Decoder = @import("../terminal/UTF8Decoder.zig");
 const unicode = @import("../unicode/main.zig");
 const uucode = @import("uucode");
 
-const log = std.log.scoped(.@"terminal-stream-bench");
+const log = @import("../log.zig").scoped(.@"terminal-stream-bench");
 
 opts: Options,
 

--- a/src/benchmark/IsSymbol.zig
+++ b/src/benchmark/IsSymbol.zig
@@ -12,7 +12,7 @@ const UTF8Decoder = @import("../terminal/UTF8Decoder.zig");
 const uucode = @import("uucode");
 const symbols_table = @import("../unicode/symbols_table.zig").table;
 
-const log = std.log.scoped(.@"is-symbol-bench");
+const log = @import("../log.zig").scoped(.@"is-symbol-bench");
 
 opts: Options,
 

--- a/src/benchmark/OscParser.zig
+++ b/src/benchmark/OscParser.zig
@@ -8,7 +8,7 @@ const Allocator = std.mem.Allocator;
 const Benchmark = @import("Benchmark.zig");
 const options = @import("options.zig");
 const Parser = @import("../terminal/osc.zig").Parser;
-const log = std.log.scoped(.@"osc-parser-bench");
+const log = @import("../log.zig").scoped(.@"osc-parser-bench");
 
 opts: Options,
 

--- a/src/benchmark/ScreenClone.zig
+++ b/src/benchmark/ScreenClone.zig
@@ -12,7 +12,7 @@ const Benchmark = @import("Benchmark.zig");
 const options = @import("options.zig");
 const Terminal = terminalpkg.Terminal;
 
-const log = std.log.scoped(.@"terminal-stream-bench");
+const log = @import("../log.zig").scoped(.@"terminal-stream-bench");
 
 opts: Options,
 terminal: Terminal,

--- a/src/benchmark/TerminalParser.zig
+++ b/src/benchmark/TerminalParser.zig
@@ -8,7 +8,7 @@ const terminalpkg = @import("../terminal/main.zig");
 const Benchmark = @import("Benchmark.zig");
 const options = @import("options.zig");
 
-const log = std.log.scoped(.@"terminal-stream-bench");
+const log = @import("../log.zig").scoped(.@"terminal-stream-bench");
 
 opts: Options,
 

--- a/src/benchmark/TerminalStream.zig
+++ b/src/benchmark/TerminalStream.zig
@@ -22,7 +22,7 @@ const options = @import("options.zig");
 const Terminal = terminalpkg.Terminal;
 const Stream = terminalpkg.Stream(*Handler);
 
-const log = std.log.scoped(.@"terminal-stream-bench");
+const log = @import("../log.zig").scoped(.@"terminal-stream-bench");
 
 opts: Options,
 terminal: Terminal,

--- a/src/cli/args.zig
+++ b/src/cli/args.zig
@@ -9,7 +9,7 @@ const Diagnostic = diags.Diagnostic;
 const DiagnosticList = diags.DiagnosticList;
 const CommaSplitter = @import("CommaSplitter.zig");
 
-const log = std.log.scoped(.cli);
+const log = @import("../log.zig").scoped(.cli);
 
 // TODO:
 //   - Only `--long=value` format is accepted. Do we want to allow

--- a/src/cli/list_fonts.zig
+++ b/src/cli/list_fonts.zig
@@ -5,7 +5,7 @@ const Action = @import("ghostty.zig").Action;
 const args = @import("args.zig");
 const font = @import("../font/main.zig");
 
-const log = std.log.scoped(.list_fonts);
+const log = @import("../log.zig").scoped(.list_fonts);
 
 pub const Options = struct {
     /// This is set by the CLI parser for deinit.

--- a/src/cli/ssh.zig
+++ b/src/cli/ssh.zig
@@ -8,7 +8,7 @@ const DiskCache = @import("ssh_cache.zig").DiskCache;
 const internal_os = @import("../os/main.zig");
 const ghostty_terminfo = @import("../terminfo/main.zig").ghostty;
 
-const log = std.log.scoped(.ssh);
+const log = @import("../log.zig").scoped(.ssh);
 
 const usage =
     \\Usage: ghostty +ssh [flags] [--] <ssh args...>

--- a/src/config/CApi.zig
+++ b/src/config/CApi.zig
@@ -9,7 +9,7 @@ const c_get = @import("c_get.zig");
 const edit = @import("edit.zig");
 const Key = @import("key.zig").Key;
 
-const log = std.log.scoped(.config);
+const log = @import("../log.zig").scoped(.config);
 
 /// Create a new configuration filled with the initial default values.
 export fn ghostty_config_new() ?*Config {

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -54,7 +54,7 @@ const terminal = struct {
     const x11_color = @import("../terminal/x11_color.zig");
 };
 
-const log = std.log.scoped(.config);
+const log = @import("../log.zig").scoped(.config);
 
 /// Used on Unixes for some defaults.
 const c = @cImport({

--- a/src/config/Wasm.zig
+++ b/src/config/Wasm.zig
@@ -5,7 +5,7 @@ const alloc = wasm.alloc;
 
 const Config = @import("Config.zig");
 
-const log = std.log.scoped(.config);
+const log = @import("../log.zig").scoped(.config);
 
 /// Create a new configuration filled with the initial default values.
 export fn config_new() ?*Config {

--- a/src/config/file_load.zig
+++ b/src/config/file_load.zig
@@ -4,7 +4,7 @@ const assert = @import("../quirks.zig").inlineAssert;
 const Allocator = std.mem.Allocator;
 const internal_os = @import("../os/main.zig");
 
-const log = std.log.scoped(.config);
+const log = @import("../log.zig").scoped(.config);
 
 /// Default path for the XDG home configuration file. Returned value
 /// must be freed by the caller.

--- a/src/config/path.zig
+++ b/src/config/path.zig
@@ -8,7 +8,7 @@ const cli = @import("../cli.zig");
 const internal_os = @import("../os/main.zig");
 const formatterpkg = @import("formatter.zig");
 
-const log = std.log.scoped(.config);
+const log = @import("../log.zig").scoped(.config);
 
 pub const ParseError = error{ValueRequired} || Allocator.Error;
 

--- a/src/crash/sentry.zig
+++ b/src/crash/sentry.zig
@@ -10,7 +10,7 @@ const crash = @import("main.zig");
 const state = &@import("../global.zig").state;
 const Surface = @import("../Surface.zig");
 
-const log = std.log.scoped(.sentry);
+const log = @import("../log.zig").scoped(.sentry);
 
 /// The global state for the Sentry SDK. This is unavoidable since crash
 /// handling is a global process-wide thing.

--- a/src/crash/sentry_envelope.zig
+++ b/src/crash/sentry_envelope.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const assert = std.debug.assert;
 const Allocator = std.mem.Allocator;
 
-const log = std.log.scoped(.sentry_envelope);
+const log = @import("../log.zig").scoped(.sentry_envelope);
 
 /// The Sentry Envelope format: https://develop.sentry.dev/sdk/envelopes/
 ///

--- a/src/font/Atlas.zig
+++ b/src/font/Atlas.zig
@@ -22,7 +22,7 @@ const testing = std.testing;
 const fastmem = @import("../fastmem.zig");
 const tripwire = @import("../tripwire.zig");
 
-const log = std.log.scoped(.atlas);
+const log = @import("../log.zig").scoped(.atlas);
 
 /// Data is the raw texture data.
 data: []u8,

--- a/src/font/CodepointResolver.zig
+++ b/src/font/CodepointResolver.zig
@@ -28,7 +28,7 @@ const RenderOptions = font.Glyph.RenderOptions;
 const SpriteFace = font.SpriteFace;
 const Style = font.Style;
 
-const log = std.log.scoped(.font_codepoint_resolver);
+const log = @import("../log.zig").scoped(.font_codepoint_resolver);
 
 /// The underlying collection of fonts. This will be modified as
 /// new fonts are found via the resolver. The resolver takes ownership

--- a/src/font/Collection.zig
+++ b/src/font/Collection.zig
@@ -29,7 +29,7 @@ const Metrics = font.Metrics;
 const Presentation = font.Presentation;
 const Style = font.Style;
 
-const log = std.log.scoped(.font_collection);
+const log = @import("../log.zig").scoped(.font_collection);
 
 /// The available faces we have. This shouldn't be modified manually.
 /// Instead, use the functions available on Collection.

--- a/src/font/DeferredFace.zig
+++ b/src/font/DeferredFace.zig
@@ -16,7 +16,7 @@ const Library = @import("main.zig").Library;
 const Face = @import("main.zig").Face;
 const Presentation = @import("main.zig").Presentation;
 
-const log = std.log.scoped(.deferred_face);
+const log = @import("../log.zig").scoped(.deferred_face);
 
 /// Fontconfig
 fc: if (options.backend == .fontconfig_freetype) ?Fontconfig else void =

--- a/src/font/SharedGrid.zig
+++ b/src/font/SharedGrid.zig
@@ -35,7 +35,7 @@ const Presentation = font.Presentation;
 const Style = font.Style;
 const RenderOptions = font.Glyph.RenderOptions;
 
-const log = std.log.scoped(.font_shared_grid);
+const log = @import("../log.zig").scoped(.font_shared_grid);
 
 /// Cache for codepoints to font indexes in a group.
 codepoints: std.AutoHashMapUnmanaged(CodepointKey, ?Collection.Index) = .{},

--- a/src/font/SharedGridSet.zig
+++ b/src/font/SharedGridSet.zig
@@ -29,7 +29,7 @@ const discovery = @import("discovery.zig");
 const configpkg = @import("../config.zig");
 const Config = configpkg.Config;
 
-const log = std.log.scoped(.font_shared_grid_set);
+const log = @import("../log.zig").scoped(.font_shared_grid_set);
 
 /// The allocator to use for all heap allocations.
 alloc: Allocator,

--- a/src/font/discovery.zig
+++ b/src/font/discovery.zig
@@ -13,7 +13,7 @@ const Library = @import("main.zig").Library;
 const Presentation = @import("main.zig").Presentation;
 const Variation = @import("main.zig").face.Variation;
 
-const log = std.log.scoped(.discovery);
+const log = @import("../log.zig").scoped(.discovery);
 
 /// Discover implementation for the compile options.
 pub const Discover = switch (options.backend) {

--- a/src/font/face/coretext.zig
+++ b/src/font/face/coretext.zig
@@ -8,7 +8,7 @@ const font = @import("../main.zig");
 const opentype = @import("../opentype.zig");
 const quirks = @import("../../quirks.zig");
 
-const log = std.log.scoped(.font_face);
+const log = @import("../../log.zig").scoped(.font_face);
 
 pub const Face = struct {
     /// Our font face

--- a/src/font/face/freetype.zig
+++ b/src/font/face/freetype.zig
@@ -21,7 +21,7 @@ const config = @import("../../config.zig");
 
 const F26Dot6 = opentype.sfnt.F26Dot6;
 
-const log = std.log.scoped(.font_face);
+const log = @import("../../log.zig").scoped(.font_face);
 
 pub const Face = struct {
     comptime {

--- a/src/font/face/web_canvas.zig
+++ b/src/font/face/web_canvas.zig
@@ -5,7 +5,7 @@ const Allocator = std.mem.Allocator;
 const js = @import("zig-js");
 const font = @import("../main.zig");
 
-const log = std.log.scoped(.font_face);
+const log = @import("../../log.zig").scoped(.font_face);
 
 pub const Face = struct {
     /// See graphemes field for more details.

--- a/src/font/shaper/Cache.zig
+++ b/src/font/shaper/Cache.zig
@@ -15,7 +15,7 @@ const Allocator = std.mem.Allocator;
 const font = @import("../main.zig");
 const CacheTable = @import("../../datastruct/main.zig").CacheTable;
 
-const log = std.log.scoped(.font_shaper_cache);
+const log = @import("../../log.zig").scoped(.font_shaper_cache);
 
 /// Context for cache table.
 const CellCacheTableContext = struct {

--- a/src/font/shaper/coretext.zig
+++ b/src/font/shaper/coretext.zig
@@ -21,7 +21,7 @@ const Style = font.Style;
 const Presentation = font.Presentation;
 const CFReleaseThread = os.CFReleaseThread;
 
-const log = std.log.scoped(.font_shaper);
+const log = @import("../../log.zig").scoped(.font_shaper);
 
 /// Shaper that uses CoreText.
 ///

--- a/src/font/shaper/feature.zig
+++ b/src/font/shaper/feature.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const assert = @import("../../quirks.zig").inlineAssert;
 const Allocator = std.mem.Allocator;
 
-const log = std.log.scoped(.font_shaper);
+const log = @import("../../log.zig").scoped(.font_shaper);
 
 /// Represents an OpenType font feature setting, which consists of a tag and
 /// a numeric parameter >= 0. Most features are boolean, so only parameters

--- a/src/font/shaper/harfbuzz.zig
+++ b/src/font/shaper/harfbuzz.zig
@@ -16,7 +16,7 @@ const SharedGrid = font.SharedGrid;
 const Style = font.Style;
 const Presentation = font.Presentation;
 
-const log = std.log.scoped(.font_shaper);
+const log = @import("../../log.zig").scoped(.font_shaper);
 
 /// Shaper that uses Harfbuzz.
 pub const Shaper = struct {

--- a/src/font/shaper/noop.zig
+++ b/src/font/shaper/noop.zig
@@ -12,7 +12,7 @@ const Style = font.Style;
 const Presentation = font.Presentation;
 const terminal = @import("../../terminal/main.zig");
 
-const log = std.log.scoped(.font_shaper);
+const log = @import("../../log.zig").scoped(.font_shaper);
 
 /// Shaper that doesn't do any shaping. Each individual codepoint is mapped
 /// directly to the detected text run font's glyph index.

--- a/src/font/shaper/web_canvas.zig
+++ b/src/font/shaper/web_canvas.zig
@@ -6,7 +6,7 @@ const terminal = @import("../../terminal/main.zig");
 const unicode = @import("../../unicode/main.zig");
 const uucode = @import("uucode");
 
-const log = std.log.scoped(.font_shaper);
+const log = @import("../../log.zig").scoped(.font_shaper);
 
 pub const Shaper = struct {
     const RunBuf = std.MultiArrayList(struct {

--- a/src/font/sprite/Face.zig
+++ b/src/font/sprite/Face.zig
@@ -22,7 +22,7 @@ const Sprite = font.sprite.Sprite;
 
 const special = @import("draw/special.zig");
 
-const log = std.log.scoped(.font_sprite);
+const log = @import("../../log.zig").scoped(.font_sprite);
 
 /// Grid metrics for rendering sprites.
 metrics: font.Metrics,

--- a/src/font/sprite/draw/common.zig
+++ b/src/font/sprite/draw/common.zig
@@ -8,7 +8,7 @@ const Allocator = std.mem.Allocator;
 
 const font = @import("../../main.zig");
 
-const log = std.log.scoped(.sprite_font);
+const log = @import("../../../log.zig").scoped(.sprite_font);
 
 // Utility names for common fractions
 pub const one_eighth: f64 = 0.125;

--- a/src/input/mouse_encode.zig
+++ b/src/input/mouse_encode.zig
@@ -7,7 +7,7 @@ const point = @import("../terminal/point.zig");
 const key = @import("key.zig");
 const mouse = @import("mouse.zig");
 
-const log = std.log.scoped(.mouse_encode);
+const log = @import("../log.zig").scoped(.mouse_encode);
 
 /// Options that affect mouse encoding behavior and provide runtime context.
 pub const Options = struct {

--- a/src/inspector/widgets/renderer.zig
+++ b/src/inspector/widgets/renderer.zig
@@ -4,7 +4,7 @@ const cimgui = @import("dcimgui");
 const widgets = @import("../widgets.zig");
 const renderer = @import("../../renderer.zig");
 
-const log = std.log.scoped(.inspector_renderer);
+const log = @import("../../log.zig").scoped(.inspector_renderer);
 
 /// Renderer information inspector widget.
 pub const Info = struct {

--- a/src/log.zig
+++ b/src/log.zig
@@ -1,0 +1,173 @@
+//! Logging wrapper that mirrors `std.log.scoped`. On Darwin debug
+//! builds it additionally delivers each entry to Apple's unified
+//! logging via an inline `_os_log_impl` call so DWARF resolves the
+//! call site to the original Zig source — that's what makes Xcode's
+//! Jump to Source land on the right file:line during development.
+//!
+//! Release builds skip the inline SPI path and let the standard log
+//! pipeline (logFn → `os_log_with_type` C wrapper) deliver os_log
+//! entries using only public API. The trade-off is that release
+//! builds attribute the log call site to the C wrapper.
+//!
+//! Non-Darwin targets are a pass-through to `std.log.scoped`.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const build_config = @import("build_config.zig");
+const state = &@import("global.zig").state;
+
+const inline_oslog = builtin.target.os.tag.isDarwin() and builtin.mode == .Debug;
+
+pub fn scoped(comptime scope: @Type(.enum_literal)) type {
+    const inner = std.log.scoped(scope);
+    return struct {
+        pub inline fn err(
+            comptime format: []const u8,
+            args: anytype,
+        ) void {
+            if (comptime inline_oslog) emitDarwin(scope, .err, format, args);
+            inner.err(format, args);
+        }
+
+        pub inline fn warn(
+            comptime format: []const u8,
+            args: anytype,
+        ) void {
+            if (comptime inline_oslog) emitDarwin(scope, .warn, format, args);
+            inner.warn(format, args);
+        }
+
+        pub inline fn info(
+            comptime format: []const u8,
+            args: anytype,
+        ) void {
+            if (comptime inline_oslog) emitDarwin(scope, .info, format, args);
+            inner.info(format, args);
+        }
+
+        pub inline fn debug(
+            comptime format: []const u8,
+            args: anytype,
+        ) void {
+            if (comptime inline_oslog) emitDarwin(scope, .debug, format, args);
+            inner.debug(format, args);
+        }
+    };
+}
+
+const LogType = enum(u8) {
+    default = 0x00,
+    info = 0x01,
+    debug = 0x02,
+    err = 0x10,
+    fault = 0x11,
+};
+
+const OsLog = opaque {};
+
+extern "c" fn os_log_create(
+    subsystem: [*:0]const u8,
+    category: [*:0]const u8,
+) ?*OsLog;
+extern "c" fn os_release(*OsLog) void;
+
+extern "c" fn _os_log_impl(
+    dso: *const anyopaque,
+    log: *OsLog,
+    log_type: u8,
+    format: [*]const u8,
+    buf: [*]const u8,
+    size: u32,
+) callconv(.c) void;
+
+const oslog_fmt_public_s: [10:0]u8 linksection("__TEXT,__oslogstring") = "%{public}s".*;
+
+const Dl_info = extern struct {
+    dli_fname: ?[*:0]const u8,
+    dli_fbase: ?*const anyopaque,
+    dli_sname: ?[*:0]const u8,
+    dli_saddr: ?*const anyopaque,
+};
+
+extern "c" fn dladdr(addr: *const anyopaque, info: *Dl_info) c_int;
+
+/// Mach-O header of the image we're linked into, for `_os_log_impl`.
+/// `__dso_handle` is unusable (Zig defines its own placeholder in the
+/// data segment) and `_dyld_get_image_header(0)` returns the main
+/// executable's header instead of ours when this code lives in a dylib
+/// like ghostty.debug.dylib.
+inline fn dsoHandle() *const anyopaque {
+    var info: Dl_info = undefined;
+    _ = dladdr(&oslog_fmt_public_s, &info);
+    return info.dli_fbase.?;
+}
+
+inline fn emitDarwin(
+    comptime scope: @Type(.enum_literal),
+    comptime level: std.log.Level,
+    comptime format: []const u8,
+    args: anytype,
+) void {
+    @setEvalBranchQuota(10_000);
+
+    if (!state.logging.macos) return;
+
+    const log = getScopedLog(scope) orelse return;
+
+    var stack_buf: [4096]u8 = undefined;
+    const msg = std.fmt.bufPrintZ(
+        &stack_buf,
+        format,
+        args,
+    ) catch return;
+
+    var buf: [12]u8 align(8) = undefined;
+    buf[0] = 0x02;
+    buf[1] = 0x01;
+    buf[2] = 0x22;
+    buf[3] = 0x08;
+    @as(*align(1) [*:0]const u8, @ptrCast(&buf[4])).* = msg.ptr;
+
+    _os_log_impl(
+        dsoHandle(),
+        log,
+        @intFromEnum(comptime macLevel(level)),
+        &oslog_fmt_public_s,
+        &buf,
+        buf.len,
+    );
+}
+
+inline fn macLevel(comptime level: std.log.Level) LogType {
+    return comptime switch (level) {
+        .debug => .debug,
+        .info => .info,
+        .warn => .err,
+        .err => .fault,
+    };
+}
+
+inline fn getScopedLog(comptime scope: @Type(.enum_literal)) ?*OsLog {
+    const Slot = struct {
+        var cached: std.atomic.Value(usize) = std.atomic.Value(usize).init(0);
+    };
+
+    const existing = Slot.cached.load(.acquire);
+    if (existing != 0) return @ptrFromInt(existing);
+
+    const fresh = os_log_create(
+        build_config.bundle_id,
+        @tagName(scope),
+    ) orelse return null;
+
+    if (Slot.cached.cmpxchgStrong(
+        0,
+        @intFromPtr(fresh),
+        .acq_rel,
+        .acquire,
+    )) |winner| {
+        os_release(fresh);
+        return @ptrFromInt(winner);
+    }
+    return fresh;
+}

--- a/src/main_ghostty.zig
+++ b/src/main_ghostty.zig
@@ -125,6 +125,10 @@ fn logFn(
     // macOS logging is thread safe so no need for locks/mutexes
     macos: {
         if (comptime !builtin.target.os.tag.isDarwin()) break :macos;
+        // Debug builds skip this branch — log.zig's inline path
+        // handles os_log delivery there instead, so DWARF can resolve the
+        // call site to Zig source for Xcode's Jump to Source.
+        if (comptime builtin.mode == .Debug) break :macos;
         if (!state.logging.macos) break :macos;
 
         const prefix = if (scope == .default) "" else @tagName(scope) ++ ": ";

--- a/src/os/TempDir.zig
+++ b/src/os/TempDir.zig
@@ -6,7 +6,7 @@ const std = @import("std");
 const Dir = std.fs.Dir;
 const file = @import("file.zig");
 
-const log = std.log.scoped(.tempdir);
+const log = @import("../log.zig").scoped(.tempdir);
 
 /// Dir is the directory handle
 dir: Dir,

--- a/src/os/cf_release_thread.zig
+++ b/src/os/cf_release_thread.zig
@@ -13,7 +13,7 @@ const xev = @import("../global.zig").xev;
 const BlockingQueue = @import("../datastruct/main.zig").BlockingQueue;
 
 const Allocator = std.mem.Allocator;
-const log = std.log.scoped(.cf_release_thread);
+const log = @import("../log.zig").scoped(.cf_release_thread);
 
 pub const Message = union(enum) {
     /// Release a slice of CFTypeRefs. Uses alloc to free the slice after

--- a/src/os/cgroup.zig
+++ b/src/os/cgroup.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 
-const log = std.log.scoped(.@"linux-cgroup");
+const log = @import("../log.zig").scoped(.@"linux-cgroup");
 
 /// Returns the path to the cgroup for the given pid.
 pub fn current(buf: []u8, pid: u32) ?[]const u8 {

--- a/src/os/file.zig
+++ b/src/os/file.zig
@@ -3,7 +3,7 @@ const builtin = @import("builtin");
 const posix = std.posix;
 const windows = @import("windows.zig");
 
-const log = std.log.scoped(.os);
+const log = @import("../log.zig").scoped(.os);
 
 pub const rlimit = if (@hasDecl(posix.system, "rlimit")) posix.rlimit else struct {};
 

--- a/src/os/flatpak.zig
+++ b/src/os/flatpak.zig
@@ -4,7 +4,7 @@ const builtin = @import("builtin");
 const posix = std.posix;
 const xev = @import("../global.zig").xev;
 
-const log = std.log.scoped(.flatpak);
+const log = @import("../log.zig").scoped(.flatpak);
 
 /// Returns true if we're running in a Flatpak environment.
 pub fn isFlatpak() bool {

--- a/src/os/i18n.zig
+++ b/src/os/i18n.zig
@@ -3,7 +3,7 @@ const builtin = @import("builtin");
 const build_config = @import("../build_config.zig");
 const locales = @import("i18n_locales.zig");
 
-const log = std.log.scoped(.i18n);
+const log = @import("../log.zig").scoped(.i18n);
 
 /// Set for faster membership lookup of locales.
 pub const locales_map = map: {

--- a/src/os/locale.zig
+++ b/src/os/locale.zig
@@ -6,7 +6,7 @@ const objc = @import("objc");
 const internal_os = @import("main.zig");
 const i18n = internal_os.i18n;
 
-const log = std.log.scoped(.os_locale);
+const log = @import("../log.zig").scoped(.os_locale);
 
 /// Ensure that the locale is set.
 pub fn ensureLocale(alloc: std.mem.Allocator) !void {

--- a/src/os/mouse.zig
+++ b/src/os/mouse.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const objc = @import("objc");
 
-const log = std.log.scoped(.os);
+const log = @import("../log.zig").scoped(.os);
 
 /// The system-configured double-click interval if its available.
 pub fn clickInterval() ?u32 {

--- a/src/os/open.zig
+++ b/src/os/open.zig
@@ -4,7 +4,7 @@ const Allocator = std.mem.Allocator;
 const build_config = @import("../build_config.zig");
 const apprt = @import("../apprt.zig");
 
-const log = std.log.scoped(.@"os-open");
+const log = @import("../log.zig").scoped(.@"os-open");
 
 /// Open a URL in the default handling application.
 ///

--- a/src/os/passwd.zig
+++ b/src/os/passwd.zig
@@ -6,7 +6,7 @@ const Allocator = std.mem.Allocator;
 const ArenaAllocator = std.heap.ArenaAllocator;
 const posix = std.posix;
 
-const log = std.log.scoped(.passwd);
+const log = @import("../log.zig").scoped(.passwd);
 
 // We want to be extra sure since this will force bad symbols into our import table
 comptime {

--- a/src/os/systemd.zig
+++ b/src/os/systemd.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 
-const log = std.log.scoped(.systemd);
+const log = @import("../log.zig").scoped(.systemd);
 
 /// Returns true if the program was launched as a systemd service.
 ///

--- a/src/pty.zig
+++ b/src/pty.zig
@@ -4,7 +4,7 @@ const windows = @import("os/main.zig").windows;
 const posix = std.posix;
 const assert = @import("quirks.zig").inlineAssert;
 
-const log = std.log.scoped(.pty);
+const log = @import("log.zig").scoped(.pty);
 
 /// Redeclare this winsize struct so we can just use a Zig struct. This
 /// layout should be correct on all tested platforms. The defaults on this

--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -36,7 +36,7 @@ pub const custom_shader_y_is_down = true;
 /// Triple buffering.
 pub const swap_chain_count = 3;
 
-const log = std.log.scoped(.metal);
+const log = @import("../log.zig").scoped(.metal);
 
 layer: IOSurfaceLayer,
 

--- a/src/renderer/OpenGL.zig
+++ b/src/renderer/OpenGL.zig
@@ -31,7 +31,7 @@ pub const custom_shader_y_is_down = false;
 /// sync, we have no need for multi-buffering.
 pub const swap_chain_count = 1;
 
-const log = std.log.scoped(.opengl);
+const log = @import("../log.zig").scoped(.opengl);
 
 /// We require at least OpenGL 4.3
 pub const MIN_VERSION_MAJOR = 4;

--- a/src/renderer/Overlay.zig
+++ b/src/renderer/Overlay.zig
@@ -21,7 +21,7 @@ const Size = size.Size;
 const CellSize = size.CellSize;
 const Image = @import("image.zig").Image;
 
-const log = std.log.scoped(.renderer_overlay);
+const log = @import("../log.zig").scoped(.renderer_overlay);
 
 /// The colors we use for overlays.
 pub const Color = enum {

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -14,7 +14,7 @@ const BlockingQueue = @import("../datastruct/main.zig").BlockingQueue;
 const App = @import("../App.zig");
 
 const Allocator = std.mem.Allocator;
-const log = std.log.scoped(.renderer_thread);
+const log = @import("../log.zig").scoped(.renderer_thread);
 
 const DRAW_INTERVAL = 8; // 120 FPS
 const CURSOR_BLINK_INTERVAL = 600;

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -41,7 +41,7 @@ const DisplayLink = switch (builtin.os.tag) {
     else => void,
 };
 
-const log = std.log.scoped(.generic_renderer);
+const log = @import("../log.zig").scoped(.generic_renderer);
 
 /// Create a renderer type with the provided graphics API wrapper.
 ///

--- a/src/renderer/image.zig
+++ b/src/renderer/image.zig
@@ -10,7 +10,7 @@ const Texture = GraphicsAPI.Texture;
 const CellSize = @import("size.zig").CellSize;
 const Overlay = @import("Overlay.zig");
 
-const log = std.log.scoped(.renderer_image);
+const log = @import("../log.zig").scoped(.renderer_image);
 
 /// Generic image rendering state for the renderer. This stores all
 /// images and their placements and exposes only a limited public API

--- a/src/renderer/link.zig
+++ b/src/renderer/link.zig
@@ -8,7 +8,7 @@ const point = terminal.point;
 const Screen = terminal.Screen;
 const Terminal = terminal.Terminal;
 
-const log = std.log.scoped(.renderer_link);
+const log = @import("../log.zig").scoped(.renderer_link);
 
 /// The link configuration needed for renderers.
 pub const Link = struct {

--- a/src/renderer/metal/Frame.zig
+++ b/src/renderer/metal/Frame.zig
@@ -13,7 +13,7 @@ const RenderPass = @import("RenderPass.zig");
 
 const Health = @import("../../renderer.zig").Health;
 
-const log = std.log.scoped(.metal);
+const log = @import("../../log.zig").scoped(.metal);
 
 /// Options for beginning a frame.
 pub const Options = struct {

--- a/src/renderer/metal/IOSurfaceLayer.zig
+++ b/src/renderer/metal/IOSurfaceLayer.zig
@@ -9,7 +9,7 @@ const macos = @import("macos");
 
 const IOSurface = macos.iosurface.IOSurface;
 
-const log = std.log.scoped(.IOSurfaceLayer);
+const log = @import("../../log.zig").scoped(.IOSurfaceLayer);
 
 /// We subclass CALayer with a custom display handler, we only need
 /// to make the subclass once, and then we can use it as a singleton.

--- a/src/renderer/metal/Pipeline.zig
+++ b/src/renderer/metal/Pipeline.zig
@@ -8,7 +8,7 @@ const objc = @import("objc");
 
 const mtl = @import("api.zig");
 
-const log = std.log.scoped(.metal);
+const log = @import("../../log.zig").scoped(.metal);
 
 /// Options for initializing a render pipeline.
 pub const Options = struct {

--- a/src/renderer/metal/RenderPass.zig
+++ b/src/renderer/metal/RenderPass.zig
@@ -11,7 +11,7 @@ const Sampler = @import("Sampler.zig");
 const Texture = @import("Texture.zig");
 const Target = @import("Target.zig");
 
-const log = std.log.scoped(.metal);
+const log = @import("../../log.zig").scoped(.metal);
 
 /// Options for beginning a render pass.
 pub const Options = struct {

--- a/src/renderer/metal/Sampler.zig
+++ b/src/renderer/metal/Sampler.zig
@@ -8,7 +8,7 @@ const objc = @import("objc");
 const mtl = @import("api.zig");
 const Metal = @import("../Metal.zig");
 
-const log = std.log.scoped(.metal);
+const log = @import("../../log.zig").scoped(.metal);
 
 /// Options for initializing a sampler.
 pub const Options = struct {

--- a/src/renderer/metal/Target.zig
+++ b/src/renderer/metal/Target.zig
@@ -12,7 +12,7 @@ const IOSurface = macos.iosurface.IOSurface;
 
 const mtl = @import("api.zig");
 
-const log = std.log.scoped(.metal);
+const log = @import("../../log.zig").scoped(.metal);
 
 /// Options for initializing a Target
 pub const Options = struct {

--- a/src/renderer/metal/Texture.zig
+++ b/src/renderer/metal/Texture.zig
@@ -9,7 +9,7 @@ const objc = @import("objc");
 const mtl = @import("api.zig");
 const Metal = @import("../Metal.zig");
 
-const log = std.log.scoped(.metal);
+const log = @import("../../log.zig").scoped(.metal);
 
 /// Options for initializing a texture.
 pub const Options = struct {

--- a/src/renderer/metal/buffer.zig
+++ b/src/renderer/metal/buffer.zig
@@ -6,7 +6,7 @@ const macos = @import("macos");
 const mtl = @import("api.zig");
 const Metal = @import("../Metal.zig");
 
-const log = std.log.scoped(.metal);
+const log = @import("../../log.zig").scoped(.metal);
 
 /// Options for initializing a buffer.
 pub const Options = struct {

--- a/src/renderer/metal/shaders.zig
+++ b/src/renderer/metal/shaders.zig
@@ -7,7 +7,7 @@ const math = @import("../../math.zig");
 const mtl = @import("api.zig");
 const Pipeline = @import("Pipeline.zig");
 
-const log = std.log.scoped(.metal);
+const log = @import("../../log.zig").scoped(.metal);
 
 const pipeline_descs: []const struct { [:0]const u8, PipelineDescription } =
     &.{

--- a/src/renderer/opengl/Frame.zig
+++ b/src/renderer/opengl/Frame.zig
@@ -12,7 +12,7 @@ const RenderPass = @import("RenderPass.zig");
 
 const Health = @import("../../renderer.zig").Health;
 
-const log = std.log.scoped(.opengl);
+const log = @import("../../log.zig").scoped(.opengl);
 
 /// Options for beginning a frame.
 pub const Options = struct {};

--- a/src/renderer/opengl/Pipeline.zig
+++ b/src/renderer/opengl/Pipeline.zig
@@ -5,7 +5,7 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 const gl = @import("opengl");
 
-const log = std.log.scoped(.opengl);
+const log = @import("../../log.zig").scoped(.opengl);
 
 /// Options for initializing a render pipeline.
 pub const Options = struct {

--- a/src/renderer/opengl/Sampler.zig
+++ b/src/renderer/opengl/Sampler.zig
@@ -7,7 +7,7 @@ const gl = @import("opengl");
 
 const OpenGL = @import("../OpenGL.zig");
 
-const log = std.log.scoped(.opengl);
+const log = @import("../../log.zig").scoped(.opengl);
 
 /// Options for initializing a sampler.
 pub const Options = struct {

--- a/src/renderer/opengl/Target.zig
+++ b/src/renderer/opengl/Target.zig
@@ -7,7 +7,7 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 const gl = @import("opengl");
 
-const log = std.log.scoped(.opengl);
+const log = @import("../../log.zig").scoped(.opengl);
 
 /// Options for initializing a Target
 pub const Options = struct {

--- a/src/renderer/opengl/Texture.zig
+++ b/src/renderer/opengl/Texture.zig
@@ -7,7 +7,7 @@ const gl = @import("opengl");
 
 const OpenGL = @import("../OpenGL.zig");
 
-const log = std.log.scoped(.opengl);
+const log = @import("../../log.zig").scoped(.opengl);
 
 /// Options for initializing a texture.
 pub const Options = struct {

--- a/src/renderer/opengl/buffer.zig
+++ b/src/renderer/opengl/buffer.zig
@@ -4,7 +4,7 @@ const gl = @import("opengl");
 
 const OpenGL = @import("../OpenGL.zig");
 
-const log = std.log.scoped(.opengl);
+const log = @import("../../log.zig").scoped(.opengl);
 
 /// Options for initializing a buffer.
 pub const Options = struct {

--- a/src/renderer/opengl/shaders.zig
+++ b/src/renderer/opengl/shaders.zig
@@ -5,7 +5,7 @@ const math = @import("../../math.zig");
 
 const Pipeline = @import("Pipeline.zig");
 
-const log = std.log.scoped(.opengl);
+const log = @import("../../log.zig").scoped(.opengl);
 
 const pipeline_descs: []const struct { [:0]const u8, PipelineDescription } =
     &.{

--- a/src/renderer/shadertoy.zig
+++ b/src/renderer/shadertoy.zig
@@ -6,7 +6,7 @@ const glslang = @import("glslang");
 const spvcross = @import("spirv_cross");
 const configpkg = @import("../config.zig");
 
-const log = std.log.scoped(.shadertoy);
+const log = @import("../log.zig").scoped(.shadertoy);
 
 /// The uniform struct used for shadertoy shaders.
 pub const Uniforms = extern struct {

--- a/src/renderer/size.zig
+++ b/src/renderer/size.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 const terminal_size = @import("../terminal/size.zig");
 
-const log = std.log.scoped(.renderer_size);
+const log = @import("../log.zig").scoped(.renderer_size);
 
 /// Controls how extra whitespace around the terminal grid is distributed.
 pub const PaddingBalance = enum {

--- a/src/simd/base64.zig
+++ b/src/simd/base64.zig
@@ -3,7 +3,7 @@ const options = @import("build_options");
 const assert = @import("../quirks.zig").inlineAssert;
 const scalar_decoder = @import("base64_scalar.zig").scalar_decoder;
 
-const log = std.log.scoped(.simd_base64);
+const log = @import("../log.zig").scoped(.simd_base64);
 
 pub fn maxLen(input: []const u8) usize {
     if (comptime options.simd) return ghostty_simd_base64_max_length(

--- a/src/synthetic/cli/Ascii.zig
+++ b/src/synthetic/cli/Ascii.zig
@@ -5,7 +5,7 @@ const assert = std.debug.assert;
 const Allocator = std.mem.Allocator;
 const Bytes = @import("../Bytes.zig");
 
-const log = std.log.scoped(.@"terminal-stream-bench");
+const log = @import("../../log.zig").scoped(.@"terminal-stream-bench");
 
 pub const Options = struct {};
 

--- a/src/synthetic/cli/Osc.zig
+++ b/src/synthetic/cli/Osc.zig
@@ -5,7 +5,7 @@ const assert = std.debug.assert;
 const Allocator = std.mem.Allocator;
 const synthetic = @import("../main.zig");
 
-const log = std.log.scoped(.@"terminal-stream-bench");
+const log = @import("../../log.zig").scoped(.@"terminal-stream-bench");
 
 pub const Options = struct {
     /// Probability of generating a valid value.

--- a/src/terminal/PageList.zig
+++ b/src/terminal/PageList.zig
@@ -23,7 +23,7 @@ const Capacity = pagepkg.Capacity;
 const Page = pagepkg.Page;
 const Row = pagepkg.Row;
 
-const log = std.log.scoped(.page_list);
+const log = @import("../log.zig").scoped(.page_list);
 
 /// The number of PageList.Nodes we preheat the pool with. A node is
 /// a very small struct so we can afford to preheat many, but the exact

--- a/src/terminal/Parser.zig
+++ b/src/terminal/Parser.zig
@@ -9,7 +9,7 @@ const testing = std.testing;
 const table = @import("parse_table.zig").table;
 const osc = @import("osc.zig");
 
-const log = std.log.scoped(.parser);
+const log = @import("../log.zig").scoped(.parser);
 
 /// States for the state machine
 pub const State = enum {

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -30,7 +30,7 @@ const Pin = PageList.Pin;
 
 pub const CursorStyle = @import("cursor.zig").Style;
 
-const log = std.log.scoped(.screen);
+const log = @import("../log.zig").scoped(.screen);
 
 /// The general purpose allocator to use for all memory allocations.
 /// Unfortunately some screen operations do require allocation.

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -36,7 +36,7 @@ const Page = pagepkg.Page;
 const Cell = pagepkg.Cell;
 const Row = pagepkg.Row;
 
-const log = std.log.scoped(.terminal);
+const log = @import("../log.zig").scoped(.terminal);
 
 /// Default tabstop interval
 const TABSTOP_INTERVAL = 8;

--- a/src/terminal/UTF8Decoder.zig
+++ b/src/terminal/UTF8Decoder.zig
@@ -11,7 +11,7 @@ const UTF8Decoder = @This();
 const std = @import("std");
 const testing = std.testing;
 
-const log = std.log.scoped(.utf8decoder);
+const log = @import("../log.zig").scoped(.utf8decoder);
 
 // zig fmt: off
 const char_classes = [_]u4{

--- a/src/terminal/apc.zig
+++ b/src/terminal/apc.zig
@@ -5,7 +5,7 @@ const Allocator = std.mem.Allocator;
 pub const glyph = @import("apc/glyph.zig");
 const kitty_gfx = @import("kitty/graphics.zig");
 
-const log = std.log.scoped(.terminal_apc);
+const log = @import("../log.zig").scoped(.terminal_apc);
 
 /// APC command handler. This should be hooked into a terminal.Stream handler.
 /// The start/feed/end functions are meant to be called from the terminal.Stream

--- a/src/terminal/c/build_info.zig
+++ b/src/terminal/c/build_info.zig
@@ -4,7 +4,7 @@ const lib = @import("../lib.zig");
 const build_options = @import("terminal_options");
 const Result = @import("result.zig").Result;
 
-const log = std.log.scoped(.build_info_c);
+const log = @import("../../log.zig").scoped(.build_info_c);
 
 /// C: GhosttyOptimizeMode
 pub const OptimizeMode = enum(c_int) {

--- a/src/terminal/c/key_encode.zig
+++ b/src/terminal/c/key_encode.zig
@@ -11,7 +11,7 @@ const KeyEvent = @import("key_event.zig").Event;
 const Terminal = @import("terminal.zig").Terminal;
 const ZigTerminal = @import("../Terminal.zig");
 
-const log = std.log.scoped(.key_encode);
+const log = @import("../../log.zig").scoped(.key_encode);
 
 /// Wrapper around key encoding options that tracks the allocator for C API usage.
 const KeyEncoderWrapper = struct {

--- a/src/terminal/c/key_event.zig
+++ b/src/terminal/c/key_event.zig
@@ -5,7 +5,7 @@ const CAllocator = lib.alloc.Allocator;
 const key = @import("../../input/key.zig");
 const Result = @import("result.zig").Result;
 
-const log = std.log.scoped(.key_event);
+const log = @import("../../log.zig").scoped(.key_event);
 
 /// Wrapper around KeyEvent that tracks the allocator for C API usage.
 /// The UTF-8 text is not owned by this wrapper - the caller is responsible

--- a/src/terminal/c/mouse_encode.zig
+++ b/src/terminal/c/mouse_encode.zig
@@ -13,7 +13,7 @@ const Event = mouse_event.Event;
 const Terminal = @import("terminal.zig").Terminal;
 const ZigTerminal = @import("../Terminal.zig");
 
-const log = std.log.scoped(.mouse_encode);
+const log = @import("../../log.zig").scoped(.mouse_encode);
 
 /// Wrapper around mouse encoding options that tracks the allocator for C API usage.
 const MouseEncoderWrapper = struct {

--- a/src/terminal/c/mouse_event.zig
+++ b/src/terminal/c/mouse_event.zig
@@ -8,7 +8,7 @@ const mouse = @import("../../input/mouse.zig");
 const mouse_encode = @import("../../input/mouse_encode.zig");
 const Result = @import("result.zig").Result;
 
-const log = std.log.scoped(.mouse_event);
+const log = @import("../../log.zig").scoped(.mouse_event);
 
 /// Wrapper around mouse event that tracks the allocator for C API usage.
 const MouseEventWrapper = struct {

--- a/src/terminal/c/osc.zig
+++ b/src/terminal/c/osc.zig
@@ -4,7 +4,7 @@ const CAllocator = lib.alloc.Allocator;
 const osc = @import("../osc.zig");
 const Result = @import("result.zig").Result;
 
-const log = std.log.scoped(.osc);
+const log = @import("../../log.zig").scoped(.osc);
 
 /// C: GhosttyOscParser
 pub const Parser = ?*osc.Parser;

--- a/src/terminal/c/render.zig
+++ b/src/terminal/c/render.zig
@@ -15,7 +15,7 @@ const Result = @import("result.zig").Result;
 const row = @import("row.zig");
 const style_c = @import("style.zig");
 
-const log = std.log.scoped(.render_state_c);
+const log = @import("../../log.zig").scoped(.render_state_c);
 
 const RenderStateWrapper = struct {
     alloc: std.mem.Allocator,

--- a/src/terminal/c/selection.zig
+++ b/src/terminal/c/selection.zig
@@ -10,7 +10,7 @@ const Selection = @import("../Selection.zig");
 const Result = @import("result.zig").Result;
 const terminal_c = @import("terminal.zig");
 
-const log = std.log.scoped(.selection_c);
+const log = @import("../../log.zig").scoped(.selection_c);
 
 pub const Adjustment = Selection.Adjustment;
 pub const Order = Selection.Order;

--- a/src/terminal/c/selection_gesture.zig
+++ b/src/terminal/c/selection_gesture.zig
@@ -12,7 +12,7 @@ const terminal_c = @import("terminal.zig");
 const types = @import("types.zig");
 const Result = @import("result.zig").Result;
 
-const log = std.log.scoped(.selection_gesture_c);
+const log = @import("../../log.zig").scoped(.selection_gesture_c);
 
 /// C: GhosttySelectionGesture
 pub const Gesture = ?*GestureWrapper;

--- a/src/terminal/c/sgr.zig
+++ b/src/terminal/c/sgr.zig
@@ -6,7 +6,7 @@ const CAllocator = lib.alloc.Allocator;
 const sgr = @import("../sgr.zig");
 const Result = @import("result.zig").Result;
 
-const log = std.log.scoped(.sgr);
+const log = @import("../../log.zig").scoped(.sgr);
 
 /// Wrapper around parser that tracks the allocator for C API usage.
 const ParserWrapper = struct {

--- a/src/terminal/c/terminal.zig
+++ b/src/terminal/c/terminal.zig
@@ -28,7 +28,7 @@ const Result = @import("result.zig").Result;
 
 const Handler = @import("../stream_terminal.zig").Handler;
 
-const log = std.log.scoped(.terminal_c);
+const log = @import("../../log.zig").scoped(.terminal_c);
 
 /// Wrapper around ZigTerminal that tracks additional state for C API usage,
 /// such as the persistent VT stream needed to handle escape sequences split

--- a/src/terminal/dcs.zig
+++ b/src/terminal/dcs.zig
@@ -5,7 +5,7 @@ const Allocator = std.mem.Allocator;
 const terminal = @import("main.zig");
 const DCS = terminal.DCS;
 
-const log = std.log.scoped(.terminal_dcs);
+const log = @import("../log.zig").scoped(.terminal_dcs);
 
 /// DCS command handler. This should be hooked into a terminal.Stream handler.
 /// The hook/put/unhook functions are meant to be called from the

--- a/src/terminal/kitty/graphics_command.zig
+++ b/src/terminal/kitty/graphics_command.zig
@@ -5,7 +5,7 @@ const ArenaAllocator = std.heap.ArenaAllocator;
 const simd = @import("../../simd/main.zig");
 const lib = @import("../lib.zig");
 
-const log = std.log.scoped(.kitty_gfx);
+const log = @import("../../log.zig").scoped(.kitty_gfx);
 
 /// The key-value pairs for the control information for a command. The
 /// keys are always single characters and the values are either single

--- a/src/terminal/kitty/graphics_exec.zig
+++ b/src/terminal/kitty/graphics_exec.zig
@@ -11,7 +11,7 @@ const LoadingImage = image.LoadingImage;
 const Image = image.Image;
 const ImageStorage = @import("graphics_storage.zig").ImageStorage;
 
-const log = std.log.scoped(.kitty_gfx);
+const log = @import("../../log.zig").scoped(.kitty_gfx);
 
 /// Execute a Kitty graphics command against the given terminal. This
 /// will never fail, but the response may indicate an error and the

--- a/src/terminal/kitty/graphics_image.zig
+++ b/src/terminal/kitty/graphics_image.zig
@@ -16,7 +16,7 @@ const temp_dir = struct {
     const freeTmpDir = @import("../../os/file.zig").freeTmpDir;
 };
 
-const log = std.log.scoped(.kitty_gfx);
+const log = @import("../../log.zig").scoped(.kitty_gfx);
 
 /// Maximum width or height of an image. Taken directly from Kitty.
 const max_dimension = 10000;

--- a/src/terminal/kitty/graphics_storage.zig
+++ b/src/terminal/kitty/graphics_storage.zig
@@ -14,7 +14,7 @@ const Image = @import("graphics_image.zig").Image;
 const Rect = @import("graphics_image.zig").Rect;
 const Command = command.Command;
 
-const log = std.log.scoped(.kitty_gfx);
+const log = @import("../../log.zig").scoped(.kitty_gfx);
 
 /// An image storage is associated with a terminal screen (i.e. main
 /// screen, alt screen) and contains all the transmitted images and

--- a/src/terminal/kitty/graphics_unicode.zig
+++ b/src/terminal/kitty/graphics_unicode.zig
@@ -10,7 +10,7 @@ const Image = kitty_gfx.Image;
 const ImageStorage = kitty_gfx.ImageStorage;
 const RenderPlacement = kitty_gfx.RenderPlacement;
 
-const log = std.log.scoped(.kitty_gfx);
+const log = @import("../../log.zig").scoped(.kitty_gfx);
 
 /// Codepoint for the unicode placeholder character.
 pub const placeholder: u21 = 0x10EEEE;

--- a/src/terminal/osc.zig
+++ b/src/terminal/osc.zig
@@ -20,7 +20,7 @@ const encoding = @import("osc/encoding.zig");
 pub const color = parsers.color;
 pub const semantic_prompt = parsers.semantic_prompt;
 
-const log = std.log.scoped(.osc);
+const log = @import("../log.zig").scoped(.osc);
 
 pub const Command = union(Key) {
     /// This generally shouldn't ever be set except as an initial zero value.

--- a/src/terminal/osc/parsers/color.zig
+++ b/src/terminal/osc/parsers/color.zig
@@ -7,7 +7,7 @@ const RGB = @import("../../color.zig").RGB;
 const Parser = @import("../../osc.zig").Parser;
 const Command = @import("../../osc.zig").Command;
 
-const log = std.log.scoped(.osc_color);
+const log = @import("../../../log.zig").scoped(.osc_color);
 
 const ParseError = Allocator.Error || error{
     MissingOperation,

--- a/src/terminal/osc/parsers/context_signal.zig
+++ b/src/terminal/osc/parsers/context_signal.zig
@@ -9,7 +9,7 @@ const std = @import("std");
 const Parser = @import("../../osc.zig").Parser;
 const OSCCommand = @import("../../osc.zig").Command;
 
-const log = std.log.scoped(.osc_context_signal);
+const log = @import("../../../log.zig").scoped(.osc_context_signal);
 
 /// Maximum length of a context identifier (per spec).
 const max_context_id_len = 64;

--- a/src/terminal/osc/parsers/hyperlink.zig
+++ b/src/terminal/osc/parsers/hyperlink.zig
@@ -3,7 +3,7 @@ const std = @import("std");
 const Parser = @import("../../osc.zig").Parser;
 const Command = @import("../../osc.zig").Command;
 
-const log = std.log.scoped(.osc_hyperlink);
+const log = @import("../../../log.zig").scoped(.osc_hyperlink);
 
 /// Parse OSC 8 hyperlinks
 pub fn parse(parser: *Parser, _: ?u8) ?*Command {

--- a/src/terminal/osc/parsers/iterm2.zig
+++ b/src/terminal/osc/parsers/iterm2.zig
@@ -6,7 +6,7 @@ const simd = @import("../../../simd/main.zig");
 const Parser = @import("../../osc.zig").Parser;
 const Command = @import("../../osc.zig").Command;
 
-const log = std.log.scoped(.osc_iterm2);
+const log = @import("../../../log.zig").scoped(.osc_iterm2);
 
 const Key = enum {
     AddAnnotation,

--- a/src/terminal/osc/parsers/kitty_clipboard_protocol.zig
+++ b/src/terminal/osc/parsers/kitty_clipboard_protocol.zig
@@ -12,7 +12,7 @@ const Command = @import("../../osc.zig").Command;
 const Terminator = @import("../../osc.zig").Terminator;
 const encoding = @import("../encoding.zig");
 
-const log = std.log.scoped(.kitty_clipboard_protocol);
+const log = @import("../../../log.zig").scoped(.kitty_clipboard_protocol);
 
 pub const OSC = struct {
     /// The raw metadata that was received. It can be parsed by using the `readOption` method.

--- a/src/terminal/osc/parsers/kitty_color.zig
+++ b/src/terminal/osc/parsers/kitty_color.zig
@@ -7,7 +7,7 @@ const Command = @import("../../osc.zig").Command;
 const kitty_color = @import("../../kitty/color.zig");
 const RGB = @import("../../color.zig").RGB;
 
-const log = std.log.scoped(.osc_kitty_color);
+const log = @import("../../../log.zig").scoped(.osc_kitty_color);
 
 /// Parse OSC 21, the Kitty Color Protocol.
 pub fn parse(parser: *Parser, terminator_ch: ?u8) ?*Command {

--- a/src/terminal/osc/parsers/kitty_text_sizing.zig
+++ b/src/terminal/osc/parsers/kitty_text_sizing.zig
@@ -10,7 +10,7 @@ const Command = @import("../../osc.zig").Command;
 const encoding = @import("../encoding.zig");
 const lib = @import("../../lib.zig");
 
-const log = std.log.scoped(.kitty_text_sizing);
+const log = @import("../../../log.zig").scoped(.kitty_text_sizing);
 
 pub const max_payload_length = 4096;
 

--- a/src/terminal/osc/parsers/rxvt_extension.zig
+++ b/src/terminal/osc/parsers/rxvt_extension.zig
@@ -3,7 +3,7 @@ const std = @import("std");
 const Parser = @import("../../osc.zig").Parser;
 const Command = @import("../../osc.zig").Command;
 
-const log = std.log.scoped(.osc_rxvt_extension);
+const log = @import("../../../log.zig").scoped(.osc_rxvt_extension);
 
 /// Parse OSC 777
 pub fn parse(parser: *Parser, _: ?u8) ?*Command {

--- a/src/terminal/osc/parsers/semantic_prompt.zig
+++ b/src/terminal/osc/parsers/semantic_prompt.zig
@@ -5,7 +5,7 @@ const Parser = @import("../../osc.zig").Parser;
 const OSCCommand = @import("../../osc.zig").Command;
 const string_encoding = @import("../../../os/string_encoding.zig");
 
-const log = std.log.scoped(.osc_semantic_prompt);
+const log = @import("../../../log.zig").scoped(.osc_semantic_prompt);
 
 /// A single semantic prompt command.
 ///

--- a/src/terminal/page.zig
+++ b/src/terminal/page.zig
@@ -25,7 +25,7 @@ const AutoOffsetHashMap = hash_map.AutoOffsetHashMap;
 const alignForward = std.mem.alignForward;
 const alignBackward = std.mem.alignBackward;
 
-const log = std.log.scoped(.page);
+const log = @import("../log.zig").scoped(.page);
 
 /// Page-aligned allocator used for terminal page backing memory. Pages
 /// require page-aligned, zeroed memory obtained directly from the OS

--- a/src/terminal/search/Thread.zig
+++ b/src/terminal/search/Thread.zig
@@ -28,7 +28,7 @@ const Terminal = @import("../Terminal.zig");
 const ScreenSearch = @import("screen.zig").ScreenSearch;
 const ViewportSearch = @import("viewport.zig").ViewportSearch;
 
-const log = std.log.scoped(.search_thread);
+const log = @import("../../log.zig").scoped(.search_thread);
 
 // TODO: Some stuff that could be improved:
 // - pause the refresh timer when the terminal isn't focused

--- a/src/terminal/search/screen.zig
+++ b/src/terminal/search/screen.zig
@@ -16,7 +16,7 @@ const ActiveSearch = @import("active.zig").ActiveSearch;
 const PageListSearch = @import("pagelist.zig").PageListSearch;
 const SlidingWindow = @import("sliding_window.zig").SlidingWindow;
 
-const log = std.log.scoped(.search_screen);
+const log = @import("../../log.zig").scoped(.search_screen);
 
 const reloadActive_tw = tripwire.module(enum {
     history_append_new,

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -19,7 +19,7 @@ const sgr = @import("sgr.zig");
 const UTF8Decoder = @import("UTF8Decoder.zig");
 const MouseShape = @import("mouse.zig").Shape;
 
-const log = std.log.scoped(.stream);
+const log = @import("../log.zig").scoped(.stream);
 
 /// Flip this to true when you want verbose debug output for
 /// debugging terminal stream issues. In addition to louder

--- a/src/terminal/stream_terminal.zig
+++ b/src/terminal/stream_terminal.zig
@@ -14,7 +14,7 @@ const kitty_color = @import("kitty/color.zig");
 const size_report = @import("size_report.zig");
 const Terminal = @import("Terminal.zig");
 
-const log = std.log.scoped(.stream_terminal);
+const log = @import("../log.zig").scoped(.stream_terminal);
 
 /// This is a Stream implementation that processes actions against
 /// a Terminal and updates the Terminal state.

--- a/src/terminal/tmux/control.zig
+++ b/src/terminal/tmux/control.zig
@@ -8,7 +8,7 @@ const Allocator = std.mem.Allocator;
 const assert = @import("../../quirks.zig").inlineAssert;
 const oni = @import("oniguruma");
 
-const log = std.log.scoped(.terminal_tmux);
+const log = @import("../../log.zig").scoped(.terminal_tmux);
 
 /// A tmux control mode parser. This takes in output from tmux control
 /// mode and parses it into a structured notifications.

--- a/src/terminal/tmux/viewer.zig
+++ b/src/terminal/tmux/viewer.zig
@@ -13,7 +13,7 @@ const Layout = @import("layout.zig").Layout;
 const control = @import("control.zig");
 const output = @import("output.zig");
 
-const log = std.log.scoped(.terminal_tmux_viewer);
+const log = @import("../../log.zig").scoped(.terminal_tmux_viewer);
 
 // TODO: A list of TODOs as I think about them.
 // - We need to make startup more robust so session and block can happen

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -29,7 +29,7 @@ const PasswdEntry = internal_os.passwd.Entry;
 const windows = internal_os.windows;
 const ProcessInfo = @import("../pty.zig").ProcessInfo;
 
-const log = std.log.scoped(.io_exec);
+const log = @import("../log.zig").scoped(.io_exec);
 
 /// The termios poll rate in milliseconds.
 const TERMIOS_POLL_MS = 200;

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -21,7 +21,7 @@ const windows = internal_os.windows;
 const configpkg = @import("../config.zig");
 const ProcessInfo = @import("../pty.zig").ProcessInfo;
 
-const log = std.log.scoped(.io_exec);
+const log = @import("../log.zig").scoped(.io_exec);
 
 /// Mutex state argument for queueMessage.
 pub const MutexState = enum { locked, unlocked };

--- a/src/termio/Thread.zig
+++ b/src/termio/Thread.zig
@@ -21,7 +21,7 @@ const termio = @import("../termio.zig");
 const renderer = @import("../renderer.zig");
 
 const Allocator = std.mem.Allocator;
-const log = std.log.scoped(.io_thread);
+const log = @import("../log.zig").scoped(.io_thread);
 
 /// This stores the information that is coalesced.
 const Coalesce = struct {

--- a/src/termio/mailbox.zig
+++ b/src/termio/mailbox.zig
@@ -5,7 +5,7 @@ const renderer = @import("../renderer.zig");
 const termio = @import("../termio.zig");
 const BlockingQueue = @import("../datastruct/main.zig").BlockingQueue;
 
-const log = std.log.scoped(.io_writer);
+const log = @import("../log.zig").scoped(.io_writer);
 
 /// A queue used for storing messages that is periodically drained.
 /// Typically used by a multi-threaded application. The capacity is

--- a/src/termio/shell_integration.zig
+++ b/src/termio/shell_integration.zig
@@ -7,7 +7,7 @@ const config = @import("../config.zig");
 const homedir = @import("../os/homedir.zig");
 const internal_os = @import("../os/main.zig");
 
-const log = std.log.scoped(.shell_integration);
+const log = @import("../log.zig").scoped(.shell_integration);
 
 /// Shell types we support
 pub const Shell = enum {

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -13,7 +13,7 @@ const terminal = @import("../terminal/main.zig");
 const terminfo = @import("../terminfo/main.zig");
 const posix = std.posix;
 
-const log = std.log.scoped(.io_handler);
+const log = @import("../log.zig").scoped(.io_handler);
 
 /// This is used as the handler for the terminal.Stream type. This is
 /// stateful and is expected to live for the entire lifetime of the terminal.

--- a/src/tripwire.zig
+++ b/src/tripwire.zig
@@ -68,7 +68,7 @@ const builtin = @import("builtin");
 const assert = std.debug.assert;
 const testing = std.testing;
 
-const log = std.log.scoped(.tripwire);
+const log = @import("log.zig").scoped(.tripwire);
 
 // Future ideas:
 //


### PR DESCRIPTION
Previously, when we wanted to locate the logs that are emitted from `Ghostty.xcframework` (zig part), in Xcode's debug console, we had to copy and search in another editor to see them. With this, now we can just right-click **Jump To Source** on that log item.

The first commit touches a lot of files but only [`src/log.zig`](https://github.com/ghostty-org/ghostty/pull/12863/changes#diff-cc10636b160e891ce9aa77ae7289893fccd4e7fd0621746b85602d8910c47d44) and [`src/main_ghostty.zig`](https://github.com/ghostty-org/ghostty/pull/12863/changes#diff-68b77120d87317a3c2b3fe0d9f822a5e3e62b66c4ab30a3444a22a0da37ff51d) are most relevant, the rest are just import changes.

<img width="1554" height="746" alt="Xnip2026-05-30_18-50-35" src="https://github.com/user-attachments/assets/ce1ccd30-d0a7-4409-9834-6227bded91ef" />


### AI Disclosure

I used Claude (Plan mode) to implement this, and tbh I don't actually fully comprehend the changes in `src/log.zig`, but I asked another agent session to verify and review its assumption with online resources. And I verified it with Xcode and `log stream`. Since the private SPI [`_os_log_impl`](https://github.com/PureDarwin/Libtrace/blob/067c6b6156fa6ecfc0528c70944e63b86cc7d787/libsystem_trace/os_log.c#L89) is only used in debug builds, I would say it's rather safe.