### PR TITLE
macos: remove unneeded initializers

### DIFF
--- a/macos/Sources/Features/QuickTerminal/QuickTerminalRestorableState.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalRestorableState.swift
@@ -44,16 +44,6 @@ extension QuickTerminalRestorableState {
         let focusedSurface: String?
         let surfaceTree: SplitTree<ViewType>
         let screenStateEntries: QuickTerminalScreenStateCache.Entries
-
-        init(
-            focusedSurface: String?,
-            surfaceTree: SplitTree<ViewType>,
-            screenStateEntries: QuickTerminalScreenStateCache.Entries,
-        ) {
-            self.focusedSurface = focusedSurface
-            self.surfaceTree = surfaceTree
-            self.screenStateEntries = screenStateEntries
-        }
     }
 }
 

--- a/macos/Sources/Features/Terminal/TerminalRestorableState+InteralState.swift
+++ b/macos/Sources/Features/Terminal/TerminalRestorableState+InteralState.swift
@@ -15,20 +15,6 @@ extension TerminalRestorableState {
         let effectiveFullscreenMode: FullscreenMode?
         let tabColor: TerminalTabColor?
         let titleOverride: String?
-
-        init(
-            focusedSurface: String?,
-            surfaceTree: SplitTree<ViewType>,
-            effectiveFullscreenMode: FullscreenMode?,
-            tabColor: TerminalTabColor?,
-            titleOverride: String?,
-        ) {
-            self.focusedSurface = focusedSurface
-            self.surfaceTree = surfaceTree
-            self.effectiveFullscreenMode = effectiveFullscreenMode
-            self.tabColor = tabColor
-            self.titleOverride = titleOverride
-        }
     }
 }
 

--- a/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
@@ -734,8 +734,7 @@ extension Ghostty {
                 // cached value is restored next time the terminal emits a
                 // color_change.
                 if let cached = self.backgroundColor,
-                   cached != self.derivedConfig.backgroundColor
-                {
+                   cached != self.derivedConfig.backgroundColor {
                     self.backgroundColor = nil
                 }
             }


### PR DESCRIPTION
These will be automatically synthesized (they only do memberwise initialization) and do not need to be manually defined.