### PR TITLE
config: fix missing space in docs

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -752,12 +752,12 @@ foreground: Color = .{ .r = 0xFF, .g = 0xFF, .b = 0xFF },
 /// The null character (U+0000) is always treated as a boundary and does not
 /// need to be included in this configuration.
 ///
-/// Default: `` \t'"│`|:;,()[]{}<>$ ``
+/// Default: ``\t '"│`|:;,()[]{}<>$``
 ///
 /// To add or remove specific characters, you can set this to a custom value.
 /// For example, to treat semicolons as part of words:
 ///
-///     selection-word-chars = " \t'\"│`|:,()[]{}<>$"
+///     selection-word-chars = "\t '\"│`|:,()[]{}<>$"
 ///
 /// Available since: 1.3.0
 @"selection-word-chars": SelectionWordChars = .{},


### PR DESCRIPTION
fixes #12873

comment/docs only change:
switched space and tab in default value of `selection-word-chars` so there is no space at the value boundary
needed because markdown trims spaces at the beginning & end of a code snippet