### PR TITLE
Fix synthetic Command key equivalents

### DIFF
--- a/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
@@ -76,6 +76,32 @@ extension Ghostty {
         // Cancellable for search state needle changes
         private var searchNeedleCancellable: AnyCancellable?
 
+        // Tracks a real Command-key transition observed by this surface.
+        // Mouse/tracking events may carry synthetic or stale modifier flags, so
+        // they must not establish keyboard state for key-equivalent handling.
+        private var commandKeyDown = false
+
+        static func shouldIgnoreCommandKeyEquivalent(
+            _ event: NSEvent,
+            commandKeyDown: Bool
+        ) -> Bool {
+            event.type == .keyDown &&
+                event.modifierFlags.contains(.command) &&
+                !commandKeyDown
+        }
+
+        private static func isCommandModifierKey(_ keyCode: UInt16) -> Bool {
+            keyCode == 0x37 || keyCode == 0x36
+        }
+
+        private func notePhysicalCommandState(_ event: NSEvent) {
+            guard event.type == .flagsChanged,
+                  Self.isCommandModifierKey(event.keyCode)
+            else { return }
+
+            commandKeyDown = event.modifierFlags.contains(.command)
+        }
+
         // Whether the pointer should be visible or not
         @Published private(set) var pointerStyle: CursorStyle = .horizontalText
 
@@ -410,6 +436,7 @@ extension Ghostty {
             // sent to stop things like mouse selection.
             if !focused {
                 suppressNextLeftMouseUp = false
+                commandKeyDown = false
             }
 
             // Notify libghostty
@@ -1275,6 +1302,16 @@ extension Ghostty {
                 return false
             }
 
+            // AppKit may deliver synthetic Command key-equivalents during mouse
+            // interactions. Only a Command-key transition is allowed to establish
+            // real keyboard state for terminal input.
+            if Self.shouldIgnoreCommandKeyEquivalent(
+                event,
+                commandKeyDown: commandKeyDown
+            ) {
+                return true
+            }
+
             // Get information about if this is a binding.
             let bindingFlags = surfaceModel.flatMap { surface in
                 var ghosttyEvent = event.ghosttyKeyEvent(GHOSTTY_ACTION_PRESS)
@@ -1384,6 +1421,8 @@ extension Ghostty {
         }
 
         override func flagsChanged(with event: NSEvent) {
+            notePhysicalCommandState(event)
+
             let mod: UInt32
             switch event.keyCode {
             case 0x39: mod = GHOSTTY_MODS_CAPS.rawValue

--- a/macos/Tests/Ghostty/SurfaceViewAppKitTests.swift
+++ b/macos/Tests/Ghostty/SurfaceViewAppKitTests.swift
@@ -1,5 +1,6 @@
-@testable import Ghostty
+import AppKit
 import Testing
+@testable import Ghostty
 
 struct SurfaceViewAppKitTests {
     @Test(arguments: [
@@ -40,5 +41,49 @@ struct SurfaceViewAppKitTests {
                 composing: true
             ) == false
         )
+    }
+
+    @Test func ignoresCommandKeyEquivalentWithoutCommandKeyDown() throws {
+        let event = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: .command,
+            timestamp: 1,
+            windowNumber: 1,
+            context: nil,
+            characters: "c",
+            charactersIgnoringModifiers: "c",
+            isARepeat: false,
+            keyCode: 8
+        ))
+
+        #expect(Ghostty.SurfaceView.shouldIgnoreCommandKeyEquivalent(
+            event,
+            commandKeyDown: false
+        ))
+        #expect(!Ghostty.SurfaceView.shouldIgnoreCommandKeyEquivalent(
+            event,
+            commandKeyDown: true
+        ))
+    }
+
+    @Test func doesNotIgnoreNonCommandKeyEquivalent() throws {
+        let event = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [],
+            timestamp: 1,
+            windowNumber: 1,
+            context: nil,
+            characters: "c",
+            charactersIgnoringModifiers: "c",
+            isARepeat: false,
+            keyCode: 8
+        ))
+
+        #expect(!Ghostty.SurfaceView.shouldIgnoreCommandKeyEquivalent(
+            event,
+            commandKeyDown: false
+        ))
     }
 }


### PR DESCRIPTION
## Summary

  Fix a macOS AppKit event path where synthetic Command key-equivalent events could be
  delivered to `SurfaceView` during mouse/window interactions.

  In Codex running inside Ghostty, clicking blank areas or resizing the Ghostty window could
  unexpectedly insert `c`. Earlier logging showed this going through `performKeyEquivalent ->
  keyDown -> keyAction -> PTY write` as Kitty keyboard protocol Cmd+C (`ESC[99;9u`).

  This keeps the fix at the AppKit boundary. It does not change the Zig keybinding or PTY
  encoding semantics for normal focused keyboard input.

  ## Approach

  `SurfaceView` now tracks Command key state from Command `flagsChanged` events. If
  `performKeyEquivalent` receives a Command key-equivalent without the surface having observed
  Command as physically down, the event is consumed before it can reach `keyDown -> keyAction
  -> PTY`.

  A focused real Cmd+C still follows the existing path.

  ## Testing

  Automated:

  - `git diff --check upstream/main..HEAD`
  - `xcodebuild test -project macos/Ghostty.xcodeproj -scheme Ghostty -configuration Debug
  -destination 'platform=macOS' -only-testing:GhosttyTests/SurfaceViewAppKitTests`

  Manual QA:

  - Reproduced the original issue in Ghostty with Codex: clicking blank areas and resizing the
  Ghostty window could insert `c`.
  - Verified the fixed build with Codex: clicking blank areas no longer inserts `c`.
  - Verified the fixed build with Codex: resizing the Ghostty window no longer inserts `c`.
  - Verified focused real Cmd+C in a terminal with Kitty keyboard protocol still reaches the
  PTY as `ESC[99;9u`.

  ## Known behavior change

  There is one edge case where behavior changes:

  - In release Ghostty with Codex open, using Cmd+Tab to switch to Ghostty, pressing Enter to
  focus it while still holding Command, then pressing C can insert `C` into Codex.
  - In this fixed build, the same sequence has no effect because the surface did not observe
  the Command `flagsChanged` transition.

  This is an intentional tradeoff of the current fix: Command key-equivalents delivered without
  a matching Command `flagsChanged` observed by the surface are treated as synthetic. This may
  affect ambiguous app-switching, accessibility, remote-input, or automation paths that inject
  `.command` key events without normal modifier transitions.

  ## AI usage disclosure

  OpenAI Codex was used to help investigate the event path, draft and revise the Swift changes,
  add focused tests, run local verification commands, and prepare this PR description.

  I manually tested the original reproduction cases and the Cmd+Tab edge case described above,
  reviewed the resulting code, and understand the behavior change and tradeoff in this patch.