### PR TITLE
macos: fix GHOSTTY_QUICK_TERMINAL not set for quick terminal splits

### DIFF
--- a/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
@@ -315,6 +315,16 @@ class QuickTerminalController: BaseTerminalController {
         animateOut()
     }
 
+    override func newSplit(
+        at oldView: Ghostty.SurfaceView,
+        direction: SplitTree<Ghostty.SurfaceView>.NewDirection,
+        baseConfig config: Ghostty.SurfaceConfiguration? = nil
+    ) -> Ghostty.SurfaceView? {
+        var config = config ?? Ghostty.SurfaceConfiguration()
+        config.environmentVariables["GHOSTTY_QUICK_TERMINAL"] = "1"
+        return super.newSplit(at: oldView, direction: direction, baseConfig: config)
+    }
+
     // MARK: Methods
 
     func toggle() {


### PR DESCRIPTION
### Fixes #12895 


## Problem

On macOS, split panes created via Cmd+D in the Quick Terminal do not inherit `GHOSTTY_QUICK_TERMINAL=1`. The initial surface correctly receives the variable, but new split panes do not. Community disscussions report #11637 and #12652 confirm this is macOS-specific.

## Root Cause

OriginalPR #9673 used different mechanisms on each platform:

- **GTK**: `defaultTermioEnv()` dynamically queries `window.isQuickTerminal()` for every surface, a per-window property.
- **macOS**: `animateIn()` writes the env var into the first surface's `SurfaceConfiguration.environmentVariables`, a per-surface, one-shot configuration.

When a split is created, `ghostty_surface_inherited_config()` does not propagate `env_vars`, so the new pane never receives the variable.

## Fix

Override `newSplit()` in `QuickTerminalController` to inject `GHOSTTY_QUICK_TERMINAL=1` before calling `super.newSplit()`. This matches the GTK semantics: all surfaces created from a Quick Terminal Controller carry the marker.

**The change is 6 lines, in a single file:** `macos/Sources/Features/QuickTerminal/QuickTerminalController.swift`. No public API changes, no cross-platform impact.

## Verification
I manually verified the following scenarios.
- Full build (`zig build`): no errors
- Quick Terminal initial surface: `echo $GHOSTTY_QUICK_TERMINAL` → `1`
- Cmd+D split (right/down/left/up): new pane → `1`
- Multiple nested splits: all panes → `1`
- Normal (non-Quick-Terminal) window: → (empty)
- Normal window Cmd+D split: → (empty)

## AI Assistance Disclosure

Claude Code Opus 4.7 was used to analyze the original implementation logic and verify the change's impact scope. All code was reviewed and edited by myself before submission. AI also helped with the English translation work.
