### PR TITLE
renderer: glyph protocol

### DIFF
--- a/src/font/glyf_rasterize.zig
+++ b/src/font/glyf_rasterize.zig
@@ -18,15 +18,33 @@ const DesignMetrics = Glyph.DesignMetrics;
 pub const Bitmap = struct {
     width: u32,
     height: u32,
+
+    /// Horizontal bearing, in pixels, from the nominal bitmap origin to the
+    /// returned bitmap origin. This is usually zero, but can be negative when
+    /// `Placement.x` is negative and the returned bitmap grows leftward to keep
+    /// the placed outline from being clipped. The renderer passes this through
+    /// as the glyph's `offset_x`.
+    offset_x: i32,
+
     data: []u8,
 
     // An empty 0x0 bitmap.
-    pub const empty: Bitmap = .{ .width = 0, .height = 0, .data = "" };
+    pub const empty: Bitmap = .{
+        .width = 0,
+        .height = 0,
+        .offset_x = 0,
+        .data = "",
+    };
 
     pub fn initEmpty(alloc: Allocator, width: u32, height: u32) Allocator.Error!Bitmap {
         const data = try alloc.alloc(u8, @as(usize, width) * @as(usize, height));
         @memset(data, 0);
-        return .{ .width = width, .height = height, .data = data };
+        return .{
+            .width = width,
+            .height = height,
+            .offset_x = 0,
+            .data = data,
+        };
     }
 
     pub fn deinit(self: *Bitmap, alloc: Allocator) void {
@@ -37,12 +55,14 @@ pub const Bitmap = struct {
 
 pub const Error = Allocator.Error || z2d.Path.Error || z2d.painter.FillError;
 
-/// Rasterize a decoded glyf outline to a full-cell alpha bitmap.
+/// Rasterize a decoded glyf outline to an alpha bitmap.
 ///
-/// The returned bitmap is always `grid_metrics.cell_width * cell_width` by
-/// `grid_metrics.cell_height`. `opts.constraint` is applied using the same
-/// `RenderOptions.Constraint` machinery used by the platform font
-/// backends.
+/// The nominal bitmap rectangle starts as
+/// `grid_metrics.cell_width * cell_width` by `grid_metrics.cell_height`, but the
+/// returned bitmap may be wider if `Placement` puts the outline outside that
+/// rectangle. `Bitmap.offset_x` places the returned bitmap relative to the
+/// nominal bitmap origin. `opts.constraint` is applied using the same
+/// `RenderOptions.Constraint` machinery used by the platform font backends.
 ///
 /// The caller owns the returned bitmap.
 pub fn rasterize(
@@ -55,20 +75,23 @@ pub fn rasterize(
     assert(design.advance_width > 0);
     assert(design.line_height > 0);
 
-    // Calculate our final width/height.
-    const width: u32 = std.math.mul(
+    // Calculate the nominal bitmap rectangle. Placement is resolved relative to
+    // this rectangle, but this is not necessarily the final bitmap size: if the
+    // resulting Placement extends horizontally outside this rectangle, we grow
+    // the returned bitmap and preserve that overflow with Bitmap.offset_x.
+    const nominal_width: u32 = std.math.mul(
         u32,
         opts.grid_metrics.cell_width,
         opts.cell_width orelse 1,
     ) catch std.math.maxInt(u32);
-    const height = opts.grid_metrics.cell_height;
-    assert(width > 0 and height > 0);
+    const nominal_height = opts.grid_metrics.cell_height;
+    assert(nominal_width > 0 and nominal_height > 0);
 
     // If we have no contours or points then we have no drawable shape, but the
     // caller still asked for a cell-sized bitmap. Return that full bitmap with
     // zero coverage so downstream atlas/upload code doesn't need a separate
     // size contract for empty glyphs.
-    if (outline.contours.len == 0 or outline.points.len == 0) return Bitmap.initEmpty(alloc, width, height);
+    if (outline.contours.len == 0 or outline.points.len == 0) return Bitmap.initEmpty(alloc, nominal_width, nominal_height);
 
     // Glyf entries have a header bounding box, but this rasterizer operates on
     // the decoded Outline only. Recompute bounds from the decoded coordinate
@@ -97,21 +120,52 @@ pub fn rasterize(
     // Degenerate point bounds can't produce filled area and would make the
     // point-to-bitmap transform divide by zero, so return a full transparent
     // bitmap just like an empty outline.
-    if (bounds.width() == 0 or bounds.height() == 0) return Bitmap.initEmpty(alloc, width, height);
+    if (bounds.width() == 0 or bounds.height() == 0) return Bitmap.initEmpty(alloc, nominal_width, nominal_height);
+
+    // `placement` is in nominal bitmap coordinates: x=0 is the nominal left
+    // edge and x=nominal_width is the nominal right edge. The z2d surface we draw
+    // into, however, has its own bitmap coordinate system whose left edge is
+    // always x=0. If the placed outline extends outside the nominal rectangle,
+    // grow the returned bitmap just enough to include both:
+    //
+    //   * the whole nominal rectangle, so empty/transparent in-cell pixels are
+    //     still represented; and
+    //   * the whole placed outline bounds, so Placement overflow is not clipped
+    //     away before the renderer sees it.
+    //
+    // When overflow extends to the left, `left` is negative. We shift
+    // `placement.x` right by `-left` before drawing into the bitmap, then return
+    // `offset_x = left` so the renderer shifts the bitmap back to its intended
+    // position relative to the nominal origin. Example: a 20px-wide Placement
+    // centered in a 10px nominal rectangle has left=-5, bitmap_width=20,
+    // placement.x=0 in bitmap coordinates, and offset_x=-5 at render time.
+    var placement: Placement = .init(bounds, design, opts);
+    const left = @min(@as(f64, 0), @floor(placement.x));
+    const right = @max(
+        @as(f64, @floatFromInt(nominal_width)),
+        @ceil(placement.x + placement.width),
+    );
+    assert(right > left);
+
+    const bitmap_width: u32 = @intFromFloat(@min(
+        @as(f64, @floatFromInt(std.math.maxInt(u32))),
+        right - left,
+    ));
+    const offset_x: i32 = @intFromFloat(left);
+    placement.x -= left;
 
     // Build the surface we'll draw on. This is a simple alpha8 drawing.
     var sfc: z2d.Surface = try .init(
         .image_surface_alpha8,
         alloc,
-        @intCast(width),
-        @intCast(height),
+        @intCast(bitmap_width),
+        @intCast(nominal_height),
     );
     defer sfc.deinit(alloc);
 
     var path: z2d.Path = .empty;
     defer path.deinit(alloc);
 
-    const placement: Placement = .init(bounds, design, opts);
     for (0..outline.contours.len) |i| try appendContourPath(
         alloc,
         &path,
@@ -131,8 +185,9 @@ pub fn rasterize(
     );
 
     return .{
-        .width = width,
-        .height = height,
+        .width = bitmap_width,
+        .height = nominal_height,
+        .offset_x = offset_x,
         .data = try alloc.dupe(u8, std.mem.sliceAsBytes(sfc.image_surface_alpha8.buf)),
     };
 }
@@ -152,8 +207,7 @@ const Bounds = struct {
     }
 };
 
-/// Cell-relative pixel rectangle where the decoded outline bounds should be
-/// rasterized within the output bitmap.
+/// Pixel rectangle where the decoded outline bounds should be rasterized.
 ///
 /// This is deliberately the placement of the outline's computed point bounds,
 /// not the full declared advance/line-height box. `advance_width` and
@@ -165,7 +219,7 @@ const Bounds = struct {
 /// into this rectangle.
 ///
 /// ```text
-/// output bitmap / terminal cell
+/// nominal bitmap rectangle
 /// ╭────────────────────────────────────────────────────────────────────────╮ top
 /// │                                                                        │
 /// │   declared advance/line-height box                                     │
@@ -181,7 +235,10 @@ const Bounds = struct {
 /// │   ╰─────────────────▲──────────────────────────────────────────────╯   │
 /// │                     │ y                                                │
 /// ╰────────────────────────────────────────────────────────────────────────╯ bottom
-///              x is measured from the bitmap left to the Placement left.
+///              x is measured from the nominal rectangle's left edge to the
+///              Placement left edge. It may be negative when constraints place
+///              the outline before the nominal origin; rasterize grows the
+///              returned bitmap and reports that as Bitmap.offset_x.
 ///              y is measured from the bitmap bottom to the Placement bottom.
 ///              bitmap_height is the full top-to-bottom bitmap height.
 /// ```
@@ -213,29 +270,29 @@ const Placement = struct {
     bitmap_height: f64,
 
     /// Calculate where the decoded point bounds should land in the output
-    /// bitmap.
+    /// bitmap coordinate space.
     ///
-    /// The glyf protocol supplies declared metrics (`units_per_em`,
-    /// `advance_width`, and `line_height`) in design units, while Ghostty's
-    /// font constraint code works in cell-relative pixels. We first map the em
-    /// square to one cell height, matching the linked glyph rasterizer's
-    /// baseline model where design-space `y=0` is the bottom/baseline of the em
-    /// and `y=units_per_em` is its top. Then we describe the actual outline
-    /// bounds as a relative sub-rectangle of the declared advance/line-height
-    /// box. That declared box includes any intentional side bearings or
-    /// vertical whitespace around the outline; constraints should apply to that
-    /// layout box rather than to the tight point bounds alone. This returns the
-    /// final pixel rectangle for only the outline bounds that we will rasterize.
+    /// `design` supplies declared metrics (`units_per_em`, `advance_width`, and
+    /// `line_height`) in design units, while Ghostty's font constraint code
+    /// works in cell-relative pixels. We first map the em square to one cell
+    /// height, matching the rasterizer's baseline model where design-space
+    /// `y=0` is the bottom/baseline of the em and `y=units_per_em` is its top.
+    /// Then we describe the actual outline bounds as a relative sub-rectangle
+    /// of the declared advance/line-height box. That declared box includes any
+    /// intentional side bearings or vertical whitespace around the outline;
+    /// constraints should apply to that layout box rather than to the tight
+    /// point bounds alone. This returns the final pixel rectangle for only the
+    /// outline bounds that we will rasterize.
     fn init(
         bounds: Bounds,
         design: DesignMetrics,
         opts: Glyph.RenderOptions,
     ) Placement {
-        // Start with protocol-like design units mapped so that the em square
-        // occupies one cell. This makes units_per_em the scale reference and
-        // preserves the linked rasterizer's y=0 baseline/bottom behavior.
-        // Callers can then use RenderOptions.Constraint to fit/cover/stretch/
-        // align the declared advance/line-height box using existing font logic.
+        // Start with design units mapped so that the em square occupies one
+        // cell height. This makes units_per_em the scale reference and
+        // preserves the y=0 baseline/bottom behavior. Callers can then use
+        // RenderOptions.Constraint to fit/cover/stretch/align the declared
+        // advance/line-height box using existing font logic.
         const scale = @as(f64, @floatFromInt(opts.grid_metrics.cell_height)) /
             @as(f64, @floatFromInt(design.units_per_em));
 
@@ -270,11 +327,56 @@ const Placement = struct {
             }
             break :constraint constraint;
         };
-        const constrained = constraint.constrain(
+        var constrained = constraint.constrain(
             glyph,
             opts.grid_metrics,
             opts.constraint_width,
         );
+
+        // `RenderOptions.Constraint` is shared with normal font rendering and
+        // intentionally clamps oversized glyphs so they do not protrude before
+        // the cell origin. Placement supports a looser invariant: `center`
+        // aligns midpoints and `end` aligns trailing edges, even when the
+        // scaled layout box is wider than the nominal bitmap rectangle. In
+        // those cases overflow before x=0 is a valid Placement value and must
+        // be preserved by the wider bitmap/negative-bearing logic above.
+        //
+        // When constraint sizing is `.none`, the base transform has already
+        // chosen the scale. Re-apply only the alignment/padding part here in
+        // nominal bitmap coordinates, without the font helper's clamping.
+        if (constraint.size == .none) {
+            const nominal_width = @as(f64, @floatFromInt(opts.grid_metrics.cell_width)) *
+                @as(f64, @floatFromInt(opts.constraint_width));
+            const nominal_height: f64 = @floatFromInt(opts.grid_metrics.cell_height);
+
+            const group: Glyph.Size = .{
+                .width = group_width,
+                .height = group_height,
+                .x = glyph.x - (group_width * constraint.relative_x),
+                .y = glyph.y - (group_height * constraint.relative_y),
+            };
+
+            const start_x = constraint.pad_left * nominal_width;
+            const end_x = nominal_width * (1 - constraint.pad_right) - group.width;
+            const aligned_group_x = switch (constraint.align_horizontal) {
+                .none => group.x,
+                .start, .center1 => start_x,
+                .center => (start_x + end_x) / 2,
+                .end => end_x,
+            };
+
+            const start_y = constraint.pad_bottom * nominal_height;
+            const end_y = nominal_height * (1 - constraint.pad_top) - group.height;
+            const aligned_group_y = switch (constraint.align_vertical) {
+                .none => group.y,
+                .start => start_y,
+                .center, .center1 => (start_y + end_y) / 2,
+                .end => end_y,
+            };
+
+            constrained.x = aligned_group_x + (group.width * constraint.relative_x);
+            constrained.y = aligned_group_y + (group.height * constraint.relative_y);
+        }
 
         // Store the final outline placement plus the full bitmap height needed
         // later to flip from cell-relative y to z2d's y-down surface space.
@@ -501,6 +603,44 @@ test "glyf_rasterize: square fills bitmap center" {
     defer bm.deinit(alloc);
 
     try testing.expect(bm.data[10 * bm.width + 10] > 200);
+}
+
+test "glyf_rasterize: centered Placement preserves horizontal overflow" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    const outline: glyf.Glyf.Outline = .{
+        .points = &.{
+            .{ .x = 0, .y = 0, .on_curve = true },
+            .{ .x = 1000, .y = 0, .on_curve = true },
+            .{ .x = 1000, .y = 1000, .on_curve = true },
+            .{ .x = 0, .y = 1000, .on_curve = true },
+        },
+        .contours = &.{3},
+    };
+
+    var bm = try rasterize(alloc, outline, .{
+        .units_per_em = 1000,
+        .advance_width = 1000,
+        .line_height = 1000,
+    }, .{
+        .grid_metrics = testMetrics(10, 20),
+        .constraint = .{
+            .align_horizontal = .center,
+            .align_vertical = .center,
+        },
+    });
+    defer bm.deinit(alloc);
+
+    // The nominal bitmap rectangle is 10x20. The 1000x1000 design box maps to
+    // a 20x20 Placement, and center alignment places that Placement at x=-5.
+    // The returned bitmap keeps the full 20px outline instead of clipping to
+    // the nominal rectangle, and reports the left overflow as offset_x.
+    try testing.expectEqual(@as(u32, 20), bm.width);
+    try testing.expectEqual(@as(u32, 20), bm.height);
+    try testing.expectEqual(@as(i32, -5), bm.offset_x);
+    try testing.expect(bm.data[10 * bm.width + 1] > 200);
+    try testing.expect(bm.data[10 * bm.width + 18] > 200);
 }
 
 test "glyf_rasterize: quadratic contour renders" {

--- a/src/font/opentype/glyf.zig
+++ b/src/font/opentype/glyf.zig
@@ -50,6 +50,23 @@ pub const Glyf = struct {
             return self.points[start..end];
         }
 
+        /// Deep copy this outline using `alloc`.
+        ///
+        /// The returned outline owns its contour and point storage and must be
+        /// released with `deinit`.
+        pub fn clone(self: *const Outline, alloc: Allocator) Allocator.Error!Outline {
+            const contours = try alloc.dupe(sfnt.uint16, self.contours);
+            errdefer alloc.free(contours);
+
+            const points = try alloc.dupe(Point, self.points);
+            errdefer alloc.free(points);
+
+            return .{
+                .contours = contours,
+                .points = points,
+            };
+        }
+
         /// Free all memory owned by this outline. Pass in the same
         /// allocator used for decoding.
         pub fn deinit(self: *Outline, alloc: Allocator) void {

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -17,6 +17,7 @@ const noMinContrast = cellpkg.noMinContrast;
 const constraintWidth = cellpkg.constraintWidth;
 const isCovering = cellpkg.isCovering;
 const rowNeverExtendBg = @import("row.zig").neverExtendBg;
+const glyph_protocol = @import("glyph_protocol.zig");
 const Overlay = @import("Overlay.zig");
 const imagepkg = @import("image.zig");
 const ImageState = imagepkg.State;
@@ -172,6 +173,9 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
         font_grid: *font.SharedGrid,
         font_shaper: font.Shaper,
         font_shaper_cache: font.ShaperCache,
+
+        /// Renderer-local snapshot of per-session Glyph Protocol entries.
+        glyph_protocol: glyph_protocol.State = .empty,
 
         /// The images that we may render.
         images: ImageState = .empty,
@@ -815,6 +819,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
 
             self.font_shaper.deinit();
             self.font_shaper_cache.deinit(self.alloc);
+            self.glyph_protocol.deinit(self.alloc);
 
             self.config.deinit();
 
@@ -1074,6 +1079,11 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             // Update our grid
             self.font_grid = grid;
 
+            // When our font grid changes, our cell metrics can change,
+            // our atlas is gone, etc. so invalid all prior glyph
+            // protocol rasterizations.
+            self.glyph_protocol.invalidateRasterized();
+
             // Update all our textures so that they sync on the next frame.
             // We can modify this without a lock because the GPU does not
             // touch this data.
@@ -1197,6 +1207,20 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
 
                     // Scroll
                     state.terminal.scrollViewport(.bottom);
+                }
+
+                // Sync our Glyph Protocol state before updating the render
+                // state because RenderState.update consumes terminal dirty
+                // flags, including glyph_glossary.
+                if (state.terminal.flags.dirty.glyph_glossary) {
+                    self.glyph_protocol.syncFromGlossary(
+                        self.alloc,
+                        &state.terminal.glyph_glossary,
+                    ) catch |err| {
+                        // Don't hard fail the frame update, just degrade
+                        // to showing some invalid glyphs.
+                        log.warn("error syncing glyph protocol state err={}", .{err});
+                    };
                 }
 
                 // Update our terminal state
@@ -3172,6 +3196,59 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
         ) !void {
             const cell = cell_raws[x];
             const cp = cell.codepoint();
+
+            // If we have a glyph via the glyph protocol, render that.
+            if (self.glyph_protocol.renderGlyph(
+                self.alloc,
+                self.font_grid,
+                self.grid_metrics,
+                cp,
+            ) catch |err| switch (err) {
+                error.OutOfMemory => return error.OutOfMemory,
+                error.RasterizationFailed => glyph: {
+                    // If rasterization fails for any reason, just render the
+                    // replacement char to show some invalid character is
+                    // here.
+                    log.warn("error rasterizing glyph protocol glyph, rendering replacement character cp={X}", .{cp});
+                    const replacement = try self.font_grid.renderCodepoint(
+                        self.alloc,
+                        0xFFFD,
+                        .regular,
+                        .text,
+                        .{
+                            .grid_metrics = self.grid_metrics,
+                            .cell_width = cell.gridWidth(),
+                        },
+                    );
+
+                    break :glyph if (replacement) |render|
+                        render.glyph
+                    else {
+                        // Super weird, we should always have something for
+                        // the replacement char. Log it and just render
+                        // nothing I guess.
+                        log.warn("replacement character couldn't render", .{});
+                        return;
+                    };
+                },
+            }) |glyph| {
+                // If the glyph is 0 width or height, it will be invisible
+                // when drawn, so don't bother adding it to the buffer.
+                if (glyph.width == 0 or glyph.height == 0) return;
+                try self.cells.add(self.alloc, .text, .{
+                    // For now, we only support grayscale glyphs.
+                    .atlas = .grayscale,
+                    .grid_pos = .{ @intCast(x), @intCast(y) },
+                    .color = .{ color.r, color.g, color.b, alpha },
+                    .glyph_pos = .{ glyph.atlas_x, glyph.atlas_y },
+                    .glyph_size = .{ glyph.width, glyph.height },
+                    .bearings = .{
+                        @intCast(glyph.offset_x),
+                        @intCast(glyph.offset_y),
+                    },
+                });
+                return;
+            }
 
             // Render
             const render = try self.font_grid.renderGlyph(

--- a/src/renderer/glyph_protocol.zig
+++ b/src/renderer/glyph_protocol.zig
@@ -1,0 +1,318 @@
+const std = @import("std");
+const testing = std.testing;
+const Allocator = std.mem.Allocator;
+
+const font = @import("../font/main.zig");
+const glyf_rasterize = font.glyf_rasterize;
+const Glossary = @import("../terminal/main.zig").apc.glyph.Glossary;
+const Glyf = @import("../font/opentype/glyf.zig").Glyf;
+
+/// Map of registered codepoints in renderer-local state.
+pub const CodepointMap = std.AutoArrayHashMapUnmanaged(u21, Codepoint);
+
+/// Renderer-local Glyph Protocol state for one terminal session.
+///
+/// The terminal owns the authoritative `Glossary`, but the renderer cannot
+/// keep pointers into it because rendering happens outside the terminal mutex
+/// and rasterized atlas metadata has renderer-specific lifetime.
+///
+/// This state is a snapshot of the terminal glossary plus lazy rasterization
+/// cache for glyphs that have actually appeared on screen.
+pub const State = struct {
+    /// Registered codepoints keyed by Unicode scalar value.
+    codepoints: CodepointMap = .empty,
+
+    /// Empty initial state with no registrations and no allocated storage.
+    pub const empty: State = .{ .codepoints = .empty };
+
+    /// Release all cloned glossary entries and map storage owned by this state.
+    pub fn deinit(self: *State, alloc: Allocator) void {
+        for (self.codepoints.values()) |*entry| entry.deinit(alloc);
+        self.codepoints.deinit(alloc);
+        self.* = undefined;
+    }
+
+    /// Synchronize the renderer-local state from the terminal glossary.
+    ///
+    /// This does a full replacement rather than attempting to diff because the
+    /// glossary is spec-limited to 1024 entries and full replacement naturally
+    /// invalidates rasterized glyphs for clear, overwrite, and FIFO eviction.
+    /// If cloning fails, the previous renderer state is left intact.
+    pub fn syncFromGlossary(
+        self: *State,
+        alloc: Allocator,
+        glossary: *const Glossary,
+    ) Allocator.Error!void {
+        // Build a complete replacement first. If any clone/allocation fails,
+        // errdefer releases the partial map and `self` continues to point at
+        // the previous successfully-synced snapshot.
+        var new_codepoints: CodepointMap = .empty;
+        errdefer deinitMap(&new_codepoints, alloc);
+
+        try new_codepoints.ensureTotalCapacity(alloc, glossary.entries.count());
+        for (glossary.entries.keys(), glossary.entries.values()) |cp, *entry| {
+            new_codepoints.putAssumeCapacityNoClobber(cp, .{
+                .entry = try entry.clone(alloc),
+            });
+        }
+
+        // Only after the new snapshot is complete do we release the old one.
+        // This makes sync failure non-destructive, which lets the renderer
+        // fall back to the last good snapshot under memory pressure.
+        deinitMap(&self.codepoints, alloc);
+        self.codepoints = new_codepoints;
+    }
+
+    /// Invalidate rasterized atlas metadata while preserving registration
+    /// entries so they can be re-rasterized for a new font grid or cell size.
+    ///
+    /// Call this when the terminal grid metrics change in any way.
+    pub fn invalidateRasterized(self: *State) void {
+        for (self.codepoints.values()) |*entry| entry.rasterized = null;
+    }
+
+    /// Errors that callers of `renderGlyph` can meaningfully react to.
+    pub const RenderError = Allocator.Error || error{
+        /// The decoded glyph could not be rasterized by the renderer.
+        RasterizationFailed,
+    };
+
+    /// Render a registered codepoint into the shared grayscale atlas, lazily.
+    ///
+    /// The returned glyph is atlas metadata only. The underlying registration
+    /// entry is kept so font-grid changes can invalidate and rasterize again.
+    pub fn renderGlyph(
+        self: *State,
+        alloc: Allocator,
+        grid: *font.SharedGrid,
+        grid_metrics: font.Metrics,
+        cp: u21,
+    ) RenderError!?font.Glyph {
+        const codepoint = self.codepoints.getPtr(cp) orelse return null;
+
+        // Fast path: the glyph was already rasterized into the current font
+        // atlas. `font.Glyph` is just atlas metadata, so returning it by value
+        // is cheap and avoids touching the cloned outline again.
+        if (codepoint.rasterized) |glyph| return glyph;
+
+        const entry = &codepoint.entry;
+
+        // Glyph Protocol `width` is the requested cell span. Use it for both
+        // the bitmap width and constraint span so sizing/alignment/padding are
+        // applied over the same 1- or 2-cell render span described by the spec.
+        const width_cells: u2 = switch (entry.width) {
+            .narrow => 1,
+            .wide => 2,
+        };
+
+        // Decode-time validation already guaranteed this is a supported glyf
+        // outline. Rasterization happens lazily because applications may
+        // register many glyphs that never become visible.
+        var bitmap = switch (entry.glyph) {
+            .glyf => |outline| glyf_rasterize.rasterize(
+                alloc,
+                outline,
+                entry.design,
+                .{
+                    .grid_metrics = grid_metrics,
+                    .cell_width = width_cells,
+                    .constraint = entry.constraint,
+                    .constraint_width = width_cells,
+                },
+            ) catch |err| switch (err) {
+                error.OutOfMemory => return error.OutOfMemory,
+
+                error.NoCurrentPoint,
+                error.InvalidMatrix,
+                error.PathNotClosed,
+                error.InvalidHeight,
+                error.InvalidWidth,
+                error.InvalidState,
+                => return error.RasterizationFailed,
+            },
+        };
+        defer bitmap.deinit(alloc);
+
+        // Cache the empty result too. This prevents repeated rasterization for
+        // valid but visually-empty outlines while keeping downstream render code
+        // on the normal zero-sized-glyph skip path.
+        if (bitmap.width == 0 or bitmap.height == 0) {
+            codepoint.rasterized = .{
+                .width = 0,
+                .height = 0,
+                .offset_x = 0,
+                .offset_y = 0,
+                .atlas_x = 0,
+                .atlas_y = 0,
+            };
+            return codepoint.rasterized.?;
+        }
+
+        // Atlas allocation and writes must hold the shared grid lock. The more
+        // expensive vector rasterization above intentionally happens outside the
+        // lock so other surfaces sharing this grid are blocked for less time.
+        grid.lock.lock();
+        defer grid.lock.unlock();
+
+        // Reuse the normal font grayscale atlas. If it fills up, grow it and
+        // retry just like SharedGrid.renderGlyph does for regular font glyphs.
+        const region = region: while (true) {
+            break :region grid.atlas_grayscale.reserve(
+                alloc,
+                bitmap.width,
+                bitmap.height,
+            ) catch |err| switch (err) {
+                error.OutOfMemory => return error.OutOfMemory,
+                error.AtlasFull => {
+                    try grid.atlas_grayscale.grow(alloc, grid.atlas_grayscale.size * 2);
+                    continue;
+                },
+            };
+        };
+        grid.atlas_grayscale.set(region, bitmap.data);
+
+        // A Glyph Protocol glyf bitmap is rasterized as a full render-span
+        // bitmap. A top bearing equal to bitmap height places the top of the
+        // quad at the top of the cell in the existing text shader convention.
+        codepoint.rasterized = .{
+            .width = bitmap.width,
+            .height = bitmap.height,
+            .offset_x = 0,
+            .offset_y = @intCast(bitmap.height),
+            .atlas_x = region.x,
+            .atlas_y = region.y,
+        };
+
+        return codepoint.rasterized.?;
+    }
+
+    /// Release a codepoint map and all cloned entries in it.
+    ///
+    /// This helper resets the map to `.empty` so it can be safely reused after
+    /// both successful replacement and error-path cleanup.
+    fn deinitMap(map: *CodepointMap, alloc: Allocator) void {
+        for (map.values()) |*entry| entry.deinit(alloc);
+        map.deinit(alloc);
+        map.* = .empty;
+    }
+};
+
+/// One registered codepoint in the renderer snapshot.
+pub const Codepoint = struct {
+    /// Cloned terminal glossary entry. This is kept even after rasterization so
+    /// font grid changes can discard atlas metadata and rasterize again.
+    entry: Glossary.Entry,
+
+    /// Cached atlas metadata for the current font grid, if visible before.
+    rasterized: ?font.Glyph = null,
+
+    /// Release the cloned glossary entry owned by this codepoint.
+    pub fn deinit(self: *Codepoint, alloc: Allocator) void {
+        self.entry.deinit(alloc);
+        self.* = undefined;
+    }
+};
+
+fn testEntry(alloc: Allocator, x_offset: i32) !Glossary.Entry {
+    const contours = try alloc.dupe(u16, &.{2});
+    errdefer alloc.free(contours);
+
+    const points = try alloc.dupe(Glyf.Outline.Point, &.{
+        .{ .x = x_offset, .y = 0, .on_curve = true },
+        .{ .x = x_offset + 500, .y = 0, .on_curve = true },
+        .{ .x = x_offset, .y = 500, .on_curve = true },
+    });
+    errdefer alloc.free(points);
+
+    return .{
+        .glyph = .{ .glyf = .{
+            .contours = contours,
+            .points = points,
+        } },
+        .design = .{
+            .units_per_em = 1000,
+            .advance_width = 1000,
+            .line_height = 1000,
+        },
+        .width = .narrow,
+        .constraint = .none,
+    };
+}
+
+test "State syncFromGlossary clones terminal entries" {
+    const alloc = testing.allocator;
+
+    var glossary: Glossary = .empty;
+    defer glossary.deinit(alloc);
+    try glossary.register(alloc, 0xE000, try testEntry(alloc, 0));
+
+    var state: State = .empty;
+    defer state.deinit(alloc);
+    try state.syncFromGlossary(alloc, &glossary);
+
+    try testing.expect(state.codepoints.contains(0xE000));
+    try testing.expect(!state.codepoints.contains(0xE001));
+
+    const src = glossary.entries.getPtr(0xE000).?;
+    const dst = state.codepoints.getPtr(0xE000).?;
+    try testing.expect(src.glyph.glyf.points.ptr != dst.entry.glyph.glyf.points.ptr);
+    try testing.expectEqual(src.glyph.glyf.points[0], dst.entry.glyph.glyf.points[0]);
+}
+
+test "State syncFromGlossary replaces removed and changed entries" {
+    const alloc = testing.allocator;
+
+    var glossary: Glossary = .empty;
+    defer glossary.deinit(alloc);
+    try glossary.register(alloc, 0xE000, try testEntry(alloc, 0));
+
+    var state: State = .empty;
+    defer state.deinit(alloc);
+    try state.syncFromGlossary(alloc, &glossary);
+
+    try glossary.register(alloc, 0xE001, try testEntry(alloc, 10));
+    try glossary.delete(alloc, 0xE000);
+    try state.syncFromGlossary(alloc, &glossary);
+
+    try testing.expect(!state.codepoints.contains(0xE000));
+    try testing.expect(state.codepoints.contains(0xE001));
+    try testing.expectEqual(@as(i32, 10), state.codepoints.getPtr(0xE001).?.entry.glyph.glyf.points[0].x);
+}
+
+test "State invalidateRasterized clears cached glyph metadata" {
+    const alloc = testing.allocator;
+
+    var glossary: Glossary = .empty;
+    defer glossary.deinit(alloc);
+    try glossary.register(alloc, 0xE000, try testEntry(alloc, 0));
+
+    var state: State = .empty;
+    defer state.deinit(alloc);
+    try state.syncFromGlossary(alloc, &glossary);
+
+    const codepoint = state.codepoints.getPtr(0xE000).?;
+    codepoint.rasterized = .{
+        .width = 1,
+        .height = 1,
+        .offset_x = 0,
+        .offset_y = 1,
+        .atlas_x = 2,
+        .atlas_y = 3,
+    };
+
+    state.invalidateRasterized();
+    try testing.expect(codepoint.rasterized == null);
+}
+
+test "State renderGlyph returns null for unregistered codepoint" {
+    var state: State = .empty;
+
+    const grid: *font.SharedGrid = undefined;
+    const glyph = try state.renderGlyph(
+        testing.allocator,
+        grid,
+        undefined,
+        0xE000,
+    );
+    try testing.expect(glyph == null);
+}

--- a/src/renderer/glyph_protocol.zig
+++ b/src/renderer/glyph_protocol.zig
@@ -171,13 +171,16 @@ pub const State = struct {
         };
         grid.atlas_grayscale.set(region, bitmap.data);
 
-        // A Glyph Protocol glyf bitmap is rasterized as a full render-span
-        // bitmap. A top bearing equal to bitmap height places the top of the
-        // quad at the top of the cell in the existing text shader convention.
+        // The glyf rasterizer returns an atlas-ready bitmap plus bearings in
+        // the same coordinate convention as normal font glyphs. `offset_x` may
+        // be negative when the protocol sizing rules allow horizontal overflow
+        // before the cell origin. A top bearing equal to bitmap height places
+        // the top of the quad at the top of the cell in the existing text
+        // shader convention.
         codepoint.rasterized = .{
             .width = bitmap.width,
             .height = bitmap.height,
-            .offset_x = 0,
+            .offset_x = bitmap.offset_x,
             .offset_y = @intCast(bitmap.height),
             .atlas_x = region.x,
             .atlas_y = region.y,

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -567,7 +567,7 @@ pub fn print(self: *Terminal, c: u21) !void {
     // non-single-width characters properly. We have a fast-path for
     // byte-sized characters since they're so common. We can ignore
     // control characters because they're always filtered prior.
-    const width: usize = if (c <= 0xFF) 1 else @intCast(unicode.table.get(c).width);
+    const width = self.printWidth(c);
 
     // Note: it is possible to have a width of "3" and a width of "-1" from
     // uucode.x's wcwidth. We should look into those cases and handle them
@@ -698,6 +698,28 @@ pub fn print(self: *Terminal, c: u21) !void {
 
     // Move the cursor
     self.screens.active.cursorRight(1);
+}
+
+/// Return the terminal layout width for a codepoint.
+///
+/// This is on the print hot path. Glyph Protocol widths are authoritative for
+/// registered codepoints, but registrations are PUA-only, so keep the common
+/// paths free of glossary hash-map lookups.
+inline fn printWidth(self: *const Terminal, c: u21) usize {
+    if (c <= 0xFF) return 1;
+
+    if (!self.glyph_glossary.isEmpty() and glyph.Glossary.isPrivateUse(c)) {
+        @branchHint(.unlikely);
+
+        if (self.glyph_glossary.registeredWidth(c)) |width| {
+            return switch (width) {
+                .narrow => 1,
+                .wide => 2,
+            };
+        }
+    }
+
+    return @intCast(unicode.table.get(c).width);
 }
 
 fn printCell(
@@ -3377,6 +3399,29 @@ test "Terminal: print single very long line" {
     for (0..1000) |_| try t.print('x');
 }
 
+fn testRegisterGlyphWidth(
+    t: *Terminal,
+    alloc: Allocator,
+    cp: u21,
+    width: glyph.request.Width,
+) !void {
+    const data = try std.fmt.allocPrint(
+        alloc,
+        "r;cp={x};width={d};AAAAAAAAAAAAAA==",
+        .{ cp, @intFromEnum(width) },
+    );
+    defer alloc.free(data);
+
+    var parser = glyph.CommandParser.init(alloc, 1024 * 1024);
+    defer parser.deinit();
+    for (data) |byte| try parser.feed(byte);
+
+    var req = try parser.complete(alloc);
+    defer req.deinit(alloc);
+
+    _ = t.glyphProtocol(alloc, &req);
+}
+
 test "Terminal: print wide char" {
     var t = try init(testing.allocator, .{ .cols = 80, .rows = 80 });
     defer t.deinit(testing.allocator);
@@ -3398,6 +3443,56 @@ test "Terminal: print wide char" {
     }
 
     try testing.expect(t.isDirty(.{ .screen = .{ .x = 0, .y = 0 } }));
+}
+
+test "Terminal: registered wide glyph protocol PUA prints as wide" {
+    const alloc = testing.allocator;
+    var t = try init(alloc, .{ .cols = 80, .rows = 80 });
+    defer t.deinit(alloc);
+
+    try testRegisterGlyphWidth(&t, alloc, 0xE0A0, .wide);
+    try t.print(0xE0A0);
+
+    try testing.expectEqual(@as(usize, 0), t.screens.active.cursor.y);
+    try testing.expectEqual(@as(usize, 2), t.screens.active.cursor.x);
+
+    {
+        const list_cell = t.screens.active.pages.getCell(.{ .screen = .{ .x = 0, .y = 0 } }).?;
+        const cell = list_cell.cell;
+        try testing.expectEqual(@as(u21, 0xE0A0), cell.content.codepoint);
+        try testing.expectEqual(Cell.Wide.wide, cell.wide);
+    }
+    {
+        const list_cell = t.screens.active.pages.getCell(.{ .screen = .{ .x = 1, .y = 0 } }).?;
+        const cell = list_cell.cell;
+        try testing.expectEqual(Cell.Wide.spacer_tail, cell.wide);
+    }
+}
+
+test "Terminal: registered narrow glyph protocol PUA overrides previous wide registration" {
+    const alloc = testing.allocator;
+    var t = try init(alloc, .{ .cols = 80, .rows = 80 });
+    defer t.deinit(alloc);
+
+    try testRegisterGlyphWidth(&t, alloc, 0xE0A0, .wide);
+    try testRegisterGlyphWidth(&t, alloc, 0xE0A0, .narrow);
+    try t.print(0xE0A0);
+
+    try testing.expectEqual(@as(usize, 0), t.screens.active.cursor.y);
+    try testing.expectEqual(@as(usize, 1), t.screens.active.cursor.x);
+
+    {
+        const list_cell = t.screens.active.pages.getCell(.{ .screen = .{ .x = 0, .y = 0 } }).?;
+        const cell = list_cell.cell;
+        try testing.expectEqual(@as(u21, 0xE0A0), cell.content.codepoint);
+        try testing.expectEqual(Cell.Wide.narrow, cell.wide);
+    }
+    {
+        const list_cell = t.screens.active.pages.getCell(.{ .screen = .{ .x = 1, .y = 0 } }).?;
+        const cell = list_cell.cell;
+        try testing.expectEqual(@as(u21, 0), cell.content.codepoint);
+        try testing.expectEqual(Cell.Wide.narrow, cell.wide);
+    }
 }
 
 test "Terminal: print wide char at edge creates spacer head" {
@@ -3432,6 +3527,36 @@ test "Terminal: print wide char at edge creates spacer head" {
     // BUT old row is dirty because cursor moved from there
     try testing.expect(t.isDirty(.{ .screen = .{ .x = 0, .y = 0 } }));
     try testing.expect(t.isDirty(.{ .screen = .{ .x = 0, .y = 1 } }));
+}
+
+test "Terminal: registered wide glyph protocol PUA at edge creates spacer head" {
+    const alloc = testing.allocator;
+    var t = try init(alloc, .{ .cols = 10, .rows = 10 });
+    defer t.deinit(alloc);
+
+    try testRegisterGlyphWidth(&t, alloc, 0xE0A0, .wide);
+
+    t.setCursorPos(1, 10);
+    try t.print(0xE0A0);
+    try testing.expectEqual(@as(usize, 1), t.screens.active.cursor.y);
+    try testing.expectEqual(@as(usize, 2), t.screens.active.cursor.x);
+
+    {
+        const list_cell = t.screens.active.pages.getCell(.{ .screen = .{ .x = 9, .y = 0 } }).?;
+        const cell = list_cell.cell;
+        try testing.expectEqual(Cell.Wide.spacer_head, cell.wide);
+    }
+    {
+        const list_cell = t.screens.active.pages.getCell(.{ .screen = .{ .x = 0, .y = 1 } }).?;
+        const cell = list_cell.cell;
+        try testing.expectEqual(@as(u21, 0xE0A0), cell.content.codepoint);
+        try testing.expectEqual(Cell.Wide.wide, cell.wide);
+    }
+    {
+        const list_cell = t.screens.active.pages.getCell(.{ .screen = .{ .x = 1, .y = 1 } }).?;
+        const cell = list_cell.cell;
+        try testing.expectEqual(Cell.Wide.spacer_tail, cell.wide);
+    }
 }
 
 test "Terminal: print wide char with 1-column width" {

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -3208,6 +3208,11 @@ pub fn fullReset(self: *Terminal) void {
 
     // Always mark dirty so we redraw everything
     self.flags.dirty.clear = true;
+
+    // The clear dirty bit is enough to force a full render-state rebuild, but
+    // renderers keep their own cloned Glyph Protocol state. Set the glossary
+    // dirty bit too so they sync and drop any registrations cleared above.
+    self.flags.dirty.glyph_glossary = true;
 }
 
 /// Returns true if the point is dirty, used for testing.

--- a/src/terminal/apc/glyph/Glossary.zig
+++ b/src/terminal/apc/glyph/Glossary.zig
@@ -108,8 +108,23 @@ pub fn clearAndFree(self: *Glossary, alloc: Allocator) void {
 }
 
 /// Contains returns true if the codepoint is covered by the glossary.
-pub fn contains(self: *Glossary, cp: u21) bool {
+pub fn contains(self: *const Glossary, cp: u21) bool {
     return self.entries.contains(cp);
+}
+
+/// Return true if the glossary has no registered glyphs.
+pub fn isEmpty(self: *const Glossary) bool {
+    return self.entries.count() == 0;
+}
+
+/// Return the registered layout width for `cp`, if any.
+///
+/// Glyph Protocol `width` is authoritative for terminal layout decisions for
+/// registered codepoints. Callers should still avoid this map lookup unless
+/// `cp` is in a Private Use Area, because registrations are PUA-only.
+pub fn registeredWidth(self: *const Glossary, cp: u21) ?request.Width {
+    const entry = self.entries.get(cp) orelse return null;
+    return entry.width;
 }
 
 /// A single glyph registration entry.
@@ -268,7 +283,7 @@ pub const Entry = struct {
 };
 
 /// Return true if `cp` is in one of the Unicode Private Use Areas.
-fn isPrivateUse(cp: u21) bool {
+pub inline fn isPrivateUse(cp: u21) bool {
     return (cp >= 0xE000 and cp <= 0xF8FF) or
         (cp >= 0xF0000 and cp <= 0xFFFFD) or
         (cp >= 0x100000 and cp <= 0x10FFFD);
@@ -478,4 +493,33 @@ test "Glossary contains reports registered slots" {
     try glossary.register(alloc, 0xE000, try testRegisterEntry(alloc, 0xE000));
     try testing.expect(glossary.contains(0xE000));
     try testing.expect(!glossary.contains(0xE001));
+}
+
+test "Glossary registeredWidth tracks register overwrite delete and clear" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var glossary: Glossary = .empty;
+    defer glossary.deinit(alloc);
+
+    try testing.expect(glossary.isEmpty());
+    try testing.expect(glossary.registeredWidth(0xE000) == null);
+
+    try glossary.register(alloc, 0xE000, try testRegisterEntry(alloc, 0xE000));
+    try testing.expect(!glossary.isEmpty());
+    try testing.expectEqual(request.Width.wide, glossary.registeredWidth(0xE000).?);
+
+    var entry = try testRegisterEntry(alloc, 0xE000);
+    entry.width = .narrow;
+    try glossary.register(alloc, 0xE000, entry);
+    try testing.expectEqual(request.Width.narrow, glossary.registeredWidth(0xE000).?);
+
+    try glossary.delete(alloc, 0xE000);
+    try testing.expect(glossary.isEmpty());
+    try testing.expect(glossary.registeredWidth(0xE000) == null);
+
+    try glossary.register(alloc, 0xE000, try testRegisterEntry(alloc, 0xE000));
+    glossary.clearAndFree(alloc);
+    try testing.expect(glossary.isEmpty());
+    try testing.expect(glossary.registeredWidth(0xE000) == null);
 }

--- a/src/terminal/apc/glyph/Glossary.zig
+++ b/src/terminal/apc/glyph/Glossary.zig
@@ -193,6 +193,23 @@ pub const Entry = struct {
         self.* = undefined;
     }
 
+    /// Deep copy this glossary entry using `alloc`.
+    ///
+    /// The returned entry owns decoded glyph memory and must be released with
+    /// `deinit`.
+    pub fn clone(self: *const Entry, alloc: Allocator) Allocator.Error!Entry {
+        const glyph: Glyph = switch (self.glyph) {
+            .glyf => |*outline| .{ .glyf = try outline.clone(alloc) },
+        };
+
+        return .{
+            .glyph = glyph,
+            .design = self.design,
+            .width = self.width,
+            .constraint = self.constraint,
+        };
+    }
+
     /// Return the renderer constraint for a register request.
     ///
     /// Glyph Protocol §8.5 defines sizing, alignment, and padding in terms of
@@ -318,6 +335,26 @@ test "Entry init decodes glyf payload and applies register fields" {
 
     try testing.expectEqual(@as(usize, 3), entry.glyph.glyf.points.len);
     try testing.expectEqual(@as(usize, 1), entry.glyph.glyf.contours.len);
+}
+
+test "Entry clone deep copies decoded glyf payload" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var entry = try testRegisterEntry(alloc, 0xE000);
+    defer entry.deinit(alloc);
+
+    var cloned = try entry.clone(alloc);
+    defer cloned.deinit(alloc);
+
+    try testing.expectEqual(entry.design, cloned.design);
+    try testing.expectEqual(entry.width, cloned.width);
+    try testing.expectEqual(entry.constraint, cloned.constraint);
+
+    try testing.expectEqualSlices(u16, entry.glyph.glyf.contours, cloned.glyph.glyf.contours);
+    try testing.expectEqualSlices(Glyf.Outline.Point, entry.glyph.glyf.points, cloned.glyph.glyf.points);
+    try testing.expect(entry.glyph.glyf.contours.ptr != cloned.glyph.glyf.contours.ptr);
+    try testing.expect(entry.glyph.glyf.points.ptr != cloned.glyph.glyf.points.ptr);
 }
 
 test "Entry init rejects invalid register payload" {


### PR DESCRIPTION
This adds the renderer part of the glyph protocol, tying together all the other work we did.

<img width="2400" height="1196" alt="CleanShot 2026-06-05 at 21 16 41@2x" src="https://github.com/user-attachments/assets/b6ae9d20-3685-4457-a49c-e05e1008faa5" />
