### PR TITLE
Load configuration from XDG system config

### DIFF
--- a/src/build/mdgen/ghostty_1_footer.md
+++ b/src/build/mdgen/ghostty_1_footer.md
@@ -2,7 +2,11 @@
 
 _\$XDG_CONFIG_HOME/ghostty/config.ghostty_
 
-: Location of the default configuration file.
+: Location of the default user configuration file.
+
+_\$XDG_CONFIG_DIRS/ghostty/config.ghostty_
+
+: Location of the default system configuration files.
 
 _\$HOME/Library/Application Support/com.mitchellh.ghostty/config.ghostty_
 
@@ -32,6 +36,9 @@ for configuration files.
 
 : **MACOS ONLY** default location for configuration files. This location takes
 precedence over the XDG environment locations.
+**XDG_CONFIG_DIRS**
+
+: Colon separated list of paths to load configuration files.
 
 **LOCALAPPDATA**
 

--- a/src/build/mdgen/ghostty_5_footer.md
+++ b/src/build/mdgen/ghostty_5_footer.md
@@ -2,7 +2,11 @@
 
 _\$XDG_CONFIG_HOME/ghostty/config.ghostty_
 
-: Location of the default configuration file.
+: Location of the default user configuration file.
+
+_\$XDG_CONFIG_DIRS/ghostty/config.ghostty_
+
+: Location of the default system configuration files.
 
 _\$HOME/Library/Application Support/com.mitchellh.ghostty/config.ghostty_
 
@@ -24,6 +28,9 @@ for configuration files.
 
 : **MACOS ONLY** default location for configuration files. This location takes
 precedence over the XDG environment locations.
+**XDG_CONFIG_DIRS**
+
+: Colon separated list of paths to load configuration files.
 
 **LOCALAPPDATA**
 

--- a/src/cli/ssh-cache/DiskCache.zig
+++ b/src/cli/ssh-cache/DiskCache.zig
@@ -26,7 +26,7 @@ pub fn defaultPath(
     alloc: Allocator,
     program: []const u8,
 ) ![]const u8 {
-    const state_dir: []const u8 = xdg.state(
+    const state_dir: []const u8 = xdg.UserDir.state.path(
         alloc,
         .{ .subdir = program },
     ) catch |err| return switch (err) {

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -61,6 +61,9 @@ const c = @cImport({
     @cInclude("unistd.h");
 });
 
+pub const directory_name = "ghostty";
+pub const file_name = "config.ghostty";
+
 pub const compatibility = std.StaticStringMap(
     cli.CompatibilityHandler(Config),
 ).initComptime(&.{
@@ -2478,8 +2481,10 @@ keybind: Keybinds = .{},
 @"config-file": RepeatablePath = .{},
 
 /// When this is true, the default configuration file paths will be loaded.
-/// The default configuration file paths are currently only the XDG
-/// config path ($XDG_CONFIG_HOME/ghostty/config.ghostty).
+/// The default configuration files are at ./ghostty/config.ghostty,
+/// in each of the colon seperated directories in $XDG_CONFIG_DIRS, and,
+/// the xdg user config directory $XDG_CONFIG_HOME
+/// (/etc/xdg and ~/.config if these environment variables are not set).
 ///
 /// If this is false, the default configuration paths will not be loaded.
 /// This is targeted directly at using Ghostty from the CLI in a way
@@ -4023,8 +4028,9 @@ fn writeConfigTemplate(path: []const u8) !void {
     try writer.flush();
 }
 
-/// Load configurations from the default configuration files. The default
-/// configuration file is at `$XDG_CONFIG_HOME/ghostty/config.ghostty`.
+/// Load configurations from the default configuration files.
+/// The default system configuration files are at `$XDG_CONFIG_DIRS/ghostty/config.ghostty`.
+/// The default user configuration file is at `$XDG_CONFIG_HOME/ghostty/config.ghostty`.
 ///
 /// On macOS, `$HOME/Library/Application Support/$CFBundleIdentifier/`
 /// is also loaded.
@@ -4032,23 +4038,27 @@ fn writeConfigTemplate(path: []const u8) !void {
 /// The legacy `config` file (without extension) is first loaded,
 /// then `config.ghostty`.
 pub fn loadDefaultFiles(self: *Config, alloc: Allocator) !void {
-    // Load XDG first
-    const legacy_xdg_path = try file_load.legacyDefaultXdgPath(alloc);
-    defer alloc.free(legacy_xdg_path);
-    const xdg_path = try file_load.defaultXdgPath(alloc);
-    defer alloc.free(xdg_path);
-    const xdg_loaded: bool = xdg_loaded: {
-        const legacy_xdg_action = self.loadOptionalFile(alloc, legacy_xdg_path);
-        const xdg_action = self.loadOptionalFile(alloc, xdg_path);
-        if (xdg_action != .not_found and legacy_xdg_action != .not_found) {
-            log.warn("both config files `{s}` and `{s}` exist.", .{ legacy_xdg_path, xdg_path });
-            log.warn("loading them both in that order", .{});
-            break :xdg_loaded true;
+    const config_subdir = try std.fs.path.join(alloc, &[_][]const u8{
+        directory_name,
+        file_name,
+    });
+    defer alloc.free(config_subdir);
+    var it = internal_os.xdg.Dir.config.iter(alloc, .{ .subdir = config_subdir });
+    var xdg_loaded = false;
+    while (try it.next()) |candidate| {
+        defer alloc.free(candidate);
+        if (.loaded == self.loadOptionalFile(alloc, candidate)) {
+            xdg_loaded = true;
         }
+    }
 
-        break :xdg_loaded xdg_action != .not_found or
-            legacy_xdg_action != .not_found;
-    };
+    if (!xdg_loaded) {
+        // TODO(review): should we check the legacy naming for all system config dirs too?
+        const xdg_path = try file_load.legacyDefaultXdgPath(alloc);
+        defer alloc.free(xdg_path);
+        const action = self.loadOptionalFile(alloc, xdg_path);
+        if (action == .loaded) xdg_loaded = true;
+    }
 
     // On macOS load the app support directory as well
     if (comptime builtin.os.tag == .macos) {
@@ -4096,6 +4106,8 @@ pub fn loadDefaultFiles(self: *Config, alloc: Allocator) !void {
         }
     } else {
         if (!xdg_loaded) {
+            const xdg_path = try file_load.defaultXdgPath(alloc);
+            defer alloc.free(xdg_path);
             writeConfigTemplate(xdg_path) catch |err| {
                 log.warn("error creating template config file err={}", .{err});
             };

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -4020,6 +4020,7 @@ fn writeConfigTemplate(path: []const u8) !void {
         @embedFile("./config-template"),
         .{ .path = path },
     );
+    try writer.flush();
 }
 
 /// Load configurations from the default configuration files. The default

--- a/src/config/file_load.zig
+++ b/src/config/file_load.zig
@@ -9,7 +9,7 @@ const log = std.log.scoped(.config);
 /// Default path for the XDG home configuration file. Returned value
 /// must be freed by the caller.
 pub fn defaultXdgPath(alloc: Allocator) ![]const u8 {
-    return try internal_os.xdg.config(
+    return try internal_os.xdg.UserDir.config.path(
         alloc,
         .{ .subdir = "ghostty/config.ghostty" },
     );
@@ -18,7 +18,7 @@ pub fn defaultXdgPath(alloc: Allocator) ![]const u8 {
 /// Ghostty <1.3.0 default path for the XDG home configuration file.
 /// Returned value must be freed by the caller.
 pub fn legacyDefaultXdgPath(alloc: Allocator) ![]const u8 {
-    return try internal_os.xdg.config(
+    return try internal_os.xdg.UserDir.config.path(
         alloc,
         .{ .subdir = "ghostty/config" },
     );

--- a/src/config/theme.zig
+++ b/src/config/theme.zig
@@ -30,7 +30,7 @@ pub const Location = enum {
                     "ghostty", "themes",
                 }) catch return error.OutOfMemory;
 
-                break :user internal_os.xdg.config(
+                break :user internal_os.xdg.UserDir.config.path(
                     arena_alloc,
                     .{ .subdir = subdir },
                 ) catch |err| {

--- a/src/crash/dir.zig
+++ b/src/crash/dir.zig
@@ -6,7 +6,9 @@ const internal_os = @import("../os/main.zig");
 /// Returns a Dir for the default directory. The Dir.path field must be
 /// freed with the given allocator.
 pub fn defaultDir(alloc: Allocator) !Dir {
-    const crash_dir = try internal_os.xdg.state(alloc, .{ .subdir = "ghostty/crash" });
+    const subdir = try std.fs.path.join(alloc, &[_][]const u8{ "ghostty", "crash" });
+    defer alloc.free(subdir);
+    const crash_dir = try internal_os.xdg.UserDir.state.path(alloc, .{ .subdir = subdir });
     errdefer alloc.free(crash_dir);
     return .{ .path = crash_dir };
 }

--- a/src/os/xdg.zig
+++ b/src/os/xdg.zig
@@ -310,3 +310,77 @@ test parseTerminalExec {
         try testing.expectEqualSlices([*:0]const u8, actual, &.{ "a", "-e", "b", "c" });
     }
 }
+
+/// https://specifications.freedesktop.org/basedir-spec/latest/
+pub const Dir = enum {
+    config,
+    data,
+
+    pub fn key(self: Dir) [:0]const u8 {
+        return switch (self) {
+            .config => "XDG_CONFIG_DIRS",
+            .data => "XDG_DATA_DIRS",
+        };
+    }
+
+    pub fn default(self: Dir) [:0]const u8 {
+        return switch (self) {
+            .config => "/etc/xdg",
+            .data => "/usr/local/share:/usr/share",
+        };
+    }
+};
+
+pub const DirIterator = struct {
+    data: []const u8,
+    iterator: std.mem.SplitIterator(u8, .scalar),
+
+    /// https://specifications.freedesktop.org/basedir-spec/latest/
+    pub fn init(key: Dir) DirIterator {
+        const data = data: {
+            if (posix.getenv(key.key())) |data| {
+                if (std.mem.trim(u8, data, &std.ascii.whitespace).len > 0) break :data data;
+            }
+
+            break :data key.default();
+        };
+
+        return .{
+            .data = data,
+            .iterator = std.mem.splitScalar(u8, data, ':'),
+        };
+    }
+
+    pub fn next(self: *DirIterator) ?[]const u8 {
+        return self.iterator.next();
+    }
+};
+
+test "xdg dirs" {
+    const c = @cImport({
+        @cInclude("stdlib.h");
+    });
+
+    const testing = std.testing;
+    {
+        _ = c.unsetenv(Dir.config.key());
+        var it = DirIterator.init(.config);
+        try testing.expectEqualStrings("/etc/xdg", it.next().?);
+        try testing.expect(it.next() == null);
+    }
+    {
+        _ = c.unsetenv(Dir.data.key());
+        var it = DirIterator.init(.data);
+        try testing.expectEqualStrings("/usr/local/share", it.next().?);
+        try testing.expectEqualStrings("/usr/share", it.next().?);
+        try testing.expect(it.next() == null);
+    }
+    {
+        _ = c.setenv(Dir.config.key(), "a:b:c", 1);
+        var it = DirIterator.init(.config);
+        try testing.expectEqualStrings("a", it.next().?);
+        try testing.expectEqualStrings("b", it.next().?);
+        try testing.expectEqualStrings("c", it.next().?);
+        try testing.expect(it.next() == null);
+    }
+}

--- a/src/os/xdg.zig
+++ b/src/os/xdg.zig
@@ -19,35 +19,9 @@ pub const Options = struct {
     home: ?[]const u8 = null,
 };
 
-/// Get the XDG user config directory. The returned value is allocated.
-pub fn config(alloc: Allocator, opts: Options) ![]u8 {
-    return try dir(alloc, opts, .{
-        .env = "XDG_CONFIG_HOME",
-        .windows_env = "LOCALAPPDATA",
-        .default_subdir = ".config",
-    });
-}
-
-/// Get the XDG cache directory. The returned value is allocated.
-pub fn cache(alloc: Allocator, opts: Options) ![]u8 {
-    return try dir(alloc, opts, .{
-        .env = "XDG_CACHE_HOME",
-        .windows_env = "LOCALAPPDATA",
-        .default_subdir = ".cache",
-    });
-}
-
-/// Get the XDG state directory. The returned value is allocated.
-pub fn state(alloc: Allocator, opts: Options) ![]u8 {
-    return try dir(alloc, opts, .{
-        .env = "XDG_STATE_HOME",
-        .windows_env = "LOCALAPPDATA",
-        .default_subdir = ".local/state",
-    });
-}
-
 const InternalOptions = struct {
     env: []const u8,
+    // FIXME: Windows is an unsupported target, but does libghostty-vt touch xdg.zig?
     windows_env: []const u8,
     default_subdir: []const u8,
 };
@@ -101,6 +75,43 @@ fn dir(
     return error.NoHomeDir;
 }
 
+/// XDG user directories for program config, data, cache, or, state
+pub const UserDir = enum {
+    config,
+    data,
+    cache,
+    state,
+
+    pub fn path(
+        self: UserDir,
+        alloc: Allocator,
+        opts: Options,
+    ) ![]u8 {
+        const internal_opts: InternalOptions = switch (self) {
+            .config => .{
+                .env = "XDG_CONFIG_HOME",
+                .windows_env = "LOCALAPPDATA",
+                .default_subdir = ".config",
+            },
+            .data => .{
+                .env = "XDG_DATA_HOME",
+                .windows_env = "LOCALAPPDATA",
+                .default_subdir = ".local/share",
+            },
+            .cache => .{
+                .env = "XDG_CACHE_HOME",
+                .windows_env = "LOCALAPPDATA",
+                .default_subdir = ".cache",
+            },
+            .state => .{
+                .env = "XDG_STATE_HOME",
+                .windows_env = "LOCALAPPDATA",
+                .default_subdir = ".local/state",
+            },
+        };
+        return dir(alloc, opts, internal_opts);
+    }
+};
 /// Parses the xdg-terminal-exec specification. This expects argv[0] to
 /// be "xdg-terminal-exec".
 pub fn parseTerminalExec(argv: []const [*:0]const u8) ?[]const [*:0]const u8 {
@@ -123,7 +134,7 @@ test {
     const alloc = testing.allocator;
 
     {
-        const value = try config(alloc, .{});
+        const value = try UserDir.config.path(alloc, .{});
         defer alloc.free(value);
         try testing.expect(value.len > 0);
     }
@@ -138,7 +149,7 @@ test "cache directory paths" {
     {
         // Test base path
         {
-            const cache_path = try cache(alloc, .{ .home = mock_home });
+            const cache_path = try UserDir.cache.path(alloc, .{ .home = mock_home });
             defer alloc.free(cache_path);
             const expected = try std.fs.path.join(alloc, &.{ mock_home, ".cache" });
             defer alloc.free(expected);
@@ -147,7 +158,7 @@ test "cache directory paths" {
 
         // Test with subdir
         {
-            const cache_path = try cache(alloc, .{
+            const cache_path = try UserDir.cache.path(alloc, .{
                 .home = mock_home,
                 .subdir = "ghostty",
             });
@@ -181,14 +192,14 @@ test "fallback when xdg env empty" {
 
     const DirCase = struct {
         name: [:0]const u8,
-        func: fn (Allocator, Options) anyerror![]u8,
+        dir_type: UserDir,
         default_subdir: []const u8,
     };
 
     const cases = [_]DirCase{
-        .{ .name = "XDG_CONFIG_HOME", .func = config, .default_subdir = ".config" },
-        .{ .name = "XDG_CACHE_HOME", .func = cache, .default_subdir = ".cache" },
-        .{ .name = "XDG_STATE_HOME", .func = state, .default_subdir = ".local/state" },
+        .{ .name = "XDG_CONFIG_HOME", .dir_type = UserDir.config, .default_subdir = ".config" },
+        .{ .name = "XDG_CACHE_HOME", .dir_type = UserDir.cache, .default_subdir = ".cache" },
+        .{ .name = "XDG_STATE_HOME", .dir_type = UserDir.state, .default_subdir = ".local/state" },
     };
 
     inline for (cases) |case| {
@@ -214,7 +225,7 @@ test "fallback when xdg env empty" {
 
         // Test with empty string - should fallback to home
         _ = env_os.setenv(case.name, "");
-        const actual = try case.func(alloc, .{});
+        const actual = try case.dir_type.path(alloc, .{});
         defer alloc.free(actual);
 
         try std.testing.expectEqualStrings(expected, actual);
@@ -245,14 +256,14 @@ test "fallback when xdg env empty and subdir" {
 
     const DirCase = struct {
         name: [:0]const u8,
-        func: fn (Allocator, Options) anyerror![]u8,
+        dir_type: UserDir,
         default_subdir: []const u8,
     };
 
     const cases = [_]DirCase{
-        .{ .name = "XDG_CONFIG_HOME", .func = config, .default_subdir = ".config" },
-        .{ .name = "XDG_CACHE_HOME", .func = cache, .default_subdir = ".cache" },
-        .{ .name = "XDG_STATE_HOME", .func = state, .default_subdir = ".local/state" },
+        .{ .name = "XDG_CONFIG_HOME", .dir_type = UserDir.config, .default_subdir = ".config" },
+        .{ .name = "XDG_CACHE_HOME", .dir_type = UserDir.cache, .default_subdir = ".cache" },
+        .{ .name = "XDG_STATE_HOME", .dir_type = UserDir.state, .default_subdir = ".local/state" },
     };
 
     inline for (cases) |case| {
@@ -279,7 +290,7 @@ test "fallback when xdg env empty and subdir" {
 
         // Test with empty string - should fallback to home
         _ = env.setenv(case.name, "");
-        const actual = try case.func(alloc, .{ .subdir = "ghostty" });
+        const actual = try case.dir_type.path(alloc, .{ .subdir = "ghostty" });
         defer alloc.free(actual);
 
         try std.testing.expectEqualStrings(expected, actual);
@@ -311,48 +322,107 @@ test parseTerminalExec {
     }
 }
 
-/// https://specifications.freedesktop.org/basedir-spec/latest/
+/// Iterator over XDG directories system directories and user directories
+/// wraps SystemDirIterator using any values from that iterator and then
+/// the path from UserDir.path()
+const DirIterator = struct {
+    alloc: Allocator,
+    opts: Options,
+    user_dir: UserDir,
+    sys_dir_it: SystemDirIterator,
+    emited_user_dir: bool = false,
+    const Self = @This();
+    pub fn next(self: *Self) !?[]const u8 {
+        // TODO ignore relative paths where
+        // path[0] != "/" and path not contains "/../?"
+        if (self.sys_dir_it.next()) |path| {
+            return try std.fs.path.join(self.alloc, &[_][]const u8{
+                path,
+                self.opts.subdir orelse "",
+            });
+        }
+
+        if (!self.emited_user_dir) {
+            self.emited_user_dir = true;
+            return self.user_dir.path(self.alloc, self.opts) catch |err| switch (err) {
+                error.NoHomeDir => null,
+                else => err,
+            };
+        }
+
+        return null;
+    }
+};
+
+/// System and home directories for program configs and data,
+/// these are the environment variables $XDG_CONFIG_DIRS:$XDG_CONFIG_HOME, and,
+/// $XDG_DATA_DIRS:$XDG_DATA_HOME respectively
 pub const Dir = enum {
     config,
     data,
 
-    pub fn key(self: Dir) [:0]const u8 {
+    const Self = @This();
+    fn as_system_dir(self: Self) SystemDir {
+        // TODO: this cast could break if SystemDir or UserDir are reordered consider using a switch
+        return @enumFromInt(@intFromEnum(self));
+    }
+
+    fn as_user_dir(self: Self) UserDir {
+        // TODO: this cast could break if SystemDir or UserDir are reordered consider using a switch
+        return @enumFromInt(@intFromEnum(self));
+    }
+
+    pub fn iter(self: Dir, alloc: Allocator, opts: Options) DirIterator {
+        const sys_dir: SystemDir = self.as_system_dir();
+        const user_dir: UserDir = self.as_user_dir();
+        return .{ .alloc = alloc, .opts = opts, .sys_dir_it = sys_dir.iter(), .user_dir = user_dir };
+    }
+};
+
+/// Iterator over system directories in order from least importance to most
+/// importance, reverse order to how they are defined in XDG_*_DIRS
+const SystemDirIterator = struct {
+    data: []const u8,
+    iterator: std.mem.SplitBackwardsIterator(u8, .scalar),
+
+    const Self = @This();
+
+    pub fn next(self: *Self) ?[]const u8 {
+        return self.iterator.next();
+    }
+};
+
+/// XDG system directory for program configs or data
+pub const SystemDir = enum {
+    config,
+    data,
+
+    pub fn key(self: SystemDir) [:0]const u8 {
         return switch (self) {
             .config => "XDG_CONFIG_DIRS",
             .data => "XDG_DATA_DIRS",
         };
     }
 
-    pub fn default(self: Dir) [:0]const u8 {
+    pub fn default(self: SystemDir) [:0]const u8 {
         return switch (self) {
             .config => "/etc/xdg",
             .data => "/usr/local/share:/usr/share",
         };
     }
-};
 
-pub const DirIterator = struct {
-    data: []const u8,
-    iterator: std.mem.SplitIterator(u8, .scalar),
-
-    /// https://specifications.freedesktop.org/basedir-spec/latest/
-    pub fn init(key: Dir) DirIterator {
+    pub fn iter(self: SystemDir) SystemDirIterator {
         const data = data: {
-            if (posix.getenv(key.key())) |data| {
-                if (std.mem.trim(u8, data, &std.ascii.whitespace).len > 0) break :data data;
+            if (posix.getenv(self.key())) |data| {
+                if (std.mem.trim(u8, data, &std.ascii.whitespace).len > 0)
+                    break :data data;
             }
-
-            break :data key.default();
+            break :data self.default();
         };
-
         return .{
             .data = data,
-            .iterator = std.mem.splitScalar(u8, data, ':'),
+            .iterator = std.mem.splitBackwardsScalar(u8, data, ':'),
         };
-    }
-
-    pub fn next(self: *DirIterator) ?[]const u8 {
-        return self.iterator.next();
     }
 };
 
@@ -363,24 +433,24 @@ test "xdg dirs" {
 
     const testing = std.testing;
     {
-        _ = c.unsetenv(Dir.config.key());
-        var it = DirIterator.init(.config);
+        _ = c.unsetenv(SystemDir.config.key());
+        var it = SystemDir.config.iter();
         try testing.expectEqualStrings("/etc/xdg", it.next().?);
         try testing.expect(it.next() == null);
     }
     {
-        _ = c.unsetenv(Dir.data.key());
-        var it = DirIterator.init(.data);
-        try testing.expectEqualStrings("/usr/local/share", it.next().?);
+        _ = c.unsetenv(SystemDir.data.key());
+        var it = SystemDir.data.iter();
         try testing.expectEqualStrings("/usr/share", it.next().?);
+        try testing.expectEqualStrings("/usr/local/share", it.next().?);
         try testing.expect(it.next() == null);
     }
     {
-        _ = c.setenv(Dir.config.key(), "a:b:c", 1);
-        var it = DirIterator.init(.config);
-        try testing.expectEqualStrings("a", it.next().?);
-        try testing.expectEqualStrings("b", it.next().?);
+        _ = c.setenv(SystemDir.config.key(), "a:b:c", 1);
+        var it = SystemDir.config.iter();
         try testing.expectEqualStrings("c", it.next().?);
+        try testing.expectEqualStrings("b", it.next().?);
+        try testing.expectEqualStrings("a", it.next().?);
         try testing.expect(it.next() == null);
     }
 }

--- a/src/os/xdg.zig
+++ b/src/os/xdg.zig
@@ -89,7 +89,7 @@ fn dir(
     }
 
     // Get our home dir
-    var buf: [1024]u8 = undefined;
+    var buf: [std.c.PATH_MAX]u8 = undefined;
     if (try homedir.home(&buf)) |home| {
         return try std.fs.path.join(alloc, &[_][]const u8{
             home,

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -712,15 +712,15 @@ const Subprocess = struct {
 
             if (std.fmt.bufPrint(&buf, "{s}/..", .{resources_dir})) |data_dir| {
                 try env.put(
-                    xdg.Dir.data.key(),
+                    xdg.SystemDir.data.key(),
                     try internal_os.appendEnv(
                         alloc,
-                        env.get(xdg.Dir.data.key()) orelse xdg.Dir.data.default(),
+                        env.get(xdg.SystemDir.data.key()) orelse xdg.SystemDir.data.default(),
                         data_dir,
                     ),
                 );
             } else |err| {
-                log.warn("error building {s}; err={}", .{ xdg.Dir.data.key(), err });
+                log.warn("error building {s}; err={}", .{ xdg.SystemDir.data.key(), err });
             }
 
             const manpath_key = "MANPATH";

--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -16,6 +16,7 @@ const configpkg = @import("../config.zig");
 const crash = @import("../crash/main.zig");
 const fastmem = @import("../fastmem.zig");
 const internal_os = @import("../os/main.zig");
+const xdg = internal_os.xdg;
 const renderer = @import("../renderer.zig");
 const shell_integration = @import("shell_integration.zig");
 const terminal = @import("../terminal/main.zig");
@@ -709,18 +710,17 @@ const Subprocess = struct {
 
             var buf: [std.fs.max_path_bytes]u8 = undefined;
 
-            const xdg_data_dir_key = "XDG_DATA_DIRS";
             if (std.fmt.bufPrint(&buf, "{s}/..", .{resources_dir})) |data_dir| {
                 try env.put(
-                    xdg_data_dir_key,
+                    xdg.Dir.data.key(),
                     try internal_os.appendEnv(
                         alloc,
-                        env.get(xdg_data_dir_key) orelse "/usr/local/share:/usr/share",
+                        env.get(xdg.Dir.data.key()) orelse xdg.Dir.data.default(),
                         data_dir,
                     ),
                 );
             } else |err| {
-                log.warn("error building {s}; err={}", .{ xdg_data_dir_key, err });
+                log.warn("error building {s}; err={}", .{ xdg.Dir.data.key(), err });
             }
 
             const manpath_key = "MANPATH";

--- a/src/termio/shell_integration.zig
+++ b/src/termio/shell_integration.zig
@@ -658,11 +658,11 @@ fn setupXdgDataDirs(
     // our desired integration dir directly. See #2711.
     // <https://specifications.freedesktop.org/basedir-spec/0.6/#variables>
     try env.put(
-        xdg.Dir.data.key(),
+        xdg.SystemDir.data.key(),
         try internal_os.prependEnv(
             stack_alloc,
-            env.get(xdg.Dir.data.key()) orelse xdg.Dir.data.default(),
-            integ_dir,
+            env.get(xdg.SystemDir.data.key()) orelse xdg.SystemDir.data.default(),
+            integ_path,
         ),
     );
 

--- a/src/termio/shell_integration.zig
+++ b/src/termio/shell_integration.zig
@@ -6,6 +6,7 @@ const EnvMap = std.process.EnvMap;
 const config = @import("../config.zig");
 const homedir = @import("../os/homedir.zig");
 const internal_os = @import("../os/main.zig");
+const xdg = internal_os.xdg;
 
 const log = std.log.scoped(.shell_integration);
 
@@ -656,13 +657,12 @@ fn setupXdgDataDirs(
     // This ensures that the default directories aren't lost by setting
     // our desired integration dir directly. See #2711.
     // <https://specifications.freedesktop.org/basedir-spec/0.6/#variables>
-    const xdg_data_dirs_key = "XDG_DATA_DIRS";
     try env.put(
-        xdg_data_dirs_key,
+        xdg.Dir.data.key(),
         try internal_os.prependEnv(
             stack_alloc,
-            env.get(xdg_data_dirs_key) orelse "/usr/local/share:/usr/share",
-            integ_path,
+            env.get(xdg.Dir.data.key()) orelse xdg.Dir.data.default(),
+            integ_dir,
         ),
     );
 


### PR DESCRIPTION
Fixes: #4506
Builds on: #4584
This PR is a continuation of #4845, It adds internal_os.xdg.Dir which allows using XDG_CONFIG_DIRS
to load system and user config files from XDG standard paths. I believe I have addressed the issues
raised in the previous PRs; Garbled directory was caused by a use after free to me misunderstanding
that `defer` is block scoped not function scoped.
The configs are applied in reverse order from last to first, followed by the User config file which has highest precedence.

Thanks to jcollie for starting on this issue.

Windows support is out of scope for this PR.

AI Disclaimer:
I used Claude as a pair programmer for code review and to catch bugs during development.
The design, implementation, and final code are my own.

See also:
- https://stackoverflow.com/questions/43853548/xdg-basedir-directories-for-windows
- https://github.com/NixOS/nixpkgs/pull/383728
