### PR TITLE
Adds session & scrollback restore support on Linux

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -2038,6 +2038,50 @@ pub fn hasSelection(self: *const Surface) bool {
     return self.io.terminal.screens.active.selection != null;
 }
 
+/// Dump this surface's scrollback (history + active screen) as styled VT
+/// bytes suitable for replaying into a terminal (via `processOutput`) to
+/// restore its appearance — colors, bold, etc.
+///
+/// The result is tail-truncated to at most `max_bytes` on a line boundary so
+/// only the most recent content is kept, and prefixed with a reset (ESC[0m)
+/// so a truncated tail begins with a clean style. Returns null if there is
+/// nothing worth dumping. Caller owns the returned memory.
+pub fn dumpScrollbackVt(
+    self: *Surface,
+    alloc: Allocator,
+    max_bytes: usize,
+) !?[]const u8 {
+    const reset = "\x1b[0m";
+
+    const full = full: {
+        self.renderer_state.mutex.lock();
+        defer self.renderer_state.mutex.unlock();
+        break :full try self.io.terminal.screens.active.dumpStringVtAlloc(
+            alloc,
+            .{ .skip_current_prompt = true },
+        );
+    };
+    defer alloc.free(full);
+
+    // Trim trailing blank space/newlines so we don't restore a large gap.
+    const trimmed = std.mem.trimRight(u8, full, " \t\r\n");
+    if (trimmed.len == 0) return null;
+
+    // Keep only the most recent `budget` bytes.
+    const budget = if (max_bytes > reset.len) max_bytes - reset.len else 0;
+    var start: usize = if (trimmed.len > budget) trimmed.len - budget else 0;
+
+    // If we cut into the content, advance to the start of the next line so we
+    // never begin mid-line or mid-escape-sequence.
+    if (start > 0) {
+        const nl = std.mem.indexOfScalarPos(u8, trimmed, start, '\n') orelse
+            return null;
+        start = nl + 1;
+    }
+
+    return try std.mem.concat(alloc, u8, &.{ reset, trimmed[start..] });
+}
+
 /// Returns the selected text. This is allocated.
 pub fn selectionString(self: *Surface, alloc: Allocator) !?[:0]const u8 {
     self.renderer_state.mutex.lock();

--- a/src/apprt/gtk/class/application.zig
+++ b/src/apprt/gtk/class/application.zig
@@ -27,6 +27,7 @@ const lib = @import("../../../lib/main.zig");
 
 const ext = @import("../ext.zig");
 const key = @import("../key.zig");
+const session = @import("../session.zig");
 const adw_version = @import("../adw_version.zig");
 const gtk_version = @import("../gtk_version.zig");
 const winprotopkg = @import("../winproto.zig");
@@ -183,6 +184,11 @@ pub const Application = extern struct {
         /// window.
         requested_window: bool = false,
 
+        /// Set to true once we've handled the first activation of the
+        /// primary instance. Used to restore a saved session exactly once
+        /// (on the first launch) rather than on every activation.
+        did_first_activate: bool = false,
+
         /// This is set to false internally when the event loop
         /// should exit and the application should quit. This must
         /// only be set by the main loop thread.
@@ -204,6 +210,17 @@ pub const Application = extern struct {
 
         /// glib source for our signal handler.
         signal_source: ?c_uint = null,
+
+        /// glib idle source for a pending session save. Event hooks (tab
+        /// added/removed, working directory changed) schedule a save through
+        /// this so state is persisted promptly even if Ghostty is killed
+        /// without a clean shutdown (battery dies, OOM, SIGKILL). Multiple
+        /// changes before the idle fires are coalesced into a single write.
+        session_save_idle: ?c_uint = null,
+
+        /// Hash of the most recently written session state. Used to skip
+        /// redundant writes when nothing has changed since the last save.
+        last_session_hash: ?u64 = null,
 
         /// CSS Provider for any styles based on Ghostty configuration values.
         css_provider: *gtk.CssProvider,
@@ -637,6 +654,12 @@ pub const Application = extern struct {
     }
 
     fn quitNow(self: *Self) void {
+        // Save the session before we destroy any windows, while surfaces
+        // and their working directories are still valid. This is the single
+        // convergence point for all quit routes (no-windows auto-quit, the
+        // quit action, and the close-confirmation dialog).
+        self.saveSession(true);
+
         // Get all our windows and destroy them, forcing them to free.
         const list = gtk.Window.listToplevels();
         defer list.free();
@@ -662,6 +685,348 @@ pub const Application = extern struct {
 
         // Trigger our runloop exit.
         self.private().running = false;
+    }
+
+    /// Persist the current set of windows, their tabs, and each tab's working
+    /// directory to disk so they can be restored on the next launch. This is a
+    /// best-effort operation: all errors are logged and swallowed so a save
+    /// failure never blocks quit.
+    ///
+    /// This is public because it is also called from a window's close-request
+    /// handler: when the last window is closed by the user, the window is
+    /// destroyed before the run loop notices there are no windows left and
+    /// calls `quitNow`, so saving from `quitNow` alone would see zero windows.
+    pub fn saveSession(self: *Self, write_scrollback: bool) void {
+        const priv = self.private();
+        const config = priv.config.get();
+
+        // If saving is disabled, clear any stale session file when explicitly
+        // set to `never` so that it isn't restored later, then bail. This is
+        // logged at debug because the periodic timer calls us frequently.
+        if (!session.shouldSaveState(config)) {
+            log.debug(
+                "session save skipped, window-save-state={s}",
+                .{@tagName(config.@"window-save-state")},
+            );
+            if (config.@"window-save-state" == .never) {
+                session.delete(self.allocator());
+                // Force a fresh write if saving is later re-enabled, since the
+                // file no longer exists even if the state hash is unchanged.
+                priv.last_session_hash = null;
+            }
+            return;
+        }
+
+        log.debug("building session state", .{});
+
+        // Per-tab scrollback budget. 0 disables scrollback persistence.
+        const scrollback_size = config.@"window-save-state-scrollback-size";
+
+        // Build the session on an arena so cleanup is trivial.
+        var arena = std.heap.ArenaAllocator.init(self.allocator());
+        defer arena.deinit();
+        const alloc = arena.allocator();
+
+        // Tabs whose scrollback we should dump after deciding to save. Each
+        // entry pairs the GTK surface with the tab's stable id. Only realized
+        // tabs (whose shell has started) are included; unrealized tabs keep
+        // their existing on-disk scrollback untouched.
+        const ScrollbackTarget = struct { id: u64, surface: *Surface };
+        var scrollback_targets: std.ArrayListUnmanaged(ScrollbackTarget) = .empty;
+        // Every tab id in the session, used to prune orphaned scrollback files.
+        var all_tab_ids: std.ArrayListUnmanaged(u64) = .empty;
+
+        var windows: std.ArrayListUnmanaged(session.Session.Window) = .empty;
+
+        const glist = gtk.Window.listToplevels();
+        defer glist.free();
+        var current_: ?*glib.List = glist;
+        while (current_) |node| : (current_ = node.f_next) {
+            const data = node.f_data orelse continue;
+            const gtk_window: *gtk.Window = @ptrCast(@alignCast(data));
+
+            // We only persist our own windows, and never the quick terminal.
+            const window = gobject.ext.cast(Window, gtk_window) orelse continue;
+            if (window.isQuickTerminal()) continue;
+
+            const tab_view = window.getTabView();
+            const n = tab_view.getNPages();
+            if (n <= 0) continue;
+
+            var tabs: std.ArrayListUnmanaged(session.Session.Tab) = .empty;
+            for (0..@intCast(n)) |i| {
+                const page = tab_view.getNthPage(@intCast(i));
+                const child = page.getChild();
+                const tab = gobject.ext.cast(Tab, child) orelse continue;
+
+                const surface = tab.getActiveSurface() orelse {
+                    // Preserve the tab (with its stable id) even if we can't
+                    // read the surface.
+                    const id = tab.getId();
+                    all_tab_ids.append(alloc, id) catch {};
+                    tabs.append(alloc, .{ .id = id }) catch return;
+                    continue;
+                };
+
+                // Working directory: prefer the live pwd (from shell
+                // integration). Fall back to the restore-time override so that
+                // restored tabs which were never shown (so their shell never
+                // started and pwd is still null) keep their directory across
+                // save cycles instead of collapsing to the default.
+                const wd_src = surface.getPwd() orelse surface.getOverrideWorkingDirectory();
+                const wd: ?[]const u8 = if (wd_src) |pwd|
+                    (alloc.dupe(u8, pwd) catch null)
+                else
+                    null;
+
+                // Title: persist the meaningful title -- a user-set tab title
+                // override if present, otherwise the surface's effective title
+                // (its own override, else the terminal-set title). We avoid the
+                // tab's *computed* title because that includes a "Ghostty"
+                // default and bell/zoom decorations. On restore this is applied
+                // as a (pinned) title override.
+                const title_src = tab.getTitleOverride() orelse surface.getEffectiveTitle();
+                const title: ?[]const u8 = if (title_src) |t|
+                    (alloc.dupe(u8, t) catch null)
+                else
+                    null;
+
+                const tab_id = tab.getId();
+                all_tab_ids.append(alloc, tab_id) catch {};
+
+                // Collect realized tabs as scrollback dump targets. Unrealized
+                // tabs (shell not started, e.g. a restored tab never shown) are
+                // skipped so their saved scrollback file is preserved rather
+                // than overwritten with empty content.
+                if (scrollback_size > 0 and surface.core() != null) {
+                    scrollback_targets.append(alloc, .{
+                        .id = tab_id,
+                        .surface = surface,
+                    }) catch {};
+                }
+
+                tabs.append(alloc, .{
+                    .id = tab_id,
+                    .working_directory = wd,
+                    .title = title,
+                }) catch return;
+            }
+
+            if (tabs.items.len == 0) continue;
+
+            // Record the current window geometry (0 if not yet allocated).
+            const width = window.as(gtk.Widget).getWidth();
+            const height = window.as(gtk.Widget).getHeight();
+
+            // Record which tab is currently selected so it can be re-focused.
+            const focused_tab: ?u32 = ft: {
+                const sel = tab_view.getSelectedPage() orelse break :ft null;
+                const pos = tab_view.getPagePosition(sel);
+                break :ft if (pos >= 0) @intCast(pos) else null;
+            };
+            log.debug("saving window tabs={d} focused_tab={?d}", .{ tabs.items.len, focused_tab });
+
+            windows.append(alloc, .{
+                .id = window.getId(),
+                .width = if (width > 0) width else null,
+                .height = if (height > 0) height else null,
+                .focused_tab = focused_tab,
+                .tabs = tabs.items,
+            }) catch return;
+        }
+
+        // Nothing worth saving. Leave any existing file untouched so that a
+        // previously-saved good state survives (e.g. while quitNow runs after
+        // the last window was already destroyed via its close handler).
+        if (windows.items.len == 0) {
+            log.debug("no windows to save, leaving any existing session file", .{});
+            return;
+        }
+
+        var total_tabs: usize = 0;
+        for (windows.items) |w| total_tabs += w.tabs.len;
+
+        // Serialize once so we can both hash it for change detection and write
+        // it. The bytes live on the arena and are freed with it.
+        const bytes = session.serialize(alloc, .{
+            .windows = windows.items,
+        }) catch |err| {
+            log.warn("failed to serialize session err={}", .{err});
+            return;
+        };
+
+        // Skip the JSON write if nothing changed since our last successful
+        // save. This keeps the frequent event-driven saves cheap. Scrollback
+        // (below) is handled independently since it changes without the JSON.
+        const hash = std.hash.Wyhash.hash(0, bytes);
+        const changed = if (priv.last_session_hash) |prev| prev != hash else true;
+        if (changed) {
+            session.writeBytes(self.allocator(), bytes) catch |err| {
+                log.warn("failed to write session err={}", .{err});
+                return;
+            };
+            priv.last_session_hash = hash;
+            log.info(
+                "saved session windows={} tabs={}",
+                .{ windows.items.len, total_tabs },
+            );
+        } else {
+            log.debug("session unchanged, skipping json write", .{});
+        }
+
+        // Dump scrollback for each realized tab when requested (on quit /
+        // window close). Done independently of the JSON change check because
+        // scrollback grows without changing the session structure, and on a
+        // temporary allocation per tab so large dumps aren't retained.
+        // Unrealized tabs were not collected, so their `<id>.vt` is untouched.
+        if (write_scrollback and scrollback_size > 0) {
+            const gpa = self.allocator();
+            for (scrollback_targets.items) |target| {
+                const dump_ = target.surface.dumpScrollbackVt(gpa, scrollback_size) catch |err| {
+                    log.warn("failed to dump scrollback id={d} err={}", .{ target.id, err });
+                    continue;
+                };
+                if (dump_) |dump| {
+                    defer gpa.free(dump);
+                    session.writeScrollback(gpa, target.id, dump) catch |err| {
+                        log.warn("failed to write scrollback id={d} err={}", .{ target.id, err });
+                    };
+                } else {
+                    // Realized tab with empty scrollback: clear any stale file.
+                    session.deleteScrollback(gpa, target.id);
+                }
+            }
+
+            // Remove scrollback files for tabs that no longer exist.
+            session.pruneScrollback(gpa, all_tab_ids.items);
+        }
+    }
+
+    /// Attempt to restore a previously saved session. Returns true if at least
+    /// one window was restored, in which case the caller should not open the
+    /// default empty window.
+    fn tryRestoreSession(self: *Self) bool {
+        const priv = self.private();
+        const config = priv.config.get();
+        if (!session.shouldRestoreState(config)) {
+            log.info(
+                "session restore skipped, window-save-state={s}",
+                .{@tagName(config.@"window-save-state")},
+            );
+            return false;
+        }
+
+        const gpa = self.allocator();
+        const parsed = (session.load(gpa) catch |err| {
+            log.warn("failed to load session err={}", .{err});
+            return false;
+        }) orelse {
+            log.info("no saved session to restore", .{});
+            return false;
+        };
+        defer parsed.deinit();
+
+        const sess = parsed.value;
+        if (sess.windows.len == 0) return false;
+
+        log.info("restoring session windows={}", .{sess.windows.len});
+
+        // Scrollback is only restored if persistence is currently enabled.
+        const scrollback_size = config.@"window-save-state-scrollback-size";
+
+        // Arena for the temporary override strings/bytes. The window/tab/surface
+        // creation paths dupe these synchronously, so the arena can be freed
+        // once we're done creating windows.
+        var arena = std.heap.ArenaAllocator.init(gpa);
+        defer arena.deinit();
+        const alloc = arena.allocator();
+
+        // Reads a tab's saved scrollback bytes (or null) for injection, keyed
+        // by the tab's stable id.
+        const readScrollback = struct {
+            fn read(a: Allocator, size: usize, tab_data: session.Session.Tab) ?[]const u8 {
+                if (size == 0 or tab_data.id == 0) return null;
+                return session.readScrollback(a, tab_data.id) catch |err| {
+                    log.warn("failed to read scrollback id={d} err={}", .{ tab_data.id, err });
+                    return null;
+                };
+            }
+        }.read;
+
+        // A saved id of 0 (legacy session file) means "no stable id"; pass null
+        // so a fresh id is generated for that window/tab.
+        const idOrNull = struct {
+            fn f(v: u64) ?u64 {
+                return if (v == 0) null else v;
+            }
+        }.f;
+
+        var restored: usize = 0;
+        for (sess.windows) |win_data| {
+            if (win_data.tabs.len == 0) continue;
+
+            const size: ?Action.WindowSize = if (win_data.width) |w|
+                (if (win_data.height) |h| Action.WindowSize{
+                    .width = @intCast(w),
+                    .height = @intCast(h),
+                } else null)
+            else
+                null;
+
+            // First tab opens the window.
+            const first = win_data.tabs[0];
+            const win = Action.newWindowReturning(self, null, .{
+                .working_directory = dupeOptZ(alloc, first.working_directory),
+                .title = dupeOptZ(alloc, first.title),
+                .restore_scrollback = readScrollback(alloc, scrollback_size, first),
+                .id = idOrNull(first.id),
+            }, size, idOrNull(win_data.id)) catch |err| {
+                log.warn("failed to restore window err={}", .{err});
+                continue;
+            };
+
+            // Remaining tabs are added to the same window.
+            for (win_data.tabs[1..]) |tab_data| {
+                win.newTabForWindow(null, .{
+                    .working_directory = dupeOptZ(alloc, tab_data.working_directory),
+                    .title = dupeOptZ(alloc, tab_data.title),
+                    .restore_scrollback = readScrollback(alloc, scrollback_size, tab_data),
+                    .id = idOrNull(tab_data.id),
+                });
+            }
+
+            // Re-select the tab that was focused when the session was saved.
+            // newTabForWindow selects each new tab as it's added, so by default
+            // the last tab would be focused; this restores the real selection.
+            // We select the page directly by its 0-indexed position. (Window
+            // .selectTab's `.n` is 1-indexed and no-ops on 0, so it's not used
+            // here.)
+            if (win_data.focused_tab) |ft| {
+                const tab_view = win.getTabView();
+                const n = tab_view.getNPages();
+                if (n > 0 and ft < @as(u32, @intCast(n))) {
+                    tab_view.setSelectedPage(tab_view.getNthPage(@intCast(ft)));
+                    log.debug("restored focused tab index={d}", .{ft});
+                } else {
+                    log.warn(
+                        "saved focused_tab={d} out of range (npages={d})",
+                        .{ ft, n },
+                    );
+                }
+            }
+
+            restored += 1;
+        }
+
+        log.info("restored session windows={}", .{restored});
+        return restored > 0;
+    }
+
+    /// Duplicate an optional slice into an optional sentinel-terminated slice.
+    /// Returns null on allocation failure (best-effort).
+    fn dupeOptZ(alloc: Allocator, s: ?[]const u8) ?[:0]const u8 {
+        const v = s orelse return null;
+        return alloc.dupeZ(u8, v) catch null;
     }
 
     /// apprt API to perform an action.
@@ -1407,6 +1772,33 @@ pub const Application = extern struct {
         );
     }
 
+    /// Schedule a session save to run when the main loop is next idle.
+    ///
+    /// This is called from event hooks (tab added/removed, working directory
+    /// changed) so we persist state promptly without polling. Saving is
+    /// deferred to idle rather than done synchronously because some of those
+    /// events fire during widget teardown, when enumerating windows would be
+    /// unsafe; by idle time the teardown has completed. Multiple changes
+    /// before the idle fires are coalesced into a single save, and the save
+    /// itself is a no-op if nothing actually changed (see `saveSession`).
+    pub fn scheduleSaveSession(self: *Self) void {
+        const priv = self.private();
+        if (priv.session_save_idle != null) return;
+        priv.session_save_idle = glib.idleAdd(handleSaveSessionIdle, self);
+    }
+
+    /// Idle callback that performs a scheduled session save exactly once.
+    fn handleSaveSessionIdle(ud: ?*anyopaque) callconv(.c) c_int {
+        const self: *Self = @ptrCast(@alignCast(ud orelse
+            return @intFromBool(glib.SOURCE_REMOVE)));
+        self.private().session_save_idle = null;
+        // Event-driven saves (tab/cwd changes) persist structure only; dumping
+        // scrollback here would be too frequent. Scrollback is flushed on
+        // window close and quit instead.
+        self.saveSession(false);
+        return @intFromBool(glib.SOURCE_REMOVE);
+    }
+
     /// Setup our action map.
     fn startupActionMap(self: *Self) void {
         const t_variant_type = glib.ext.VariantType.newFor(u64);
@@ -1459,11 +1851,24 @@ pub const Application = extern struct {
     fn activate(self: *Self) callconv(.c) void {
         log.debug("activate", .{});
 
-        // Queue a new window
         const priv = self.private();
-        _ = priv.core_app.mailbox.push(.{
-            .new_window = .{},
-        }, .{ .forever = {} });
+
+        // On the very first activation of the primary instance, attempt to
+        // restore a previously saved session instead of opening a single
+        // empty window. If we restore at least one window, we skip the
+        // default new_window so we don't end up with an extra empty window.
+        const restored = restore: {
+            if (priv.did_first_activate) break :restore false;
+            priv.did_first_activate = true;
+            break :restore self.tryRestoreSession();
+        };
+
+        // Queue a new window unless we restored a session.
+        if (!restored) {
+            _ = priv.core_app.mailbox.push(.{
+                .new_window = .{},
+            }, .{ .forever = {} });
+        }
 
         // Call the parent activate method.
         gio.Application.virtual_methods.activate.call(
@@ -1484,6 +1889,12 @@ pub const Application = extern struct {
                 log.warn("unable to remove signal source", .{});
             }
             priv.signal_source = null;
+        }
+        if (priv.session_save_idle) |v| {
+            if (glib.Source.remove(v) == 0) {
+                log.warn("unable to remove session save idle source", .{});
+            }
+            priv.session_save_idle = null;
         }
 
         gobject.Object.virtual_methods.dispose.call(
@@ -2249,6 +2660,12 @@ const Action = struct {
         }
     }
 
+    /// An explicit window size override, in pixels.
+    pub const WindowSize = struct {
+        width: c_int,
+        height: c_int,
+    };
+
     pub fn newWindow(
         self: *Application,
         parent: ?*CoreSurface,
@@ -2260,6 +2677,33 @@ const Action = struct {
             pub const none: @This() = .{};
         },
     ) !void {
+        _ = try newWindowReturning(self, parent, .{
+            .command = overrides.command,
+            .working_directory = overrides.working_directory,
+            .title = overrides.title,
+        }, null, null);
+    }
+
+    /// Same as `newWindow` but returns the created window and accepts an
+    /// optional explicit size. Used by session restore so we can add
+    /// additional tabs and restore window geometry.
+    pub fn newWindowReturning(
+        self: *Application,
+        parent: ?*CoreSurface,
+        overrides: struct {
+            command: ?configpkg.Command = null,
+            working_directory: ?[:0]const u8 = null,
+            title: ?[:0]const u8 = null,
+            restore_scrollback: ?[]const u8 = null,
+            /// Stable id for the window's first tab (session restore).
+            id: ?u64 = null,
+
+            pub const none: @This() = .{};
+        },
+        size: ?WindowSize,
+        /// Stable id for the window itself (session restore).
+        window_id: ?u64,
+    ) !*Window {
         // Note that we've requested a window at least once. This is used
         // to trigger quit on no windows. Note I'm not sure if this is REALLY
         // necessary, but I don't want to risk a bug where on a slow machine
@@ -2269,6 +2713,7 @@ const Action = struct {
 
         const win = Window.new(self, .{
             .title = overrides.title,
+            .id = window_id,
         });
         initAndShowWindow(
             self,
@@ -2278,8 +2723,12 @@ const Action = struct {
                 .command = overrides.command,
                 .working_directory = overrides.working_directory,
                 .title = overrides.title,
+                .restore_scrollback = overrides.restore_scrollback,
+                .id = overrides.id,
             },
+            size,
         );
+        return win;
     }
 
     fn initAndShowWindow(
@@ -2290,9 +2739,12 @@ const Action = struct {
             command: ?configpkg.Command = null,
             working_directory: ?[:0]const u8 = null,
             title: ?[:0]const u8 = null,
+            restore_scrollback: ?[]const u8 = null,
+            id: ?u64 = null,
 
             pub const none: @This() = .{};
         },
+        size: ?WindowSize,
     ) void {
         // Setup a binding so that whenever our config changes so does the
         // window. There's never a time when the window config should be out
@@ -2310,18 +2762,27 @@ const Action = struct {
             .command = overrides.command,
             .working_directory = overrides.working_directory,
             .title = overrides.title,
+            .restore_scrollback = overrides.restore_scrollback,
+            .id = overrides.id,
         });
 
         // Estimate the initial window size before presenting so the window
         // manager can position it correctly.
         if (win.getActiveSurface()) |surface| {
             surface.estimateInitialSize();
-            if (surface.getDefaultSize()) |size| {
+            if (surface.getDefaultSize()) |default_size| {
                 win.as(gtk.Window).setDefaultSize(
-                    @intCast(size.width),
-                    @intCast(size.height),
+                    @intCast(default_size.width),
+                    @intCast(default_size.height),
                 );
             }
+        }
+
+        // If an explicit size was requested (e.g. session restore), it
+        // overrides the surface estimate. This must happen before present so
+        // the window is mapped at the restored size.
+        if (size) |s| {
+            win.as(gtk.Window).setDefaultSize(s.width, s.height);
         }
 
         // Show the window
@@ -2664,7 +3125,7 @@ const Action = struct {
             .@"quick-terminal" = true,
         });
         assert(win.isQuickTerminal());
-        initAndShowWindow(self, win, null, .none);
+        initAndShowWindow(self, win, null, .none, null);
         return true;
     }
 

--- a/src/apprt/gtk/class/split_tree.zig
+++ b/src/apprt/gtk/class/split_tree.zig
@@ -216,6 +216,7 @@ pub const SplitTree = extern struct {
             command: ?configpkg.Command = null,
             working_directory: ?[:0]const u8 = null,
             title: ?[:0]const u8 = null,
+            restore_scrollback: ?[]const u8 = null,
 
             pub const none: @This() = .{};
         },
@@ -227,6 +228,7 @@ pub const SplitTree = extern struct {
             .command = overrides.command,
             .working_directory = overrides.working_directory,
             .title = overrides.title,
+            .restore_scrollback = overrides.restore_scrollback,
         });
         defer surface.unref();
         _ = surface.refSink();

--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -737,6 +737,9 @@ pub const Surface = extern struct {
         overrides: struct {
             command: ?configpkg.Command = null,
             working_directory: ?[:0]const u8 = null,
+            /// Styled VT bytes to replay into the terminal as display output
+            /// once it initializes, used to restore saved scrollback.
+            restore_scrollback: ?[]const u8 = null,
 
             pub const none: @This() = .{};
         } = .none,
@@ -748,6 +751,7 @@ pub const Surface = extern struct {
         command: ?configpkg.Command = null,
         working_directory: ?[:0]const u8 = null,
         title: ?[:0]const u8 = null,
+        restore_scrollback: ?[]const u8 = null,
 
         pub const none: @This() = .{};
     }) *Self {
@@ -759,6 +763,7 @@ pub const Surface = extern struct {
         priv.overrides = .{
             .command = if (overrides.command) |c| c.clone(alloc) catch null else null,
             .working_directory = if (overrides.working_directory) |wd| alloc.dupeZ(u8, wd) catch null else null,
+            .restore_scrollback = if (overrides.restore_scrollback) |s| alloc.dupe(u8, s) catch null else null,
         };
         return self;
     }
@@ -1974,6 +1979,14 @@ pub const Surface = extern struct {
             alloc.free(wd);
             priv.overrides.working_directory = null;
         }
+        // Free restore_scrollback if it was never consumed. initSurface frees
+        // and nulls it after injecting, so this only runs for surfaces that
+        // were created (e.g. background tabs during session restore) but never
+        // realized/initialized before being destroyed.
+        if (priv.overrides.restore_scrollback) |s| {
+            alloc.free(s);
+            priv.overrides.restore_scrollback = null;
+        }
 
         // Clean up key sequence and key table state
         for (priv.key_sequence.items) |s| alloc.free(s);
@@ -2000,6 +2013,14 @@ pub const Surface = extern struct {
     pub fn getEffectiveTitle(self: *Self) ?[:0]const u8 {
         const priv = self.private();
         return priv.title_override orelse priv.title;
+    }
+
+    /// Returns the user-set title override, if any. Unlike `getEffectiveTitle`
+    /// this does NOT fall back to the terminal-set title, so it can be used to
+    /// persist only titles the user explicitly chose (which should be restored
+    /// as overrides rather than pinning a transient terminal title).
+    pub fn getTitleOverride(self: *Self) ?[:0]const u8 {
+        return self.private().title_override;
     }
 
     /// Copies the effective title to the clipboard.
@@ -2039,6 +2060,23 @@ pub const Surface = extern struct {
         return self.private().pwd;
     }
 
+    /// Returns the working-directory override this surface was created with,
+    /// if any (e.g. from session restore). Unlike `getPwd`, this is available
+    /// even before the surface is realized and its shell has started, so it
+    /// serves as a fallback for persisting the cwd of restored-but-never-shown
+    /// tabs (whose `pwd` is still null).
+    pub fn getOverrideWorkingDirectory(self: *Self) ?[:0]const u8 {
+        return self.private().overrides.working_directory;
+    }
+
+    /// Dump this surface's scrollback as styled VT bytes (for session restore).
+    /// Returns null if the core surface isn't initialized or there's nothing to
+    /// dump. Caller owns the returned memory. See `CoreSurface.dumpScrollbackVt`.
+    pub fn dumpScrollbackVt(self: *Self, alloc: Allocator, max_bytes: usize) !?[]const u8 {
+        const cs = self.private().core_surface orelse return null;
+        return try cs.dumpScrollbackVt(alloc, max_bytes);
+    }
+
     /// Set the pwd for this surface, copies the value.
     pub fn setPwd(self: *Self, pwd: ?[:0]const u8) void {
         const priv = self.private();
@@ -2046,6 +2084,11 @@ pub const Surface = extern struct {
         priv.pwd = null;
         if (pwd) |v| priv.pwd = glib.ext.dupeZ(u8, v);
         self.as(gobject.Object).notifyByPspec(properties.pwd.impl.param_spec);
+
+        // The working directory changed: persist the session. This is
+        // coalesced and a no-op if the resulting state is unchanged, so the
+        // frequent OSC 7 reports that don't actually change the cwd are cheap.
+        Application.default().scheduleSaveSession();
     }
 
     /// Returns the focus state of this surface.
@@ -3476,6 +3519,23 @@ pub const Surface = extern struct {
 
         // Store it!
         priv.core_surface = surface;
+
+        // If we have saved scrollback to restore, replay it into the terminal
+        // as display output (NOT pty input) now that the surface is
+        // initialized. This runs before the shell's first prompt arrives, so
+        // the restored history appears above it. We free it after injection.
+        //
+        // We intentionally do NOT inject a visible marker: it would be
+        // recaptured by the next save and compound across restore cycles.
+        // Reset styling first, then add a trailing newline so the shell's
+        // prompt starts on its own line below the restored history.
+        if (priv.overrides.restore_scrollback) |bytes| {
+            surface.io.processOutput("\x1b[0m");
+            surface.io.processOutput(bytes);
+            surface.io.processOutput("\r\n");
+            Application.default().allocator().free(bytes);
+            priv.overrides.restore_scrollback = null;
+        }
 
         // Emit the signal that we initialized the surface.
         Surface.signals.init.impl.emit(

--- a/src/apprt/gtk/class/tab.zig
+++ b/src/apprt/gtk/class/tab.zig
@@ -10,6 +10,7 @@ const apprt = @import("../../../apprt.zig");
 const CoreSurface = @import("../../../Surface.zig");
 const ext = @import("../ext.zig");
 const gresource = @import("../build/gresource.zig");
+const session = @import("../session.zig");
 const Common = @import("../class.zig").Common;
 const Config = @import("config.zig").Config;
 const Application = @import("application.zig").Application;
@@ -156,6 +157,10 @@ pub const Tab = extern struct {
     };
 
     const Private = struct {
+        /// Stable random identifier for this tab, assigned at creation and
+        /// overridable on session restore. Keys the tab's scrollback file.
+        id: u64 = 0,
+
         /// The configuration that this surface is using.
         config: ?*Config = null,
 
@@ -191,12 +196,20 @@ pub const Tab = extern struct {
         command: ?configpkg.Command = null,
         working_directory: ?[:0]const u8 = null,
         title: ?[:0]const u8 = null,
+        restore_scrollback: ?[]const u8 = null,
+        /// Stable id to assign (from session restore). If null, a fresh random
+        /// id is generated.
+        id: ?u64 = null,
 
         pub const none: @This() = .{};
     }) *Self {
         const tab = gobject.ext.newInstance(Tab, .{});
 
         const priv: *Private = tab.private();
+
+        // `init` already assigned a fresh random id; override it with the
+        // restored id when one is provided.
+        if (overrides.id) |id| priv.id = id;
 
         if (config) |c| priv.config = c.ref();
 
@@ -214,6 +227,7 @@ pub const Tab = extern struct {
             .command = overrides.command,
             .working_directory = overrides.working_directory,
             .title = overrides.title,
+            .restore_scrollback = overrides.restore_scrollback,
         }) catch |err| switch (err) {
             error.OutOfMemory => {
                 // TODO: We should make our "no surfaces" state more aesthetically
@@ -228,6 +242,10 @@ pub const Tab = extern struct {
 
     fn init(self: *Self, _: *Class) callconv(.c) void {
         gtk.Widget.initTemplate(self.as(gtk.Widget));
+
+        // Assign a stable random id to every tab at creation. `new()` may
+        // override it (with a restored id) for session restore.
+        self.private().id = session.newId();
 
         // Init our actions
         self.initActionMap();
@@ -250,6 +268,14 @@ pub const Tab = extern struct {
 
     //---------------------------------------------------------------
     // Properties
+
+    /// Returns the user-set tab title override (from "prompt-tab-title"), if
+    /// any. This is the raw override, NOT the computed display title (which
+    /// includes a default string and bell/zoom decorations), so it is suitable
+    /// for persisting a meaningful title to restore.
+    pub fn getTitleOverride(self: *Self) ?[:0]const u8 {
+        return self.private().title_override;
+    }
 
     /// Overridden title. This will be generally be shown over the title
     /// unless this is unset (null).
@@ -280,6 +306,11 @@ pub const Tab = extern struct {
         );
 
         dialog.present(self.as(gtk.Widget));
+    }
+
+    /// The stable id of this tab. See `Private.id`.
+    pub fn getId(self: *Self) u64 {
+        return self.private().id;
     }
 
     /// Get the currently active surface. See the "active-surface" property.

--- a/src/apprt/gtk/class/window.zig
+++ b/src/apprt/gtk/class/window.zig
@@ -18,6 +18,7 @@ const ext = @import("../ext.zig");
 const gtk_version = @import("../gtk_version.zig");
 const adw_version = @import("../adw_version.zig");
 const gresource = @import("../build/gresource.zig");
+const session = @import("../session.zig");
 const winprotopkg = @import("../winproto.zig");
 const Common = @import("../class.zig").Common;
 const Config = @import("config.zig").Config;
@@ -216,6 +217,10 @@ pub const Window = extern struct {
     };
 
     const Private = struct {
+        /// Stable random identifier for this window, assigned at creation and
+        /// overridable on session restore.
+        id: u64 = 0,
+
         /// Whether this window is a quick terminal. If it is then it
         /// behaves slightly differently under certain scenarios.
         quick_terminal: bool = false,
@@ -273,6 +278,9 @@ pub const Window = extern struct {
         app: *Application,
         overrides: struct {
             title: ?[:0]const u8 = null,
+            /// Stable id to assign (from session restore). If null, a fresh
+            /// random id is generated.
+            id: ?u64 = null,
 
             pub const none: @This() = .{};
         },
@@ -280,6 +288,10 @@ pub const Window = extern struct {
         const win = gobject.ext.newInstance(Self, .{
             .application = app,
         });
+
+        // `init` already assigned a fresh random id; override it with the
+        // restored id when one is provided.
+        if (overrides.id) |id| win.private().id = id;
 
         if (overrides.title) |title| {
             // If the overrides have a title set, we set that immediately
@@ -298,6 +310,10 @@ pub const Window = extern struct {
         // If our configuration is null then we get the configuration
         // from the application.
         const priv = self.private();
+
+        // Assign a stable random id to every window at creation. `new()` may
+        // override it (with a restored id) for session restore.
+        priv.id = session.newId();
 
         const config = config: {
             if (priv.config) |config| break :config config.get();
@@ -401,6 +417,8 @@ pub const Window = extern struct {
             command: ?configpkg.Command = null,
             working_directory: ?[:0]const u8 = null,
             title: ?[:0]const u8 = null,
+            restore_scrollback: ?[]const u8 = null,
+            id: ?u64 = null,
 
             pub const none: @This() = .{};
         },
@@ -412,6 +430,8 @@ pub const Window = extern struct {
                 .command = overrides.command,
                 .working_directory = overrides.working_directory,
                 .title = overrides.title,
+                .restore_scrollback = overrides.restore_scrollback,
+                .id = overrides.id,
             },
         );
     }
@@ -424,6 +444,8 @@ pub const Window = extern struct {
             command: ?configpkg.Command = null,
             working_directory: ?[:0]const u8 = null,
             title: ?[:0]const u8 = null,
+            restore_scrollback: ?[]const u8 = null,
+            id: ?u64 = null,
 
             pub const none: @This() = .{};
         },
@@ -438,6 +460,8 @@ pub const Window = extern struct {
                 .command = overrides.command,
                 .working_directory = overrides.working_directory,
                 .title = overrides.title,
+                .restore_scrollback = overrides.restore_scrollback,
+                .id = overrides.id,
             },
         );
 
@@ -903,6 +927,11 @@ pub const Window = extern struct {
     pub fn getActiveSurface(self: *Self) ?*Surface {
         const tab = self.getSelectedTab() orelse return null;
         return tab.getActiveSurface();
+    }
+
+    /// The stable id of this window. See `Private.id`.
+    pub fn getId(self: *Self) u64 {
+        return self.private().id;
     }
 
     /// Returns the configuration for this window. The reference count
@@ -1401,6 +1430,14 @@ pub const Window = extern struct {
         _: *gtk.Window,
         self: *Self,
     ) callconv(.c) c_int {
+        // Save the session before this window is torn down. When the user
+        // closes the last window, GTK destroys it before the run loop notices
+        // there are no windows left and calls quitNow, so saving only at quit
+        // time would miss it. We save here while all windows (including this
+        // one) are still alive. This is a no-op when window-save-state is off.
+        log.debug("window close requested, saving session", .{});
+        Application.default().saveSession(true);
+
         if (self.getNeedsConfirmQuit()) {
             // Show a confirmation dialog
             const dialog: *CloseConfirmationDialog = .new(.window);
@@ -1560,6 +1597,9 @@ pub const Window = extern struct {
         if (tab.getSurfaceTree()) |tree| {
             self.connectSurfaceHandlers(tree);
         }
+
+        // A tab (or a new window's first tab) was added: persist the session.
+        Application.default().scheduleSaveSession();
     }
 
     fn tabViewPageDetached(
@@ -1585,6 +1625,10 @@ pub const Window = extern struct {
         if (tab.getSurfaceTree()) |tree| {
             self.disconnectSurfaceHandlers(tree);
         }
+
+        // A tab was removed: persist the session. This is scheduled to idle so
+        // it runs after the teardown completes and the window list is stable.
+        Application.default().scheduleSaveSession();
     }
 
     fn tabViewCreateWindow(

--- a/src/apprt/gtk/session.zig
+++ b/src/apprt/gtk/session.zig
@@ -1,0 +1,338 @@
+//! Session save/restore for the GTK apprt.
+//!
+//! This persists the set of open windows, their tabs, and each tab's working
+//! directory to disk when Ghostty exits, and restores them on the next launch.
+//! This brings a subset of the macOS-only `window-save-state` behavior to
+//! Linux. Splits and scrollback are intentionally not handled here yet (see
+//! the plan / future work); the JSON schema is versioned and tolerant of
+//! unknown fields so those can be added later without breaking older files.
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+const internal_os = @import("../../os/main.zig");
+const configpkg = @import("../../config.zig");
+const CoreConfig = configpkg.Config;
+
+const log = std.log.scoped(.gtk_session);
+
+/// The subdirectory (under the XDG state directory) and filename we use.
+const subdir = "ghostty";
+const filename = "session.json";
+const filename_tmp = "session.json.tmp";
+
+/// Maximum size of the session file we're willing to read. Session files are
+/// tiny (a few KB at most) so this is a generous sanity bound.
+const max_read_size = 1024 * 1024;
+
+/// The current schema version. Bump this when the structure changes in a way
+/// that older Ghostty versions cannot understand. Readers reject mismatched
+/// versions (treating them as "no session") and ignore unknown fields.
+pub const version: u32 = 1;
+
+pub const Session = struct {
+    version: u32 = version,
+    windows: []const Window = &.{},
+
+    pub const Window = struct {
+        /// Stable random identifier for this window (see `newId`). 0 means
+        /// "unset" (e.g. a session file written before ids existed).
+        id: u64 = 0,
+
+        /// Window geometry. Restored via setDefaultSize when present.
+        width: ?i32 = null,
+        height: ?i32 = null,
+
+        /// The index (within `tabs`) of the tab that was selected/focused.
+        focused_tab: ?u32 = null,
+
+        tabs: []const Tab = &.{},
+    };
+
+    pub const Tab = struct {
+        /// Stable random identifier for this tab (see `newId`). This is the
+        /// key for the tab's scrollback file (`<id>.vt`). 0 means "unset".
+        id: u64 = 0,
+
+        /// The working directory for this tab. If null, the tab is restored
+        /// using the normal default working directory (e.g. when shell
+        /// integration wasn't reporting a pwd).
+        working_directory: ?[]const u8 = null,
+
+        /// The tab title, if one was known.
+        title: ?[]const u8 = null,
+    };
+};
+
+/// Generate a new stable random id for a window or tab. Kept to 52 bits so it
+/// round-trips exactly through JSON (and tools like jq/python that use f64),
+/// and is never 0 (which is the "unset" sentinel). Collisions across the small
+/// number of live windows/tabs are astronomically unlikely.
+pub fn newId() u64 {
+    const mask: u64 = (1 << 52) - 1;
+    const id = std.crypto.random.int(u64) & mask;
+    return if (id == 0) 1 else id;
+}
+
+/// Returns true if window state should be written to disk on exit.
+///
+/// On Linux there is no OS-level restoration mechanism, so `default` behaves
+/// like `always` ("just works"). `never` disables saving entirely.
+pub fn shouldSaveState(config: *const CoreConfig) bool {
+    return switch (config.@"window-save-state") {
+        .never => false,
+        .default, .always => true,
+    };
+}
+
+/// Returns true if a previously saved session should be restored on launch.
+pub fn shouldRestoreState(config: *const CoreConfig) bool {
+    return switch (config.@"window-save-state") {
+        .never => false,
+        .default, .always => true,
+    };
+}
+
+/// Compute the absolute path to the session file. Caller owns the memory.
+pub fn path(alloc: Allocator) ![]u8 {
+    const dir = try internal_os.xdg.state(alloc, .{ .subdir = subdir });
+    defer alloc.free(dir);
+    return try std.fs.path.join(alloc, &.{ dir, filename });
+}
+
+/// Serialize a session to indented JSON. Caller owns the returned memory.
+pub fn serialize(alloc: Allocator, session: Session) ![]u8 {
+    var buffer: std.Io.Writer.Allocating = .init(alloc);
+    errdefer buffer.deinit();
+    try buffer.writer.print("{f}", .{std.json.fmt(
+        session,
+        .{ .whitespace = .indent_2 },
+    )});
+    return try buffer.toOwnedSlice();
+}
+
+/// Atomically write pre-serialized session bytes to the session file,
+/// creating the state directory (and any missing parents) if needed. Errors
+/// are returned to the caller, which is expected to log and swallow them.
+pub fn writeBytes(alloc: Allocator, bytes: []const u8) !void {
+    const dir = try internal_os.xdg.state(alloc, .{ .subdir = subdir });
+    defer alloc.free(dir);
+
+    // Create/open the state directory, creating any missing parent dirs.
+    var d = try std.fs.cwd().makeOpenPath(dir, .{});
+    defer d.close();
+
+    // Write to a temp file then rename over the target so a crash mid-write
+    // never leaves a corrupt session file.
+    try d.writeFile(.{ .sub_path = filename_tmp, .data = bytes });
+    try d.rename(filename_tmp, filename);
+
+    log.info("session written to {s}/{s} ({d} bytes)", .{ dir, filename, bytes.len });
+}
+
+/// Serialize and atomically write a session to disk in one step.
+pub fn save(alloc: Allocator, session: Session) !void {
+    const bytes = try serialize(alloc, session);
+    defer alloc.free(bytes);
+    try writeBytes(alloc, bytes);
+}
+
+/// Load and parse the session file. Returns null if there is no session file,
+/// it can't be read/parsed, or its version doesn't match the current schema.
+/// The returned value must be freed with `.deinit()`.
+pub fn load(alloc: Allocator) !?std.json.Parsed(Session) {
+    const dir = try internal_os.xdg.state(alloc, .{ .subdir = subdir });
+    defer alloc.free(dir);
+
+    var d = std.fs.cwd().openDir(dir, .{}) catch |err| switch (err) {
+        error.FileNotFound => {
+            log.info("no session directory at {s}", .{dir});
+            return null;
+        },
+        else => return err,
+    };
+    defer d.close();
+
+    const file = d.openFile(filename, .{}) catch |err| switch (err) {
+        error.FileNotFound => {
+            log.info("no session file at {s}/{s}", .{ dir, filename });
+            return null;
+        },
+        else => return err,
+    };
+    defer file.close();
+
+    log.info("loading session from {s}/{s}", .{ dir, filename });
+
+    const bytes = try file.readToEndAlloc(alloc, max_read_size);
+    defer alloc.free(bytes);
+
+    const parsed = std.json.parseFromSlice(
+        Session,
+        alloc,
+        bytes,
+        .{
+            .ignore_unknown_fields = true,
+            // Copy all strings into the parsed arena so the result is fully
+            // self-contained and we can free `bytes` below without dangling.
+            .allocate = .alloc_always,
+        },
+    ) catch |err| {
+        log.warn("failed to parse session file, ignoring err={}", .{err});
+        return null;
+    };
+
+    // Reject a session written by an incompatible schema version.
+    if (parsed.value.version != version) {
+        log.info(
+            "ignoring session file with unsupported version={}",
+            .{parsed.value.version},
+        );
+        parsed.deinit();
+        return null;
+    }
+
+    return parsed;
+}
+
+/// Delete the session file if it exists. Used when saving is disabled
+/// (`window-save-state = never`) so that a stale file is not restored.
+pub fn delete(alloc: Allocator) void {
+    const p = path(alloc) catch return;
+    defer alloc.free(p);
+    std.fs.cwd().deleteFile(p) catch |err| switch (err) {
+        error.FileNotFound => return,
+        else => {
+            log.warn("failed to delete session file err={}", .{err});
+            return;
+        },
+    };
+    log.info("deleted session file {s}", .{p});
+}
+
+// ---------------------------------------------------------------------------
+// Scrollback persistence
+//
+// Each tab's scrollback is stored in its own file under a `scrollback`
+// subdirectory, named `<id>.vt` (keyed by the tab's stable id), holding styled
+// VT bytes. Keying by a stable id (rather than an enumeration index) means a
+// tab always reads/writes the same file regardless of how windows/tabs are
+// added or reordered, and lets the save path safely skip never-realized tabs.
+
+const scrollback_subdir = "scrollback";
+
+/// Open (creating if needed) the scrollback directory. Caller closes the Dir.
+fn scrollbackDir(alloc: Allocator) !std.fs.Dir {
+    const dir = try internal_os.xdg.state(alloc, .{ .subdir = subdir });
+    defer alloc.free(dir);
+    var base = try std.fs.cwd().makeOpenPath(dir, .{});
+    defer base.close();
+    return try base.makeOpenPath(scrollback_subdir, .{});
+}
+
+/// Write a tab's scrollback bytes to its id-keyed file.
+pub fn writeScrollback(alloc: Allocator, id: u64, bytes: []const u8) !void {
+    var dir = try scrollbackDir(alloc);
+    defer dir.close();
+
+    var name_buf: [32]u8 = undefined;
+    var tmp_buf: [32]u8 = undefined;
+    const name = try std.fmt.bufPrint(&name_buf, "{d}.vt", .{id});
+    const tmp = try std.fmt.bufPrint(&tmp_buf, "{d}.vt.tmp", .{id});
+
+    try dir.writeFile(.{ .sub_path = tmp, .data = bytes });
+    try dir.rename(tmp, name);
+    log.info("scrollback id {d} written ({d} bytes)", .{ id, bytes.len });
+}
+
+/// Read a tab's scrollback bytes from its id-keyed file. Returns null if there
+/// is no scrollback for that id. Caller owns the returned memory.
+pub fn readScrollback(alloc: Allocator, id: u64) !?[]u8 {
+    var dir = scrollbackDir(alloc) catch |err| switch (err) {
+        error.FileNotFound => return null,
+        else => return err,
+    };
+    defer dir.close();
+
+    var name_buf: [32]u8 = undefined;
+    const name = try std.fmt.bufPrint(&name_buf, "{d}.vt", .{id});
+
+    const file = dir.openFile(name, .{}) catch |err| switch (err) {
+        error.FileNotFound => return null,
+        else => return err,
+    };
+    defer file.close();
+
+    // Generous bound; scrollback is capped by the config size anyway.
+    const bytes = try file.readToEndAlloc(alloc, 64 * 1024 * 1024);
+    if (bytes.len == 0) {
+        alloc.free(bytes);
+        return null;
+    }
+    return bytes;
+}
+
+/// Delete a tab's scrollback file, if it exists (e.g. a realized tab whose
+/// scrollback is now empty).
+pub fn deleteScrollback(alloc: Allocator, id: u64) void {
+    var dir = scrollbackDir(alloc) catch return;
+    defer dir.close();
+    var name_buf: [32]u8 = undefined;
+    const name = std.fmt.bufPrint(&name_buf, "{d}.vt", .{id}) catch return;
+    dir.deleteFile(name) catch {};
+}
+
+/// Delete any scrollback files whose id is not in `keep`. Used to clean up
+/// files for tabs that have been closed (and legacy index-named files). We
+/// collect names first and delete afterwards so we never mutate the directory
+/// mid-iteration.
+pub fn pruneScrollback(alloc: Allocator, keep: []const u64) void {
+    var dir = scrollbackDir(alloc) catch return;
+    defer dir.close();
+
+    var to_delete: std.ArrayListUnmanaged([]u8) = .empty;
+    defer {
+        for (to_delete.items) |n| alloc.free(n);
+        to_delete.deinit(alloc);
+    }
+
+    var it = dir.iterate();
+    while (it.next() catch null) |entry| {
+        if (entry.kind != .file) continue;
+        const name = entry.name;
+        const del = del: {
+            // Remove stale temp files unconditionally.
+            if (std.mem.endsWith(u8, name, ".vt.tmp")) break :del true;
+            // Only "<id>.vt" files are candidates.
+            if (!std.mem.endsWith(u8, name, ".vt")) break :del false;
+            const id = std.fmt.parseInt(u64, name[0 .. name.len - 3], 10) catch
+                break :del false;
+            for (keep) |k| if (k == id) break :del false;
+            break :del true;
+        };
+        if (del) {
+            const dup = alloc.dupe(u8, name) catch continue;
+            to_delete.append(alloc, dup) catch alloc.free(dup);
+        }
+    }
+
+    for (to_delete.items) |n| dir.deleteFile(n) catch {};
+}
+
+test "shouldSaveState mapping" {
+    const testing = std.testing;
+    var c = try CoreConfig.default(testing.allocator);
+    defer c.deinit();
+
+    c.@"window-save-state" = .never;
+    try testing.expect(!shouldSaveState(&c));
+    try testing.expect(!shouldRestoreState(&c));
+
+    c.@"window-save-state" = .default;
+    try testing.expect(shouldSaveState(&c));
+    try testing.expect(shouldRestoreState(&c));
+
+    c.@"window-save-state" = .always;
+    try testing.expect(shouldSaveState(&c));
+    try testing.expect(shouldRestoreState(&c));
+}

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2206,7 +2206,8 @@ keybind: Keybinds = .{},
 ///
 ///   * `default` will use the default system behavior. On macOS, this
 ///     will only save state if the application is forcibly terminated
-///     or if it is configured systemwide via Settings.app.
+///     or if it is configured systemwide via Settings.app. On Linux, there
+///     is no system-level behavior, so this behaves like `always`.
 ///
 ///   * `never` will never save window state.
 ///
@@ -2226,8 +2227,31 @@ keybind: Keybinds = .{},
 ///
 /// The default value is `default`.
 ///
-/// This is currently only supported on macOS. This has no effect on Linux.
+/// ## Platform differences
+///
+/// On macOS, this uses the native AppKit window restoration system and can
+/// restore window position, size, tabs, and splits.
+///
+/// On Linux (GTK), Ghostty saves the open windows, their tabs, and each tab's
+/// working directory to `$XDG_STATE_HOME/ghostty/session.json` (typically
+/// `~/.local/state/ghostty/session.json`) on exit, and restores them on the
+/// next launch. Window size is also restored. Splits and scrollback contents
+/// are not currently restored on Linux. Accurate working directories require
+/// shell integration (see `shell-integration`); tabs whose working directory
+/// is unknown are restored using the default working directory.
 @"window-save-state": WindowSaveState = .default,
+
+/// The maximum number of bytes of scrollback to persist per tab when
+/// `window-save-state` saves a session (Linux/GTK only).
+///
+/// When greater than zero, each restored tab's scrollback (history plus the
+/// visible screen) is saved to disk and replayed into the tab on the next
+/// launch, so previous output — including colors — appears above the new
+/// shell prompt. Only the most recent bytes up to this budget are kept.
+///
+/// The default value of `0` disables scrollback persistence; window, tab, and
+/// working-directory restoration are unaffected. This has no effect on macOS.
+@"window-save-state-scrollback-size": usize = 0,
 
 /// Resize the window in discrete increments of the focused surface's cell size.
 /// If this is disabled, surfaces are resized in pixel increments. Currently

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -3155,11 +3155,15 @@ pub fn dumpString(
         /// If true, this will unwrap soft-wrapped lines. If false, this will
         /// dump the screen as it is visually seen in a rendered window.
         unwrap: bool = true,
+
+        /// The format to emit. Defaults to plain text. Use `.vt` to emit
+        /// styled output (SGR sequences) that can be replayed into a terminal.
+        emit: @import("formatter.zig").Format = .plain,
     },
 ) std.Io.Writer.Error!void {
     // Create a formatter and use that to emit our text.
     var formatter: ScreenFormatter = .init(self, .{
-        .emit = .plain,
+        .emit = opts.emit,
         .unwrap = opts.unwrap,
         .trim = false,
     });
@@ -3213,6 +3217,58 @@ pub fn dumpStringAllocUnwrapped(
         .tl = self.pages.getTopLeft(tl),
         .br = self.pages.getBottomRight(tl) orelse return error.UnknownPoint,
         .unwrap = true,
+    });
+
+    return try builder.toOwnedSlice();
+}
+
+/// Like `dumpStringAlloc` but emits styled VT output (SGR sequences) instead
+/// of plain text, so the result can be replayed into a terminal to restore
+/// the visual appearance (colors, bold, etc.) of the dumped region.
+///
+/// If `skip_current_prompt` is set, the dump stops just above the current
+/// (bottom-most) shell prompt, so a restored dump doesn't duplicate the prompt
+/// that the freshly launched shell will print itself. This relies on shell
+/// integration's semantic prompt marks (OSC 133); without them the full region
+/// is dumped. Because it keys off the marks rather than the prompt text, it
+/// works for configurable and multi-line prompts.
+pub fn dumpStringVtAlloc(
+    self: *const Screen,
+    alloc: Allocator,
+    opts: struct {
+        tl: point.Point = .{ .screen = .{} },
+        skip_current_prompt: bool = false,
+    },
+) ![]const u8 {
+    var builder: std.Io.Writer.Allocating = .init(alloc);
+    defer builder.deinit();
+
+    const top = self.pages.getTopLeft(opts.tl);
+    var br = self.pages.getBottomRight(opts.tl) orelse return error.UnknownPoint;
+
+    if (opts.skip_current_prompt) {
+        // Walk up from the bottom, within the active area only, to find the
+        // start of the current prompt block (a row marked `.prompt`). Stop the
+        // dump just above it. The loop is bounded by the active row count and
+        // breaks at the top of the buffer, so it always terminates.
+        var cur = br;
+        var i: usize = 0;
+        while (i < self.pages.rows) : (i += 1) {
+            if (cur.rowAndCell().row.semantic_prompt == .prompt) {
+                if (cur.up(1)) |above| {
+                    if (!above.before(top)) br = above;
+                }
+                break;
+            }
+            cur = cur.up(1) orelse break;
+        }
+    }
+
+    try self.dumpString(&builder.writer, .{
+        .tl = top,
+        .br = br,
+        .unwrap = false,
+        .emit = .vt,
     });
 
     return try builder.toOwnedSlice();


### PR DESCRIPTION
So far there's no session restore on Linux. This PR implements support for that, including support for saving and restoring the scrollback buffers. I'm aware that the offical position is to wait until GTK handles that, see [Feature Request: Bring `window-save-state` to Linux/GTK](https://github.com/ghostty-org/ghostty/discussions/12055#top). So this implementation is purely for those who want a stop-gap solution.

You can apply the diff to 1.3.1 official release download and enjoy session / scrollback restore until official support is released.

It introduces window and tab ids to make sure save/restore is stable across pwd changes / tab renames. It also works when quitting while some tabs/windows are still sleeping.

More details:

- Session persistence — The new src/apprt/gtk/session.zig serializes session state to $XDG_STATE_HOME/ghostty/session.json (atomic temp-file + rename write, versioned schema, tolerant of unknown fields). Restores window geometry, tab working directories, titles, and the focused tab.
- Stable window/tab IDs — Windows and tabs get a stable random 52-bit ID at creation (also stored in the session JSON), used to key scrollback files and survive restore.
- Scrollback persistence — New config window-save-state-scrollback-size (default 0 = off). When enabled, each tab's scrollback is dumped as styled VT bytes (<id>.vt, capped to the most recent N bytes with line boundary) and replayed into the restored tab above the fresh shell prompt.
- Prompt-driven saves — Saves are scheduled on tab add/remove and working-directory changes via a coalesced glib idle source, plus a synchronous save on window close and quit, so state survives unclean termination (OOM, SIGKILL). Writes are hash-skipped when nothing changed, and orphaned scrollback files are deleted.
- Config docs — window-save-state is documented for Linux (default behaves like always, since there's no OS-level mechanism).

Not yet handled

Splits and per-split scrollback are not restored (the schema is versioned to allow adding these later).
