### PR TITLE
font: add null checks for fontconfig C API return values

### DIFF
--- a/pkg/fontconfig/config.zig
+++ b/pkg/fontconfig/config.zig
@@ -13,8 +13,8 @@ pub const Config = opaque {
         c.FcConfigDestroy(@ptrCast(self));
     }
 
-    pub fn fontList(self: *Config, pat: *Pattern, os: *ObjectSet) *FontSet {
-        return @ptrCast(c.FcFontList(self.cval(), pat.cval(), os.cval()));
+    pub fn fontList(self: *Config, pat: *Pattern, os: *ObjectSet) ?*FontSet {
+        return @as(?*FontSet, @ptrCast(c.FcFontList(self.cval(), pat.cval(), os.cval())));
     }
 
     pub fn fontSort(
@@ -22,15 +22,15 @@ pub const Config = opaque {
         pat: *Pattern,
         trim: bool,
         charset: ?[*]*CharSet,
-    ) FontSortResult {
+    ) ?FontSortResult {
         var result: FontSortResult = undefined;
-        result.fs = @ptrCast(c.FcFontSort(
+        result.fs = @as(?*FontSet, @ptrCast(c.FcFontSort(
             self.cval(),
             pat.cval(),
             if (trim) c.FcTrue else c.FcFalse,
             @ptrCast(charset),
             @ptrCast(&result.result),
-        ));
+        ))) orelse return null;
 
         return result;
     }

--- a/pkg/fontconfig/font_set.zig
+++ b/pkg/fontconfig/font_set.zig
@@ -4,8 +4,8 @@ const c = @import("c.zig").c;
 const Pattern = @import("pattern.zig").Pattern;
 
 pub const FontSet = opaque {
-    pub fn create() *FontSet {
-        return @ptrCast(c.FcFontSetCreate());
+    pub fn create() ?*FontSet {
+        return @as(?*FontSet, @ptrCast(c.FcFontSetCreate()));
     }
 
     pub fn destroy(self: *FontSet) void {

--- a/pkg/fontconfig/init.zig
+++ b/pkg/fontconfig/init.zig
@@ -10,12 +10,12 @@ pub fn fini() void {
     c.FcFini();
 }
 
-pub fn initLoadConfig() *Config {
-    return @ptrCast(c.FcInitLoadConfig());
+pub fn initLoadConfig() ?*Config {
+    return @as(?*Config, @ptrCast(c.FcInitLoadConfig()));
 }
 
-pub fn initLoadConfigAndFonts() *Config {
-    return @ptrCast(c.FcInitLoadConfigAndFonts());
+pub fn initLoadConfigAndFonts() ?*Config {
+    return @as(?*Config, @ptrCast(c.FcInitLoadConfigAndFonts()));
 }
 
 pub fn version() u32 {

--- a/pkg/fontconfig/pattern.zig
+++ b/pkg/fontconfig/pattern.zig
@@ -10,12 +10,12 @@ const ValueBinding = @import("main.zig").ValueBinding;
 const Weight = @import("main.zig").Weight;
 
 pub const Pattern = opaque {
-    pub fn create() *Pattern {
-        return @ptrCast(c.FcPatternCreate());
+    pub fn create() ?*Pattern {
+        return @as(?*Pattern, @ptrCast(c.FcPatternCreate()));
     }
 
-    pub fn parse(str: [:0]const u8) *Pattern {
-        return @ptrCast(c.FcNameParse(str.ptr));
+    pub fn parse(str: [:0]const u8) ?*Pattern {
+        return @as(?*Pattern, @ptrCast(c.FcNameParse(str.ptr)));
     }
 
     pub fn destroy(self: *Pattern) void {

--- a/src/font/DeferredFace.zig
+++ b/src/font/DeferredFace.zig
@@ -478,7 +478,7 @@ test "fontconfig" {
 
     // Get a deferred face from fontconfig
     var def = def: {
-        var fc = discovery.Fontconfig.init(lib);
+        var fc = discovery.Fontconfig.init(lib) orelse return error.SkipZigTest;
         defer fc.deinit();
         var it = try fc.discover(alloc, .{ .family = "monospace", .size = 12 });
         defer it.deinit();

--- a/src/font/SharedGridSet.zig
+++ b/src/font/SharedGridSet.zig
@@ -443,7 +443,8 @@ fn discover(self: *SharedGridSet) !?*Discover {
     if (self.font_discover) |*v| return v;
 
     self.font_discover = .init(self.font_lib);
-    return &self.font_discover.?;
+    if (self.font_discover) |*v| return v;
+    return null;
 }
 
 /// Ref-counted SharedGrid.

--- a/src/font/discovery.zig
+++ b/src/font/discovery.zig
@@ -114,8 +114,8 @@ pub const Descriptor = struct {
     /// Convert to Fontconfig pattern to use for lookup. The pattern does
     /// not have defaults filled/substituted (Fontconfig thing) so callers
     /// must still do this.
-    pub fn toFcPattern(self: Descriptor) *fontconfig.Pattern {
-        const pat = fontconfig.Pattern.create();
+    pub fn toFcPattern(self: Descriptor) ?*fontconfig.Pattern {
+        const pat = fontconfig.Pattern.create() orelse return null;
         if (self.family) |family| {
             assert(pat.add(.family, .{ .string = family }, false));
         }
@@ -247,11 +247,14 @@ pub const Descriptor = struct {
 pub const Fontconfig = struct {
     fc_config: *fontconfig.Config,
 
-    pub fn init(lib: Library) Fontconfig {
+    pub fn init(lib: Library) ?Fontconfig {
         _ = lib;
-        // safe to call multiple times and concurrently
         _ = fontconfig.init();
-        return .{ .fc_config = fontconfig.initLoadConfigAndFonts() };
+        const cfg = fontconfig.initLoadConfigAndFonts() orelse {
+            log.warn("fontconfig initialization failed, font discovery disabled", .{});
+            return null;
+        };
+        return .{ .fc_config = cfg };
     }
 
     pub fn deinit(self: *Fontconfig) void {
@@ -267,14 +270,15 @@ pub const Fontconfig = struct {
     ) !DiscoverIterator {
         _ = alloc;
 
-        // Build our pattern that we'll search for
-        const pat = desc.toFcPattern();
+        const pat = desc.toFcPattern() orelse return error.FontConfigFailed;
         errdefer pat.destroy();
         assert(self.fc_config.substituteWithPat(pat, .pattern));
         pat.defaultSubstitute();
 
-        // Search
-        const res = self.fc_config.fontSort(pat, false, null);
+        const res = self.fc_config.fontSort(pat, false, null) orelse {
+            pat.destroy();
+            return error.FontConfigFailed;
+        };
         if (res.result != .match) return error.FontConfigFailed;
         errdefer res.fs.destroy();
 
@@ -1167,7 +1171,7 @@ test "fontconfig" {
     var lib = try Library.init(alloc);
     defer lib.deinit();
 
-    var fc = Fontconfig.init(lib);
+    var fc = Fontconfig.init(lib) orelse return error.SkipZigTest;
     defer fc.deinit();
     var it = try fc.discover(alloc, .{ .family = "monospace", .size = 12 });
     defer it.deinit();
@@ -1182,7 +1186,7 @@ test "fontconfig codepoint" {
     var lib = try Library.init(alloc);
     defer lib.deinit();
 
-    var fc = Fontconfig.init(lib);
+    var fc = Fontconfig.init(lib) orelse return error.SkipZigTest;
     defer fc.deinit();
     var it = try fc.discover(alloc, .{ .codepoint = 'A', .size = 12 });
     defer it.deinit();


### PR DESCRIPTION
## Context

Ghostty crashes with SIGSEGV when fontconfig initialization fails (e.g., corrupted cache, missing config files). The crash occurs in `FcCompare` during fallback font discovery in the renderer thread. All 15 recorded coredumps show the identical stack trace:

```
FcCompare -> FcFontSetSort -> FcFontSort
  -> config.Config.fontSort
  -> font.discovery.Fontconfig.discoverFallback
  -> font.SharedGrid.getIndex
  -> font.shaper.run.RunIterator.indexForCell
  -> renderer.generic.Renderer.rebuildRow
```

### Root Cause

The fontconfig C functions (`FcInitLoadConfigAndFonts`, `FcPatternCreate`, `FcFontSort`, etc.) can return `NULL` on failure, but the Zig wrappers in `pkg/fontconfig/` cast the return values directly to non-optional pointer types (`*Config`, `*Pattern`, `*FontSet`). When fontconfig initialization fails, a NULL pointer propagates through the system and is dereferenced in `FcCompare`, causing SIGSEGV. Since SIGSEGV cannot be caught by Zig's `catch`, the process crashes immediately.

## Changes

- **pkg/fontconfig**: Return optional types (`?*T`) from `initLoadConfig`, `initLoadConfigAndFonts`, `Pattern.create/parse`, `FontSet.create`, `Config.fontList`, and `Config.fontSort` so callers must handle NULL
- **src/font/discovery.zig**: `Fontconfig.init()` returns `?Fontconfig`, gracefully returning null when fontconfig cannot initialize; `discover()` handles null from `toFcPattern()` and `fontSort()`
- **src/font/SharedGridSet.zig**: `discover()` no longer panics when `Fontconfig.init()` returns null, instead returns null to safely disable font discovery

## Testing

- Existing tests updated to handle optional return with `orelse return error.SkipZigTest`
- Crash scenario (fontconfig init failure) now gracefully degrades: font discovery is disabled instead of crashing the renderer

Fixes #12968