### PR TITLE
input: add new_tab_with_command keybind action

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -827,6 +827,12 @@ typedef struct {
   uintptr_t len;
 } ghostty_action_open_url_s;
 
+// apprt.action.NewTabCommand.C
+typedef struct {
+  const char* command;
+  uintptr_t len;
+} ghostty_action_new_tab_with_command_s;
+
 // apprt.action.CloseTabMode
 typedef enum {
   GHOSTTY_ACTION_CLOSE_TAB_MODE_THIS,
@@ -956,6 +962,7 @@ typedef enum {
   GHOSTTY_ACTION_SEARCH_SELECTED,
   GHOSTTY_ACTION_READONLY,
   GHOSTTY_ACTION_COPY_TITLE_TO_CLIPBOARD,
+  GHOSTTY_ACTION_NEW_TAB_WITH_COMMAND,
 } ghostty_action_tag_e;
 
 typedef union {
@@ -998,6 +1005,7 @@ typedef union {
   ghostty_action_search_total_s search_total;
   ghostty_action_search_selected_s search_selected;
   ghostty_action_readonly_e readonly;
+  ghostty_action_new_tab_with_command_s new_tab_with_command;
 } ghostty_action_u;
 
 typedef struct {

--- a/macos/Sources/Ghostty/Ghostty.App.swift
+++ b/macos/Sources/Ghostty/Ghostty.App.swift
@@ -501,6 +501,9 @@ extension Ghostty {
             case GHOSTTY_ACTION_NEW_TAB:
                 newTab(app, target: target)
 
+            case GHOSTTY_ACTION_NEW_TAB_WITH_COMMAND:
+                newTabWithCommand(app, target: target, v: action.action.new_tab_with_command)
+
             case GHOSTTY_ACTION_NEW_SPLIT:
                 newSplit(app, target: target, direction: action.action.new_split)
 
@@ -847,6 +850,54 @@ extension Ghostty {
                     object: surfaceView,
                     userInfo: [
                         Notification.NewSurfaceConfigKey: SurfaceConfiguration(from: ghostty_surface_inherited_config(surface, GHOSTTY_SURFACE_CONTEXT_TAB)),
+                    ]
+                )
+
+            default:
+                assertionFailure()
+            }
+        }
+
+        private static func newTabWithCommand(
+            _ app: ghostty_app_t,
+            target: ghostty_target_s,
+            v: ghostty_action_new_tab_with_command_s
+        ) {
+            let command = String(
+                bytes: UnsafeRawBufferPointer(start: v.command, count: Int(v.len)),
+                encoding: .utf8
+            )
+
+            switch target.tag {
+            case GHOSTTY_TARGET_APP:
+                // A new tab with a command requires a surface context so
+                // we can inherit the proper configuration. Without one we
+                // do nothing.
+                Ghostty.logger.warning("new_tab_with_command does nothing with an app target")
+                return
+
+            case GHOSTTY_TARGET_SURFACE:
+                guard let surface = target.target.surface else { return }
+                guard let surfaceView = self.surfaceView(from: surface) else { return }
+                guard let appState = self.appState(fromView: surfaceView) else { return }
+                guard appState.config.windowDecorations else {
+                    let alert = NSAlert()
+                    alert.messageText = "Tabs are disabled"
+                    alert.informativeText = "Enable window decorations to use tabs"
+                    alert.addButton(withTitle: "OK")
+                    alert.alertStyle = .warning
+                    _ = alert.runModal()
+                    return
+                }
+
+                var config = SurfaceConfiguration(from: ghostty_surface_inherited_config(surface, GHOSTTY_SURFACE_CONTEXT_TAB))
+                config.command = command
+
+                NotificationCenter.default.post(
+                    name: Notification.ghosttyNewTab,
+                    object: surfaceView,
+                    userInfo: [
+                        Notification.NewSurfaceConfigKey: config,
                     ]
                 )
 

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -5302,6 +5302,12 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
             {},
         ),
 
+        .new_tab_with_command => |v| return try self.rt_app.performAction(
+            .{ .surface = self },
+            .new_tab_with_command,
+            .{ .command = v },
+        ),
+
         .close_tab => |v| return try self.rt_app.performAction(
             .{ .surface = self },
             .close_tab,

--- a/src/apprt/action.zig
+++ b/src/apprt/action.zig
@@ -351,6 +351,10 @@ pub const Action = union(Key) {
     /// otherwise the terminal-set title.
     copy_title_to_clipboard,
 
+    /// Open a new tab running the given command instead of the default.
+    /// Otherwise behaves the same as new_tab.
+    new_tab_with_command: NewTabCommand,
+
     /// Sync with: ghostty_action_tag_e
     pub const Key = enum(c_int) {
         quit,
@@ -420,6 +424,7 @@ pub const Action = union(Key) {
         search_selected,
         readonly,
         copy_title_to_clipboard,
+        new_tab_with_command,
 
         test "ghostty.h Action.Key" {
             try lib.checkGhosttyHEnum(Key, "GHOSTTY_ACTION_");
@@ -958,6 +963,25 @@ pub const OpenUrl = struct {
             .kind = self.kind,
             .url = self.url.ptr,
             .len = self.url.len,
+        };
+    }
+};
+
+/// The command to run in a new tab for new_tab_with_command.
+pub const NewTabCommand = struct {
+    /// The command to execute.
+    command: []const u8,
+
+    // Sync with: ghostty_action_new_tab_with_command_s
+    pub const C = extern struct {
+        command: [*]const u8,
+        len: usize,
+    };
+
+    pub fn cval(self: NewTabCommand) C {
+        return .{
+            .command = self.command.ptr,
+            .len = self.command.len,
         };
     }
 };

--- a/src/apprt/gtk/class/application.zig
+++ b/src/apprt/gtk/class/application.zig
@@ -799,6 +799,7 @@ pub const Application = extern struct {
             .check_for_updates,
             .undo,
             .redo,
+            .new_tab_with_command,
             => {
                 log.warn("unimplemented action={}", .{action});
                 return false;

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -559,6 +559,23 @@ pub const Action = union(enum) {
     /// Open a new tab.
     new_tab,
 
+    /// Open a new tab running the given command instead of the
+    /// default configured command, e.g.
+    /// `keybind = cmd+ctrl+digit_1=new_tab_with_command:ssh myhost`
+    ///
+    /// The command is always run in a shell (e.g. `/bin/sh -c`), so it
+    /// may contain arguments. Unlike the `command` configuration, the
+    /// `direct:` and `shell:` prefixes are not supported.
+    ///
+    /// The new tab behaves as if `wait-after-command` were enabled:
+    /// when the command exits, the terminal remains open and must be
+    /// closed manually.
+    ///
+    /// This is currently only implemented on macOS. On other platforms
+    /// the action is unhandled: a warning is logged and the keybind is
+    /// not consumed.
+    new_tab_with_command: []const u8,
+
     /// Go to the previous tab.
     previous_tab,
 
@@ -1413,6 +1430,7 @@ pub const Action = union(enum) {
             // come from. For example `new_window` needs to be sourced to
             // a surface so inheritance can be done correctly.
             .new_tab,
+            .new_tab_with_command,
             .previous_tab,
             .next_tab,
             .last_tab,
@@ -3075,6 +3093,24 @@ test "parse: text action equals sign" {
         }, binding.trigger);
         try testing.expectEqualStrings("=hello", binding.action.text);
     }
+}
+
+test "parse: new_tab_with_command" {
+    const testing = std.testing;
+    {
+        const binding = try parseSingle("ctrl+a=new_tab_with_command:ssh myhost");
+        try testing.expect(binding.action == .new_tab_with_command);
+        try testing.expectEqualStrings(
+            "ssh myhost",
+            binding.action.new_tab_with_command,
+        );
+    }
+
+    // A command is required: no colon is an error.
+    try testing.expectError(
+        Error.InvalidFormat,
+        parseSingle("ctrl+a=new_tab_with_command"),
+    );
 }
 
 // For Ghostty 1.2+ we changed our key names to match the W3C and removed

--- a/src/input/command.zig
+++ b/src/input/command.zig
@@ -708,6 +708,7 @@ fn actionCommands(action: Action.Key) []const Command {
         .jump_to_prompt,
         .write_scrollback_file,
         .goto_tab,
+        .new_tab_with_command,
         .resize_split,
         .activate_key_table,
         .activate_key_table_once,


### PR DESCRIPTION
## Summary

Adds a new keybind action `new_tab_with_command:<command>` that opens a new tab running the given command instead of the configured default:

```ini
keybind = cmd+ctrl+digit_1=new_tab_with_command:ssh myhost
```

This gives a lightweight version of iTerm2's "profile that runs a command" workflow: a dedicated shortcut per remote host or tool, each opening in a native tab.

Vouched in #12977. Design discussion for window/split variants: #12985.

## Implementation notes

- The surface configuration plumbing already existed (`SurfaceConfiguration.command` and the inherited-config notification on macOS); this change only exposes it through a binding action.
- The apprt action follows the existing `OpenUrl` pattern for passing a C-ABI string across the boundary.
- The command is always run in a shell and the surface behaves as if `wait-after-command` were enabled — both inherited from the existing embedded surface-config behavior, and documented in the action's doc comment.
- macOS implements the full behavior. **GTK does not implement it**: the action joins the existing `// Unimplemented` list in `apprt/gtk/class/application.zig`, which logs a warning and leaves the keybind unconsumed, the same as `undo`/`redo`/`secure_input` do today. I don't have a Linux dev setup to wire and test the GTK side, and a silent fallback to a plain `new_tab` would drop the command with no way for the user to notice.
- Added a parse test (`parse: new_tab_with_command`); `zig fmt --check` clean.

## Open design question

@jcollie asked in the vouch discussion whether there should be similar actions for new windows and splits, and whether that should be one parameterized action or separate actions. I originally kept this PR minimal — tab only, as a separate action mirroring the existing `new_tab` naming — and argued that parameterizing `new_tab` carried an external ABI cost. @00-kat correctly pointed out that `include/ghostty.h` says of itself that "the only consumer of this API is the macOS app", so that cost does not exist. Reworking toward `new_tab` taking an optional command.

## AI disclosure

Per `AI_POLICY.md`: this change was developed with assistance from Claude Code (Anthropic). I directed the design and reviewed every line.

An earlier version of this section said the result was built and tested locally on macOS. I can't reproduce that today — this machine has the Command Line Tools only, no Xcode and therefore no `metal` compiler — so I've replaced it with what is actually verifiable here: `zig fmt --check` clean, and a `-Dtarget=x86_64-linux -Dapp-runtime=none` build covering `action.zig`, `Binding.zig`, `command.zig` and `Surface.zig`. The macOS and GTK builds have only ever been exercised by CI.

