### PR TITLE
Surface: open file paths with trailing :line[:col] suffixes

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -4429,7 +4429,28 @@ fn processLinks(self: *Surface, pos: apprt.CursorPos) !bool {
             const resolved_path = try self.resolvePathForOpening(str);
             defer if (resolved_path) |p| self.alloc.free(p);
 
-            const url_to_open = resolved_path orelse str;
+            // Compilers and tools commonly suffix file paths with
+            // `:line[:col]` (e.g. `src/main.zig:42:10`). If the text
+            // as-is doesn't resolve to a real file but the path with
+            // the suffix stripped does, open the stripped path so that
+            // the click does something useful instead of silently
+            // failing. Exact matches above take precedence so that
+            // files whose names actually contain a numeric suffix
+            // still open correctly.
+            const stripped_path: ?[]const u8 = stripped: {
+                if (resolved_path != null) break :stripped null;
+                const parsed = input.Link.parseFilePath(str);
+                if (parsed.line == null) break :stripped null;
+                if (std.fs.path.isAbsolute(parsed.path)) {
+                    std.fs.accessAbsolute(parsed.path, .{}) catch
+                        break :stripped null;
+                    break :stripped try self.alloc.dupe(u8, parsed.path);
+                }
+                break :stripped try self.resolvePathForOpening(parsed.path);
+            };
+            defer if (stripped_path) |p| self.alloc.free(p);
+
+            const url_to_open = resolved_path orelse stripped_path orelse str;
             try self.openUrl(.{ .kind = .unknown, .url = url_to_open });
         },
 

--- a/src/input/Link.zig
+++ b/src/input/Link.zig
@@ -51,6 +51,73 @@ pub const Highlight = union(enum) {
     hover_mods: Mods,
 };
 
+/// The result of parsing a matched link string for a trailing
+/// `:line[:col]` suffix, e.g. `src/main.zig:42:10`.
+pub const ParsedFilePath = struct {
+    path: []const u8,
+    line: ?[]const u8 = null,
+    col: ?[]const u8 = null,
+};
+
+/// Parse a trailing `:line[:col]` suffix from a matched link string.
+/// The numeric components are returned as substrings of the input;
+/// they are validated to be all digits but not range-checked.
+pub fn parseFilePath(str: []const u8) ParsedFilePath {
+    var result: ParsedFilePath = .{ .path = str };
+    for (0..2) |_| {
+        const idx = std.mem.lastIndexOfScalar(u8, result.path, ':') orelse break;
+        const seg = result.path[idx + 1 ..];
+        if (!allDigits(seg)) break;
+        result.col = result.line;
+        result.line = seg;
+        result.path = result.path[0..idx];
+    }
+
+    return result;
+}
+
+fn allDigits(s: []const u8) bool {
+    if (s.len == 0) return false;
+    for (s) |c| if (!std.ascii.isDigit(c)) return false;
+    return true;
+}
+
+test "parseFilePath" {
+    const testing = std.testing;
+
+    {
+        const p = parseFilePath("src/main.zig");
+        try testing.expectEqualStrings("src/main.zig", p.path);
+        try testing.expect(p.line == null);
+        try testing.expect(p.col == null);
+    }
+    {
+        const p = parseFilePath("src/main.zig:42");
+        try testing.expectEqualStrings("src/main.zig", p.path);
+        try testing.expectEqualStrings("42", p.line.?);
+        try testing.expect(p.col == null);
+    }
+    {
+        const p = parseFilePath("/abs/path/main.zig:42:10");
+        try testing.expectEqualStrings("/abs/path/main.zig", p.path);
+        try testing.expectEqualStrings("42", p.line.?);
+        try testing.expectEqualStrings("10", p.col.?);
+    }
+    {
+        // Numeric suffix segments are parsed even for non-path strings;
+        // callers are expected to validate the path on disk.
+        const p = parseFilePath("magnet:?xt=urn:btih:1234567890");
+        try testing.expectEqualStrings("magnet:?xt=urn:btih", p.path);
+        try testing.expectEqualStrings("1234567890", p.line.?);
+        try testing.expect(p.col == null);
+    }
+    {
+        const p = parseFilePath("foo:bar");
+        try testing.expectEqualStrings("foo:bar", p.path);
+        try testing.expect(p.line == null);
+    }
+}
+
 /// Returns a new oni.Regex that can be used to match the link.
 pub fn oniRegex(self: *const Link) !oni.Regex {
     return try oni.Regex.init(


### PR DESCRIPTION
Fixes a long-standing paper cut discussed extensively in #1972: clicking a
file path that carries a `:line[:col]` suffix (the standard output format
of most compilers, e.g. `src/main.zig:42:10` from zig/clang, or
`file.scala:47:70` as reported [here](https://github.com/ghostty-org/ghostty/issues/1972#issuecomment-2626961340))
does nothing today. The URL regex matches the full string including the
numeric suffix, so the path fails to resolve on disk and the click fails
silently (or hands a nonexistent path to the system opener).

With this change, when the clicked text doesn't resolve to a real file
as-is, we strip a trailing `:line[:col]` (validated to be all digits) and
try again, for both relative paths (resolved against the terminal pwd,
as before) and absolute paths. Exact matches take precedence, so files
whose names genuinely contain a numeric suffix still open correctly.
If neither resolves, behavior is unchanged.

The parsing helper returns the line/column components as well; they are
unused by the system opener today but are the natural parse result of
this format and are relevant to the custom-handler ideas discussed in
#9546.

Includes unit tests for the suffix parser. Tested manually on macOS
against compiler output and `grep -rn` output. The full test suite was
also run on Linux (`nix develop -c zig build test`); no new failures
versus unpatched main in the same environment, and the new unit test
passes on both platforms.

Disclosure: I used Claude Code to assist with this change, and I have
reviewed and tested every line personally.
