### PR TITLE
macOS: disable liquid class explicitly for layers in icon

### DIFF
--- a/images/Ghostty.icon/icon.json
+++ b/images/Ghostty.icon/icon.json
@@ -18,6 +18,7 @@
               "srgb:0.00000,0.00000,0.00000,1.00000"
             ]
           },
+          "glass" : false,
           "hidden" : false,
           "image-name" : "gloss.png",
           "name" : "GlossTop",
@@ -33,6 +34,7 @@
         {
           "blend-mode" : "normal",
           "fill" : "automatic",
+          "glass" : false,
           "hidden" : false,
           "image-name" : "gloss.png",
           "name" : "gloss",
@@ -93,6 +95,7 @@
         {
           "blend-mode" : "normal",
           "fill" : "automatic",
+          "glass" : false,
           "hidden" : false,
           "image-name" : "Ghostty.png",
           "name" : "Ghostty",
@@ -122,6 +125,7 @@
           }
         },
         {
+          "glass" : false,
           "hidden" : false,
           "image-name" : "Screen.png",
           "name" : "Screen"
@@ -144,6 +148,7 @@
       "hidden" : false,
       "layers" : [
         {
+          "glass" : false,
           "image-name" : "Inner Bevel 6px.png",
           "name" : "Inner Bevel 6px"
         }


### PR DESCRIPTION
Remove the tiny border in app icon on macOS 27. It seems like macOS 27 will [enable liquid glass](https://developer.apple.com/documentation/xcode/creating-your-app-icon-using-icon-composer/#Apply-Liquid-Glass-effects-to-groups-and-layers) for layers in icon that do not disable liquid glass explicitly.

<img width="2662" height="1061" alt="Xnip2026-06-12_09-52-19" src="https://github.com/user-attachments/assets/a25f0157-64ef-46cd-8c27-f23eddd1df09" />

> Left is Icon Composer 1.5 in Xcode 26, right is Icon Composer 2.0 in Xcode 27

I know macOS 27 is still in beta, and default behaviors are very likely to change before public release. But I think this change is reasonable, and it's the original intention.

Relates to #13001 

---

Before(Left) and After(Right)
<table>
    <tr>
      <td><img width="522" height="294" alt="Xnip2026-06-12_09-36-37"
  src="https://github.com/user-attachments/assets/84682907-9ed7-4d93-9b18-2ffd3354e1ad" /></td>
      <td><img width="542" height="274" alt="Xnip2026-06-12_09-39-31"
  src="https://github.com/user-attachments/assets/5ae3af36-a081-4a8f-a204-10b48bc113ee" /></td>
    </tr>
    <tr>
      <td><img width="572" height="290" alt="Xnip2026-06-12_09-39-46"
  src="https://github.com/user-attachments/assets/a8622bf0-4973-403c-ac31-9fa087d7c012" /></td>
      <td><img width="516" height="284" alt="Xnip2026-06-12_09-40-05"
  src="https://github.com/user-attachments/assets/212ef852-54c2-47fe-9452-7214fbcb7511" /></td>
    </tr>
  </table>
