### PR TITLE
gtk: remove deprecated style-hc.css resources, use media query

### DIFF
--- a/src/apprt/gtk/build/gresource.zig
+++ b/src/apprt/gtk/build/gresource.zig
@@ -58,8 +58,6 @@ pub const blueprints: []const Blueprint = &.{
 pub const css = [_][]const u8{
     "style.css",
     "style-dark.css",
-    "style-hc.css",
-    "style-hc-dark.css",
 };
 
 pub const Blueprint = struct {

--- a/src/apprt/gtk/css/style-hc-dark.css
+++ b/src/apprt/gtk/css/style-hc-dark.css
@@ -1,3 +1,0 @@
-.transparent {
-  background-color: transparent;
-}

--- a/src/apprt/gtk/css/style-hc.css
+++ b/src/apprt/gtk/css/style-hc.css
@@ -1,3 +1,0 @@
-.transparent {
-  background-color: transparent;
-}

--- a/src/apprt/gtk/css/style.css
+++ b/src/apprt/gtk/css/style.css
@@ -181,3 +181,9 @@ label.resize-overlay {
   margin: 0;
   padding: 0;
 }
+
+@media (prefers-contrast: more) {
+    .transparent {
+        background-color: transparent;
+    }
+}


### PR DESCRIPTION
The libadwaita warning says style-hc.css is deprecated and style.css with media queries should be used instead.

Move the .transparent rule from style-hc.css and
style-hc-dark.css into style.css wrapped in a
@media (prefers-contrast: more) query, then remove the separate high-contrast resource files and their entries in the gresource build.