### PR TITLE
Add macOS clipboard copy toast

### DIFF
--- a/macos/Sources/Ghostty/Ghostty.App.swift
+++ b/macos/Sources/Ghostty/Ghostty.App.swift
@@ -413,6 +413,19 @@ extension Ghostty {
                     guard let type = NSPasteboard.PasteboardType(mimeType: item.mime) else { continue }
                     pasteboard.setString(item.data, forType: type)
                 }
+
+                if location == GHOSTTY_CLIPBOARD_STANDARD {
+                    let text = contentArray.first(where: { $0.mime == "text/plain" })?.data ?? ""
+                    NotificationCenter.default.post(
+                        name: Ghostty.Notification.didWriteClipboard,
+                        object: surface,
+                        userInfo: [
+                            Ghostty.Notification.DidWriteClipboardMessageKey: text.isEmpty
+                                ? "Cleared clipboard"
+                                : "Copied to clipboard",
+                        ]
+                    )
+                }
                 return
             }
 

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -189,6 +189,14 @@ extension Ghostty {
             return .init(rawValue: v)
         }
 
+        var appNotifications: AppNotifications {
+            guard let config = self.config else { return .all }
+            var v: CUnsignedInt = 0
+            let key = "app-notifications"
+            guard ghostty_config_get(config, &v, key, UInt(key.lengthOfBytes(using: .utf8))) else { return .all }
+            return .init(rawValue: v)
+        }
+
         var initialWindow: Bool {
             guard let config = self.config else { return true }
             var v = true
@@ -835,6 +843,15 @@ extension Ghostty.Config {
         let rawValue: CUnsignedInt
 
         static let navigation = SplitPreserveZoom(rawValue: 1 << 0)
+    }
+
+    struct AppNotifications: OptionSet {
+        let rawValue: CUnsignedInt
+
+        static let clipboardCopy = AppNotifications(rawValue: 1 << 0)
+        static let configReload = AppNotifications(rawValue: 1 << 1)
+
+        static let all: AppNotifications = [.clipboardCopy, .configReload]
     }
 
     enum MacDockDropBehavior: String {

--- a/macos/Sources/Ghostty/GhosttyPackage.swift
+++ b/macos/Sources/Ghostty/GhosttyPackage.swift
@@ -431,6 +431,10 @@ extension Ghostty.Notification {
     static let ConfirmClipboardStateKey = confirmClipboard.rawValue + ".state"
     static let ConfirmClipboardRequestKey = confirmClipboard.rawValue + ".request"
 
+    /// Notification sent when Ghostty writes to the standard clipboard.
+    static let didWriteClipboard = Notification.Name("com.mitchellh.ghostty.didWriteClipboard")
+    static let DidWriteClipboardMessageKey = didWriteClipboard.rawValue + ".message"
+
     /// Notification sent to the active split view to resize the split.
     static let didResizeSplit = Notification.Name("com.mitchellh.ghostty.didResizeSplit")
     static let ResizeSplitDirectionKey = didResizeSplit.rawValue + ".direction"

--- a/macos/Sources/Ghostty/Surface View/SurfaceView.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView.swift
@@ -48,6 +48,10 @@ extension Ghostty {
         // Maintain whether our window has focus (is key) or not
         @State private var windowFocus: Bool = true
 
+        // A short-lived in-app feedback message for clipboard writes.
+        @State private var clipboardFeedbackMessage: String?
+        @State private var clipboardFeedbackTask: Task<Void, Never>?
+
         #if canImport(AppKit)
         // Observe SecureInput to detect when its enabled
         @ObservedObject private var secureInput = SecureInput.shared
@@ -132,6 +136,12 @@ extension Ghostty {
                     keySequence: surfaceView.keySequence
                 )
                 .zIndex(1)
+
+                if let clipboardFeedbackMessage {
+                    ClipboardFeedbackOverlay(message: clipboardFeedbackMessage)
+                        .transition(.opacity.combined(with: .scale(scale: 0.96)))
+                        .zIndex(2)
+                }
 #endif
 
                 VStack(spacing: 0) {
@@ -207,6 +217,26 @@ extension Ghostty {
                 // This is disabled except on macOS because it uses AppKit drag/drop APIs.
                 SurfaceGrabHandle(surfaceView: surfaceView)
                 #endif
+            }
+            .onReceive(center.publisher(for: Ghostty.Notification.didWriteClipboard)) { notification in
+                guard notification.object as? SurfaceView === surfaceView else { return }
+                guard ghostty.config.appNotifications.contains(.clipboardCopy) else { return }
+
+                let message = notification.userInfo?[Ghostty.Notification.DidWriteClipboardMessageKey] as? String
+                clipboardFeedbackTask?.cancel()
+
+                withAnimation(.easeOut(duration: 0.12)) {
+                    clipboardFeedbackMessage = message ?? "Copied to clipboard"
+                }
+
+                clipboardFeedbackTask = Task { @MainActor in
+                    try? await Task.sleep(for: .seconds(2))
+                    guard !Task.isCancelled else { return }
+
+                    withAnimation(.easeIn(duration: 0.18)) {
+                        clipboardFeedbackMessage = nil
+                    }
+                }
             }
         }
     }
@@ -1040,6 +1070,25 @@ extension Ghostty {
                     }
                 }
             }
+        }
+    }
+
+    /// A short-lived in-app overlay shown after copying to the clipboard.
+    struct ClipboardFeedbackOverlay: View {
+        let message: String
+
+        var body: some View {
+            Text(message)
+                .font(.body.weight(.semibold))
+                .foregroundStyle(Color(red: 0.38, green: 0.58, blue: 0.32))
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+                .background(.regularMaterial)
+                .clipShape(Capsule())
+                .shadow(radius: 8)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
+                .padding(.bottom, 18)
+                .allowsHitTesting(false)
         }
     }
 

--- a/macos/Tests/Ghostty/ConfigTests.swift
+++ b/macos/Tests/Ghostty/ConfigTests.swift
@@ -111,6 +111,16 @@ struct ConfigTests {
         #expect(config.resizeOverlay == .after_first)
     }
 
+    @Test func appNotificationsClipboardCopyDefaultsToTrue() throws {
+        let config = try TemporaryConfig("")
+        #expect(config.appNotifications.contains(.clipboardCopy))
+    }
+
+    @Test func appNotificationsClipboardCopyCanBeDisabled() throws {
+        let config = try TemporaryConfig("app-notifications = no-clipboard-copy")
+        #expect(!config.appNotifications.contains(.clipboardCopy))
+    }
+
     @Test(arguments: [
         ("always", Ghostty.Config.ResizeOverlay.always),
         ("never", Ghostty.Config.ResizeOverlay.never),

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -3139,9 +3139,9 @@ keybind: Keybinds = .{},
 
 /// Control the in-app notifications that Ghostty shows.
 ///
-/// On Linux (GTK), in-app notifications show up as toasts. Toasts appear
-/// overlaid on top of the terminal window. They are used to show information
-/// that is not critical but may be important.
+/// On Linux (GTK) and macOS, in-app notifications show up as toasts. Toasts
+/// appear overlaid on top of the terminal window. They are used to show
+/// information that is not critical but may be important.
 ///
 /// Possible notifications are:
 ///
@@ -3160,8 +3160,6 @@ keybind: Keybinds = .{},
 ///
 /// A value of "false" will disable all notifications. A value of "true" will
 /// enable all notifications.
-///
-/// This configuration only applies to GTK.
 ///
 /// Available since: 1.1.0
 @"app-notifications": AppNotifications = .{},


### PR DESCRIPTION
## Summary

This adds macOS support for the existing `app-notifications = clipboard-copy` behavior.

GTK already shows an in-app Adwaita toast when Ghostty writes to the standard clipboard. macOS went through the same clipboard write path, but it did not surface any in-app feedback. This PR emits a macOS-side internal `didWriteClipboard` notification from the clipboard write callback and renders a short-lived SwiftUI overlay on the matching surface.

The macOS behavior intentionally follows the GTK semantics:

- only standard clipboard writes show feedback
- selection clipboard writes are ignored
- `app-notifications.clipboard-copy` gates the feedback
- non-empty text shows `Copied to clipboard`
- empty text shows `Cleared clipboard`
- the overlay uses a 3 second timeout, matching GTK's `adw.Toast` timeout

The overlay uses native SwiftUI material, system text styling, and primary foreground color so the typography and colors follow the macOS runtime instead of introducing a custom visual style.

## Changes

- Expose `app-notifications` through the macOS Swift config wrapper.
- Add a macOS internal `didWriteClipboard` notification.
- Post that notification when the macOS runtime writes to the standard clipboard.
- Render a transient clipboard feedback overlay in `SurfaceWrapper`.
- Add macOS config tests for default and disabled `clipboard-copy` notification behavior.
- Update config docs so `app-notifications` is no longer documented as GTK-only.

## Validation

- `git diff --check`

I could not run the full macOS test/build command in this local environment because `macos/build.nu` requires `nu`, and `xcodebuild` requires a full Xcode install while this machine only has Command Line Tools selected.