### PR TITLE
Remove unintended reasoning for user 'qappell' in vouched list

### DIFF
--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -230,7 +230,7 @@ poweruser64
 prakhar54-byte
 priyans-hu
 puzza007
-qappell qappell
+qappell
 qwerasd205
 raphamorim
 reo101


### PR DESCRIPTION
It seems that when I ran `!vouch qappell`, the qappell was used as the reasoning for the vouch. That was not my intention.