### PR TITLE
macos: fix SurfaceView notification retain cycle

### DIFF
--- a/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
@@ -292,7 +292,11 @@ extension Ghostty {
             // A drag can emit multiple selection changes. Debounce so screen
             // readers hear one announcement once the selection settles.
             accessibilitySelectionCancellable = NotificationCenter.default
-                .publisher(for: .ghosttySelectionDidChange, object: self)
+                .publisher(for: .ghosttySelectionDidChange, object: nil)
+                .filter { [weak self] notification in
+                    guard let self else { return false }
+                    return (notification.object as AnyObject?) === self
+                }
                 .debounce(for: .milliseconds(100), scheduler: DispatchQueue.main)
                 .sink { [weak self] _ in
                     guard let self else { return }
@@ -386,6 +390,9 @@ extension Ghostty {
             let center = NotificationCenter.default
             center.removeObserver(self)
 
+            accessibilitySelectionCancellable = nil
+            searchNeedleCancellable = nil
+
             // Remove our event monitor
             if let eventMonitor {
                 NSEvent.removeMonitor(eventMonitor)
@@ -406,6 +413,7 @@ extension Ghostty {
 
             // Cancel progress report timer
             progressReportTimer?.invalidate()
+            progressReportTimer = nil
         }
 
         override func endSearch() {


### PR DESCRIPTION
## What

Fix a `SurfaceView` retain cycle caused by storing a Combine notification subscription on `self` while the publisher is also scoped with `object: self`.

The subscription now listens for the notification without a retained object filter and applies an equivalent weak identity filter in the Combine chain.

I also explicitly clear the related cancellables/timer in `deinit`.

## Why

Discussion: https://github.com/ghostty-org/ghostty/discussions/13090

In local A/B testing on macOS, closing a test window with 13 terminal surfaces left all 39 Ghostty-named IOSurfaces alive in the unpatched build. With this patch, the same workload dropped to zero Ghostty-named IOSurfaces after close.

```text
unpatched:
after-create    ghostty_iosurfaces=39
after-close     ghostty_iosurfaces=39

patched:
after-create    ghostty_iosurfaces=39
after-close     ghostty_iosurfaces=0
```

The suspected cycle is:

```text
SurfaceView
  -> accessibilitySelectionCancellable
  -> NotificationCenter publisher/subscription
  -> object self
  -> SurfaceView
```

The sink closure already captured `self` weakly, but the publisher's `object: self` argument appears to retain the object as part of the subscription.

## Test

```sh
mise x zig@0.15.2 -- zig build test
```
