### PR TITLE
gtk: forward middle click to TUIs with mouse reporting

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -3642,6 +3642,12 @@ fn isMouseReporting(self: *const Surface) bool {
         self.io.terminal.flags.mouse_event != .none;
 }
 
+pub fn mouseReportingActive(self: *Surface) bool {
+    self.renderer_state.mutex.lock();
+    defer self.renderer_state.mutex.unlock();
+    return self.isMouseReporting();
+}
+
 fn mouseReport(
     self: *Surface,
     button: ?input.MouseButton,

--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -2815,7 +2815,10 @@ pub const Surface = extern struct {
             return;
         }
 
-        if (button == .middle and !priv.gtk_enable_primary_paste) {
+        if (button == .middle and
+            !priv.gtk_enable_primary_paste and
+            !core_surface.mouseReportingActive())
+        {
             return;
         }
 
@@ -2875,7 +2878,10 @@ pub const Surface = extern struct {
             return;
         }
 
-        if (button == .middle and !priv.gtk_enable_primary_paste) {
+        if (button == .middle and
+            !priv.gtk_enable_primary_paste and
+            !surface.mouseReportingActive())
+        {
             return;
         }
 


### PR DESCRIPTION
Fix for Issue #12940 
I actually do not know if this has already been resolved and the issue is just still open. Either way, here's a fix. Now we run a check to see if the current program is accepting mouse events before discarding the middle click.