### PR TITLE
macOS: reset key state when focus leaves the surface

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -1113,6 +1113,7 @@ GHOSTTY_API void ghostty_surface_refresh(ghostty_surface_t);
 GHOSTTY_API void ghostty_surface_draw(ghostty_surface_t);
 GHOSTTY_API void ghostty_surface_set_content_scale(ghostty_surface_t, double, double);
 GHOSTTY_API void ghostty_surface_set_focus(ghostty_surface_t, bool);
+GHOSTTY_API void ghostty_surface_reset_key_state(ghostty_surface_t);
 GHOSTTY_API void ghostty_surface_set_occlusion(ghostty_surface_t, bool);
 GHOSTTY_API void ghostty_surface_set_size(ghostty_surface_t, uint32_t, uint32_t);
 GHOSTTY_API ghostty_surface_size_s ghostty_surface_size(ghostty_surface_t);

--- a/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
@@ -348,6 +348,16 @@ extension Ghostty {
                 selector: #selector(windowDidChangeScreen),
                 name: NSWindow.didChangeScreenNotification,
                 object: nil)
+            center.addObserver(
+                self,
+                selector: #selector(windowDidResignKey),
+                name: NSWindow.didResignKeyNotification,
+                object: nil)
+            center.addObserver(
+                self,
+                selector: #selector(applicationDidResignActive),
+                name: NSApplication.didResignActiveNotification,
+                object: nil)
 
             // Listen for local events that we need to know of outside of
             // single surface handlers.
@@ -429,6 +439,7 @@ extension Ghostty {
             // sent to stop things like mouse selection.
             if !focused {
                 suppressNextLeftMouseUp = false
+                resetKeyState()
             }
 
             // Notify libghostty
@@ -798,6 +809,16 @@ extension Ghostty {
             DispatchQueue.main.async { [weak self] in
                 self?.viewDidChangeBackingProperties()
             }
+        }
+
+        @objc private func windowDidResignKey(notification: SwiftUI.Notification) {
+            guard let window = self.window else { return }
+            guard let object = notification.object as? NSWindow, window == object else { return }
+            resetKeyState()
+        }
+
+        @objc private func applicationDidResignActive(notification: SwiftUI.Notification) {
+            resetKeyState()
         }
 
         // MARK: - NSView
@@ -1403,15 +1424,7 @@ extension Ghostty {
         }
 
         override func flagsChanged(with event: NSEvent) {
-            let mod: UInt32
-            switch event.keyCode {
-            case 0x39: mod = GHOSTTY_MODS_CAPS.rawValue
-            case 0x38, 0x3C: mod = GHOSTTY_MODS_SHIFT.rawValue
-            case 0x3B, 0x3E: mod = GHOSTTY_MODS_CTRL.rawValue
-            case 0x3A, 0x3D: mod = GHOSTTY_MODS_ALT.rawValue
-            case 0x37, 0x36: mod = GHOSTTY_MODS_SUPER.rawValue
-            default: return
-            }
+            guard let mod = Self.modifierMask(for: event.keyCode) else { return }
 
             // If we're in the middle of a preedit, don't do anything with mods.
             if hasMarkedText() { return }
@@ -1421,32 +1434,18 @@ extension Ghostty {
             let mods = Ghostty.ghosttyMods(event.modifierFlags)
 
             // If the key that pressed this is active, its a press, else release.
-            var action = GHOSTTY_ACTION_RELEASE
-            if mods.rawValue & mod != 0 {
-                // If the key is pressed, its slightly more complicated, because we
-                // want to check if the pressed modifier is the correct side. If the
-                // correct side is pressed then its a press event otherwise its a release
-                // event with the opposite modifier still held.
-                let sidePressed: Bool
-                switch event.keyCode {
-                case 0x3C:
-                    sidePressed = event.modifierFlags.rawValue & UInt(NX_DEVICERSHIFTKEYMASK) != 0
-                case 0x3E:
-                    sidePressed = event.modifierFlags.rawValue & UInt(NX_DEVICERCTLKEYMASK) != 0
-                case 0x3D:
-                    sidePressed = event.modifierFlags.rawValue & UInt(NX_DEVICERALTKEYMASK) != 0
-                case 0x36:
-                    sidePressed = event.modifierFlags.rawValue & UInt(NX_DEVICERCMDKEYMASK) != 0
-                default:
-                    sidePressed = true
-                }
-
-                if sidePressed {
-                    action = GHOSTTY_ACTION_PRESS
-                }
-            }
+            let action = Self.modifierAction(
+                keyCode: event.keyCode,
+                flags: event.modifierFlags,
+                mod: mod,
+                mods: mods)
 
             _ = keyAction(action, event: event)
+        }
+
+        private func resetKeyState() {
+            guard let surface = self.surface else { return }
+            ghostty_surface_reset_key_state(surface)
         }
 
         private func keyAction(
@@ -2104,6 +2103,46 @@ extension Ghostty.SurfaceView: NSTextInputClient {
         }
         return scalar.value < 0x20
     }
+
+    static func modifierMask(for keyCode: UInt16) -> UInt32? {
+        switch keyCode {
+        case 0x39: return GHOSTTY_MODS_CAPS.rawValue
+        case 0x38, 0x3C: return GHOSTTY_MODS_SHIFT.rawValue
+        case 0x3B, 0x3E: return GHOSTTY_MODS_CTRL.rawValue
+        case 0x3A, 0x3D: return GHOSTTY_MODS_ALT.rawValue
+        case 0x37, 0x36: return GHOSTTY_MODS_SUPER.rawValue
+        default: return nil
+        }
+    }
+
+    static func modifierAction(
+        keyCode: UInt16,
+        flags: NSEvent.ModifierFlags,
+        mod: UInt32,
+        mods: ghostty_input_mods_e
+    ) -> ghostty_input_action_e {
+        guard mods.rawValue & mod != 0 else { return GHOSTTY_ACTION_RELEASE }
+
+        // For side-specific modifiers, AppKit keeps the base modifier flag set
+        // while the opposite side remains held. Check the side bit so releasing
+        // right shift with left shift still down reports a release for right shift.
+        let sidePressed: Bool
+        switch keyCode {
+        case 0x3C:
+            sidePressed = flags.rawValue & UInt(NX_DEVICERSHIFTKEYMASK) != 0
+        case 0x3E:
+            sidePressed = flags.rawValue & UInt(NX_DEVICERCTLKEYMASK) != 0
+        case 0x3D:
+            sidePressed = flags.rawValue & UInt(NX_DEVICERALTKEYMASK) != 0
+        case 0x36:
+            sidePressed = flags.rawValue & UInt(NX_DEVICERCMDKEYMASK) != 0
+        default:
+            sidePressed = true
+        }
+
+        return sidePressed ? GHOSTTY_ACTION_PRESS : GHOSTTY_ACTION_RELEASE
+    }
+
 }
 
 // MARK: Services

--- a/macos/Tests/Ghostty/SurfaceViewAppKitTests.swift
+++ b/macos/Tests/Ghostty/SurfaceViewAppKitTests.swift
@@ -1,4 +1,6 @@
 @testable import Ghostty
+import AppKit
+import GhosttyKit
 import Testing
 
 struct SurfaceViewAppKitTests {
@@ -39,6 +41,36 @@ struct SurfaceViewAppKitTests {
                 nil,
                 composing: true
             ) == false
+        )
+    }
+
+    @Test func modifierActionPressesBaseModifier() throws {
+        let mod = try #require(Ghostty.SurfaceView.modifierMask(for: 0x3A))
+        let flags = NSEvent.ModifierFlags.option
+        let mods = Ghostty.ghosttyMods(flags)
+
+        #expect(
+            Ghostty.SurfaceView.modifierAction(
+                keyCode: 0x3A,
+                flags: flags,
+                mod: mod,
+                mods: mods
+            ) == GHOSTTY_ACTION_PRESS
+        )
+    }
+
+    @Test func modifierActionReleasesSideModifierWhenOtherSideRemainsPressed() throws {
+        let mod = try #require(Ghostty.SurfaceView.modifierMask(for: 0x3D))
+        let flags = NSEvent.ModifierFlags.option
+        let mods = Ghostty.ghosttyMods(flags)
+
+        #expect(
+            Ghostty.SurfaceView.modifierAction(
+                keyCode: 0x3D,
+                flags: flags,
+                mod: mod,
+                mods: mods
+            ) == GHOSTTY_ACTION_RELEASE
         )
     }
 }

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1557,6 +1557,27 @@ fn modsChanged(self: *Surface, mods: input.Mods) void {
     }
 }
 
+/// Reset key state tracked for UI affordances without sending any key event
+/// to the PTY. This is used by apprts when the OS may have stolen focus before
+/// delivering matching key releases.
+pub fn resetKeyState(self: *Surface) !void {
+    self.pressed_key = null;
+    self.modsChanged(.{});
+
+    if ((SurfaceMouse{
+        .physical_key = .alt_left,
+        .mouse_event = self.io.terminal.flags.mouse_event,
+        .mouse_shape = self.io.terminal.mouse_shape,
+        .mods = self.mouse.mods,
+        .over_link = self.mouse.over_link,
+        .hidden = self.mouse.hidden,
+    }).keyToMouseShape()) |shape| _ = try self.rt_app.performAction(
+        .{ .surface = self },
+        .mouse_shape,
+        shape,
+    );
+}
+
 /// Call this whenever the mouse moves or mods changed. The time
 /// at which this is called may matter for the correctness of other
 /// mouse events (see cursorPosCallback) but this is shared logic

--- a/src/apprt/embedded.zig
+++ b/src/apprt/embedded.zig
@@ -1751,6 +1751,13 @@ pub const CAPI = struct {
         surface.focusCallback(focused);
     }
 
+    /// Reset key state without sending key releases to the terminal.
+    export fn ghostty_surface_reset_key_state(surface: *Surface) void {
+        surface.core_surface.resetKeyState() catch |err| {
+            log.warn("error resetting key state err={}", .{err});
+        };
+    }
+
     /// Update the occlusion state of a surface.
     export fn ghostty_surface_set_occlusion(surface: *Surface, visible: bool) void {
         surface.occlusionCallback(visible);


### PR DESCRIPTION
## Summary

- Reset macOS surface key/modifier state when the surface loses focus, the window resigns key, or the app resigns active.
- Add an embedded API so the macOS apprt can request a silent key-state reset from the core surface.
- Keep this scoped to the stale modifier/focus-loss bug; this does not change unbound Hyper/key encoding behavior.

## Why

Hyper/global shortcut tools can move focus away after Ghostty sees modifier/key-down state but before AppKit delivers the matching key-up / flagsChanged release. When that happens, Ghostty can keep stale modifier state after focus has already left the surface.

Related GitHub conversations/reports:

- https://github.com/ghostty-org/ghostty/discussions/11397
- https://github.com/ghostty-org/ghostty/discussions/11912
- https://github.com/ghostty-org/ghostty/issues/12265

## Fix

Instead of synthesizing key releases, the macOS surface now asks the core surface to reset key state silently on focus/window/app loss. The core reset clears pressed key state, resets modifier state, and restores the normal mouse shape.

## Follow-up: unbound Hyper combinations

While testing, I observed a separate behavior difference for unhandled Hyper combinations.

In the current debug build, pressing an unbound Hyper+4 can emit terminal keyboard-protocol fragments such as `2;8u3;8u3;8u`. In native Ghostty 1.3.1, the same combo appears to produce macOS Option-translated glyph text instead. For comparison, iTerm2, Apple Terminal, and Codex appear to suppress these unbound Hyper combinations rather than writing terminal-keyboard-protocol fragments into the shell. I am not sure yet why Ghostty allows those fragments through here, so this PR leaves that behavior as a follow-up decision instead of bundling it into the focus-loss fix.

Screenshots:

Debug build Hyper+4 output:

![Debug build Hyper+4 emits CSI-u fragments](https://gist.githubusercontent.com/KingPsychopath/89dfa5ab232d63d8335b7a90c2604f6a/raw/7eaf4f3a6ea6341effeb58b01e03f87fc840a2c6/ghostty-debug-hyper4.png)

Native 1.3.1 Hyper+4 output:

![Native 1.3.1 Hyper+4 produces glyph output](https://gist.githubusercontent.com/KingPsychopath/89dfa5ab232d63d8335b7a90c2604f6a/raw/b9048b0a2c4d0d012bc346d8a605de4ce3bd19ae/ghostty-native-1.3.1-hyper4.png)

This PR does not choose behavior for unhandled Hyper chords. A separate decision is likely needed: suppress those combinations on macOS, preserve macOS Option glyph translation, or continue encoding them as terminal keyboard-protocol input.

## Test plan

- `swiftlint lint --strict`
- `zig build -Demit-macos-app=false`
- `macos/build.nu --scheme Ghostty --configuration Debug --action test`
- Manual: Hyper shortcuts that switch focus no longer leave Ghostty in stale modifier/crosshair state.
