### PR TITLE
config: make `link` settable, add capture-group templates for open

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1604,8 +1604,19 @@ fn mouseRefreshLinks(
         }
 
         const link = (try self.linkAtPos(pos)) orelse break :link .{ null, false };
+
+        // `linkAtPin` may allocate capture groups (owned by `self.alloc`,
+        // not the arena above) when the action is `.open` with a template.
+        // We don't need them for the hover preview, so free immediately.
+        defer link.deinit(self.alloc);
+
         switch (link.action) {
-            .open => {
+            .open => |_| {
+                // Note: the preview always shows the raw matched text, even
+                // if the link's action is configured with a capture-group
+                // template. Building the actual templated value here would
+                // require re-running capture-group extraction, which isn't
+                // currently worth the complexity for a hover preview.
                 const str = try self.io.terminal.screens.active.selectionString(alloc, .{
                     .sel = link.selection,
                     .trim = false,
@@ -2083,6 +2094,47 @@ fn resolvePathForOpening(
     }
 
     return null;
+}
+
+/// Resolves each of `groups` via `resolvePathForOpening`, falling back to
+/// the original (unresolved) string for any group that isn't a relative
+/// path that exists on disk (e.g. a captured line/column number). The
+/// returned slice always has the same length as `groups`; free it with
+/// `freeResolvedGroupPaths`.
+fn resolveGroupPaths(
+    self: *Surface,
+    groups: []const []const u8,
+) Allocator.Error![]const []const u8 {
+    const resolved = try self.alloc.alloc([]const u8, groups.len);
+    var i: usize = 0;
+    errdefer {
+        for (resolved[0..i], groups[0..i]) |r, g| {
+            if (r.ptr != g.ptr) self.alloc.free(r);
+        }
+        self.alloc.free(resolved);
+    }
+
+    while (i < groups.len) : (i += 1) {
+        resolved[i] = try self.resolvePathForOpening(groups[i]) orelse groups[i];
+    }
+
+    return resolved;
+}
+
+/// Frees a slice returned by `resolveGroupPaths`. `original` must be the
+/// same `groups` slice that was passed to `resolveGroupPaths`.
+fn freeResolvedGroupPaths(
+    self: *Surface,
+    original: []const []const u8,
+    resolved: []const []const u8,
+) void {
+    for (resolved, original) |r, g| {
+        // Only free entries that are distinct allocations (i.e. were
+        // actually resolved); entries that fell back to the original
+        // group string are not separately owned.
+        if (r.ptr != g.ptr) self.alloc.free(r);
+    }
+    self.alloc.free(resolved);
 }
 
 /// Returns the x/y coordinate of where the IME (Input Method Editor)
@@ -3996,6 +4048,10 @@ pub fn mouseButtonCallback(
                 )) |result_| {
                     if (result_) |result| {
                         press_selection = result.selection;
+
+                        // Discard any capture groups; we only need the
+                        // selection here, not the templated open action.
+                        result.deinit(self.alloc);
                     }
                 } else |_| {
                     // Ignore any errors, likely regex errors.
@@ -4083,6 +4139,7 @@ pub fn mouseButtonCallback(
                 // If there is a link at this position, we want to
                 // select the link. Otherwise, select the word.
                 if (try self.linkAtPos(pos)) |link| {
+                    link.deinit(self.alloc);
                     try self.setSelectionAndCopy(link.selection);
                 } else {
                     const sel = screen.selectWord(
@@ -4271,6 +4328,19 @@ fn maybePromptClick(self: *Surface) !bool {
 const Link = struct {
     action: input.Link.Action,
     selection: terminal.Selection,
+
+    /// Owned capture group substrings (index 0 is the whole match, index
+    /// N is capture group N). Only populated when `action` is `.open`
+    /// with a non-null template, since that's the only case that needs
+    /// them. Every caller of `linkAtPos`/`linkAtPin` must call `deinit`
+    /// (even if it doesn't use `groups`) to avoid leaking this.
+    groups: ?[]const []const u8 = null,
+
+    fn deinit(self: Link, alloc: Allocator) void {
+        const groups = self.groups orelse return;
+        for (groups) |g| alloc.free(g);
+        alloc.free(groups);
+    }
 };
 
 /// Returns the link at the given cursor position, if any.
@@ -4350,14 +4420,57 @@ fn linkAtPin(
             defer match.deinit();
             const sel = match.selection();
             if (!sel.contains(screen, mouse_pin)) continue;
+
+            // If this is an "open" action with a capture-group template,
+            // extract the capture group substrings now while the match's
+            // backing string is still alive (it's owned by `strmap`, which
+            // we're about to deinit).
+            const groups: ?[]const []const u8 = switch (link.action) {
+                .open => |template| if (template != null)
+                    try captureGroupStrings(self.alloc, &match)
+                else
+                    null,
+                ._open_osc8 => null,
+            };
+
             return .{
                 .action = link.action,
                 .selection = sel,
+                .groups = groups,
             };
         }
     }
 
     return null;
+}
+
+/// Extracts owned copies of all capture group substrings from a regex
+/// match (index 0 is the whole match, index N is capture group N). An
+/// unmatched optional group is returned as an empty string. Caller owns
+/// the returned slice and each string within it.
+fn captureGroupStrings(
+    alloc: Allocator,
+    match: *const terminal.StringMap.Match,
+) Allocator.Error![]const []const u8 {
+    const count = match.region.count();
+    const groups = try alloc.alloc([]const u8, count);
+    errdefer alloc.free(groups);
+
+    var i: usize = 0;
+    errdefer for (groups[0..i]) |g| alloc.free(g);
+
+    const starts = match.region.starts();
+    const ends = match.region.ends();
+    while (i < count) : (i += 1) {
+        const start = starts[i];
+        const end = ends[i];
+        groups[i] = if (start < 0 or end < 0)
+            try alloc.dupe(u8, "")
+        else
+            try alloc.dupe(u8, match.map.string[match.offset + @as(usize, @intCast(start)) .. match.offset + @as(usize, @intCast(end))]);
+    }
+
+    return groups;
 }
 
 /// This returns the mouse mods to consider for link highlighting or
@@ -4386,18 +4499,40 @@ fn mouseModsWithCapture(self: *Surface, mods: input.Mods) input.Mods {
 fn processLinks(self: *Surface, pos: apprt.CursorPos) !bool {
     const link = try self.linkAtPos(pos) orelse return false;
     switch (link.action) {
-        .open => {
-            const str = try self.io.terminal.screens.active.selectionString(self.alloc, .{
-                .sel = link.selection,
-                .trim = false,
-            });
-            defer self.alloc.free(str);
+        .open => |maybe_template| {
+            defer link.deinit(self.alloc);
 
-            const resolved_path = try self.resolvePathForOpening(str);
-            defer if (resolved_path) |p| self.alloc.free(p);
+            if (maybe_template) |template| {
+                // Capture groups are the raw matched text (e.g. a path
+                // exactly as it appeared in terminal output, which is
+                // almost always relative to the terminal's pwd). Resolve
+                // each group that looks like a relative path that exists
+                // on disk to an absolute path before substituting, so
+                // templates like `vscode://file\1:\2:\3` work regardless
+                // of the terminal's current working directory. Groups
+                // that aren't resolvable paths (e.g. line/column numbers)
+                // are left as-is.
+                const groups = link.groups.?;
+                const resolved_groups = try self.resolveGroupPaths(groups);
+                defer self.freeResolvedGroupPaths(groups, resolved_groups);
 
-            const url_to_open = resolved_path orelse str;
-            try self.openUrl(.{ .kind = .unknown, .url = url_to_open });
+                const str = try substituteCaptureGroups(self.alloc, template, resolved_groups);
+                defer self.alloc.free(str);
+
+                try self.openUrl(.{ .kind = .unknown, .url = str });
+            } else {
+                const str = try self.io.terminal.screens.active.selectionString(self.alloc, .{
+                    .sel = link.selection,
+                    .trim = false,
+                });
+                defer self.alloc.free(str);
+
+                const resolved_path = try self.resolvePathForOpening(str);
+                defer if (resolved_path) |p| self.alloc.free(p);
+
+                const url_to_open = resolved_path orelse str;
+                try self.openUrl(.{ .kind = .unknown, .url = url_to_open });
+            }
         },
 
         ._open_osc8 => {
@@ -4410,6 +4545,95 @@ fn processLinks(self: *Surface, pos: apprt.CursorPos) !bool {
     }
 
     return true;
+}
+
+/// Substitutes `\0`-`\9` placeholders in `template` with the corresponding
+/// capture group from `groups` (index 0 is the whole match). A `\` not
+/// followed by a digit, or a digit beyond `groups.len`, is left as literal
+/// text.
+fn substituteCaptureGroups(
+    alloc: Allocator,
+    template: []const u8,
+    groups: []const []const u8,
+) Allocator.Error![]const u8 {
+    var result: std.ArrayList(u8) = .empty;
+    errdefer result.deinit(alloc);
+
+    var i: usize = 0;
+    while (i < template.len) {
+        const c = template[i];
+        if (c == '\\' and
+            i + 1 < template.len and
+            std.ascii.isDigit(template[i + 1]))
+        {
+            const digit = template[i + 1] - '0';
+            if (digit < groups.len) {
+                try result.appendSlice(alloc, groups[digit]);
+            } else {
+                try result.appendSlice(alloc, template[i .. i + 2]);
+            }
+            i += 2;
+            continue;
+        }
+
+        try result.append(alloc, c);
+        i += 1;
+    }
+
+    return try result.toOwnedSlice(alloc);
+}
+
+test "substituteCaptureGroups full substitution" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    const groups = [_][]const u8{
+        "cmd-device-type.go:229:32",
+        "cmd-device-type.go",
+        "229",
+        "32",
+    };
+    const result = try substituteCaptureGroups(
+        alloc,
+        "vscode://file\\1:\\2:\\3",
+        &groups,
+    );
+    defer alloc.free(result);
+    try testing.expectEqualStrings("vscode://filecmd-device-type.go:229:32", result);
+}
+
+test "substituteCaptureGroups unmatched optional group is empty" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    const groups = [_][]const u8{ "file.go:229", "file.go", "229", "" };
+    const result = try substituteCaptureGroups(
+        alloc,
+        "vscode://file\\1:\\2:\\3",
+        &groups,
+    );
+    defer alloc.free(result);
+    try testing.expectEqualStrings("vscode://filefile.go:229:", result);
+}
+
+test "substituteCaptureGroups digit beyond group count is literal" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    const groups = [_][]const u8{"whole"};
+    const result = try substituteCaptureGroups(alloc, "\\0 and \\5", &groups);
+    defer alloc.free(result);
+    try testing.expectEqualStrings("whole and \\5", result);
+}
+
+test "substituteCaptureGroups backslash without digit is literal" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    const groups = [_][]const u8{"whole"};
+    const result = try substituteCaptureGroups(alloc, "\\a\\", &groups);
+    defer alloc.free(result);
+    try testing.expectEqualStrings("\\a\\", result);
 }
 
 fn openUrl(
@@ -5025,6 +5249,8 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
             self.renderer_state.mutex.lock();
             defer self.renderer_state.mutex.unlock();
             if (try self.linkAtPos(pos)) |link_info| {
+                defer link_info.deinit(self.alloc);
+
                 const url_text = switch (link_info.action) {
                     .open => url_text: {
                         // For regex links, get the text from selection

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -22,6 +22,7 @@ const fontpkg = @import("../font/main.zig");
 const inputpkg = @import("../input.zig");
 const internal_os = @import("../os/main.zig");
 const cli = @import("../cli.zig");
+const oni = @import("oniguruma");
 
 const conditional = @import("conditional.zig");
 const Conditional = conditional.Conditional;
@@ -1404,17 +1405,35 @@ input: RepeatableReadableIO = .{},
 scrollbar: Scrollbar = .system,
 
 /// Match a regular expression against the terminal text and associate clicking
-/// it with an action. This can be used to match URLs, file paths, etc. Actions
-/// can be opening using the system opener (e.g. `open` or `xdg-open`) or
-/// executing any arbitrary binding action.
+/// it with an action.
+///
+/// The value takes the format `regex=action`, where `regex` is matched
+/// against terminal text and `action` determines what happens when the
+/// matched text is clicked. The only currently supported action is `open`,
+/// which opens the matched text (or a value built from it, see below) using
+/// the system opener (e.g. `open` on macOS or `xdg-open` on Linux).
+///
+/// By default, `open` opens the full matched text verbatim. You can instead
+/// give it a template with `open:template`, where `template` may contain
+/// `\0`-`\9` placeholders that are substituted with the whole match (`\0`)
+/// and the regex's capture groups (`\1`-`\9`) before opening. This is useful
+/// for jumping to a specific line/column in an editor that registers its own
+/// URL scheme, since Ghostty has no built-in knowledge of any particular
+/// editor. For example, to open `file.go:123:45`-style paths (as commonly
+/// seen in compiler/linter output) in Visual Studio Code at the exact line
+/// and column:
+///
+/// ```
+/// link = ([\w./-]+\.\w+):(\d+)(?::(\d+))?=open:vscode://file\1:\2:\3
+/// ```
 ///
 /// Links that are configured earlier take precedence over links that are
 /// configured later.
 ///
 /// A default link that matches a URL and opens it in the system opener always
-/// exists. This can be disabled using `link-url`.
+/// exists, at lowest priority. This can be disabled using `link-url`.
 ///
-/// TODO: This can't currently be set!
+/// Available since: 1.4.0
 link: RepeatableLink = .{},
 
 /// Enable URL matching. URLs are matched on hover with control (Linux) or
@@ -3879,12 +3898,9 @@ pub fn default(alloc_gpa: Allocator) Allocator.Error!Config {
     // Add our default command palette entries
     try result.@"command-palette-entry".init(alloc);
 
-    // Add our default link for URL detection
-    try result.link.links.append(alloc, .{
-        .regex = url.regex,
-        .action = .{ .open = {} },
-        .highlight = .{ .hover_mods = inputpkg.ctrlOrSuper(.{}) },
-    });
+    // Note: the default URL-matching link is NOT added here. It's appended
+    // in `finalize` (if `link-url` is enabled) so that it always ends up
+    // last, i.e. lowest priority, behind any user-configured `link` entries.
 
     return result;
 }
@@ -4691,9 +4707,17 @@ pub fn finalize(self: *Config) !void {
     if (self.@"window-width" > 0) self.@"window-width" = @max(10, self.@"window-width");
     if (self.@"window-height" > 0) self.@"window-height" = @max(4, self.@"window-height");
 
-    // If URLs are disabled, cut off the first link. The first link is
-    // always the URL matcher.
-    if (!self.@"link-url") self.link.links.items = self.link.links.items[1..];
+    // Append the default URL-matching link, unless disabled. This is
+    // appended (rather than added as part of our defaults) so that it always
+    // ends up last, i.e. lowest priority, behind any user-configured `link`
+    // entries (links configured earlier take precedence).
+    if (self.@"link-url") {
+        try self.link.links.append(alloc, .{
+            .regex = url.regex,
+            .action = .{ .open = null },
+            .highlight = .{ .hover_mods = inputpkg.ctrlOrSuper(.{}) },
+        });
+    }
 
     // We warn when the quit-after-last-window-closed-delay is set to a very
     // short value because it can cause Ghostty to quit before the first
@@ -8579,10 +8603,41 @@ pub const RepeatableLink = struct {
     links: std.ArrayListUnmanaged(inputpkg.Link) = .{},
 
     pub fn parseCLI(self: *Self, alloc: Allocator, input_: ?[]const u8) !void {
-        _ = self;
-        _ = alloc;
-        _ = input_;
-        return error.NotImplemented;
+        const input = input_ orelse return error.ValueRequired;
+        const eql_idx = std.mem.indexOfScalar(u8, input, '=') orelse
+            return error.InvalidValue;
+        const whitespace = " \t";
+        const regex = std.mem.trim(u8, input[0..eql_idx], whitespace);
+        const action_str = std.mem.trim(u8, input[eql_idx + 1 ..], whitespace);
+        if (regex.len == 0) return error.InvalidValue;
+
+        // Validate that the regex actually compiles. We don't keep the
+        // compiled regex around; each usage site compiles its own copy
+        // on demand (see `inputpkg.Link.oniRegex`).
+        {
+            var re = oni.Regex.init(
+                regex,
+                .{},
+                oni.Encoding.utf8,
+                oni.Syntax.default,
+                null,
+            ) catch return error.InvalidValue;
+            re.deinit();
+        }
+
+        const action = inputpkg.Link.Action.parse(action_str) catch
+            return error.InvalidValue;
+
+        try self.links.append(alloc, .{
+            .regex = try alloc.dupe(u8, regex),
+            .action = switch (action) {
+                .open => |template| .{
+                    .open = if (template) |t| try alloc.dupe(u8, t) else null,
+                },
+                ._open_osc8 => unreachable, // Action.parse never returns this
+            },
+            .highlight = .{ .hover_mods = inputpkg.ctrlOrSuper(.{}) },
+        });
     }
 
     /// Deep copy of the struct. Required by Config.
@@ -8617,9 +8672,55 @@ pub const RepeatableLink = struct {
 
     /// Used by Formatter
     pub fn formatEntry(self: Self, formatter: formatterpkg.EntryFormatter) !void {
-        // This currently can't be set so we don't format anything.
-        _ = self;
-        _ = formatter;
+        if (self.links.items.len == 0) {
+            try formatter.formatEntry(void, {});
+            return;
+        }
+
+        var buf: [4096]u8 = undefined;
+        for (self.links.items) |link| {
+            const str = switch (link.action) {
+                .open => |template| if (template) |t|
+                    std.fmt.bufPrint(&buf, "{s}=open:{s}", .{ link.regex, t })
+                else
+                    std.fmt.bufPrint(&buf, "{s}=open", .{link.regex}),
+
+                // "_open_osc8" links are internal-only and are never
+                // present in user-configurable `links`.
+                ._open_osc8 => unreachable,
+            } catch return error.OutOfMemory;
+            try formatter.formatEntry([]const u8, str);
+        }
+    }
+
+    test "RepeatableLink parseCLI" {
+        const testing = std.testing;
+        var arena = ArenaAllocator.init(testing.allocator);
+        defer arena.deinit();
+        const alloc = arena.allocator();
+
+        var list: Self = .{};
+        try list.parseCLI(alloc, "https://example.com=open");
+        try testing.expectEqual(@as(usize, 1), list.links.items.len);
+        try testing.expect(list.links.items[0].action.open == null);
+
+        try list.parseCLI(alloc, "([\\w./-]+):(\\d+)=open:vscode://file\\1:\\2");
+        try testing.expectEqual(@as(usize, 2), list.links.items.len);
+        try testing.expectEqualStrings(
+            "vscode://file\\1:\\2",
+            list.links.items[1].action.open.?,
+        );
+
+        // Missing '='
+        try testing.expectError(error.InvalidValue, list.parseCLI(alloc, "foo"));
+        // Invalid regex
+        try testing.expectError(error.InvalidValue, list.parseCLI(alloc, "(=open"));
+        // Invalid action
+        try testing.expectError(error.InvalidValue, list.parseCLI(alloc, "foo=bogus"));
+        // Empty regex
+        try testing.expectError(error.InvalidValue, list.parseCLI(alloc, "=open"));
+        // Internal-only action can't be user-specified
+        try testing.expectError(error.InvalidValue, list.parseCLI(alloc, "foo=_open_osc8"));
     }
 };
 

--- a/src/input/Link.zig
+++ b/src/input/Link.zig
@@ -22,13 +22,39 @@ action: Action,
 highlight: Highlight,
 
 pub const Action = union(enum) {
-    /// Open the full matched value using the default open program.
-    /// For example, on macOS this is "open" and on Linux this is "xdg-open".
-    open: void,
+    /// Open the matched value using the default open program. For example,
+    /// on macOS this is "open" and on Linux this is "xdg-open".
+    ///
+    /// If null, the full matched value is opened as-is. If set, the value
+    /// is a template containing `\0`-`\9` placeholders that are substituted
+    /// with the whole match (`\0`) and regex capture groups (`\1`-`\9`)
+    /// before opening. This allows building a URL or path from capture
+    /// groups, e.g. to open a specific line/column in an editor that
+    /// registers its own URL scheme: `vscode://file\1:\2:\3`.
+    open: ?[]const u8,
 
     /// Open the OSC8 hyperlink under the mouse position. _-prefixed means
     /// this can't be user-specified, it's only used internally.
     _open_osc8: void,
+
+    pub const Error = error{
+        InvalidFormat,
+    };
+
+    /// Parse an action in the format of "name" or "name:param", where
+    /// "param" is the (optional, depending on the action) parameter.
+    pub fn parse(input: []const u8) Error!Action {
+        const colon_idx = std.mem.indexOfScalar(u8, input, ':');
+        const name = input[0..(colon_idx orelse input.len)];
+
+        if (std.mem.eql(u8, name, "open")) {
+            const param = colon_idx orelse return .{ .open = null };
+            return .{ .open = input[param + 1 ..] };
+        }
+
+        // "_open_osc8" is intentionally not parseable; it is internal-only.
+        return Error.InvalidFormat;
+    }
 };
 
 pub const Highlight = union(enum) {
@@ -66,7 +92,12 @@ pub fn oniRegex(self: *const Link) !oni.Regex {
 pub fn clone(self: *const Link, alloc: Allocator) Allocator.Error!Link {
     return .{
         .regex = try alloc.dupe(u8, self.regex),
-        .action = self.action,
+        .action = switch (self.action) {
+            .open => |template| .{
+                .open = if (template) |t| try alloc.dupe(u8, t) else null,
+            },
+            ._open_osc8 => .{ ._open_osc8 = {} },
+        },
         .highlight = self.highlight,
     };
 }
@@ -76,4 +107,24 @@ pub fn equal(self: *const Link, other: *const Link) bool {
     return std.meta.eql(self.action, other.action) and
         std.meta.eql(self.highlight, other.highlight) and
         std.mem.eql(u8, self.regex, other.regex);
+}
+
+test "Action parse open" {
+    const testing = std.testing;
+    const action = try Action.parse("open");
+    try testing.expect(action == .open);
+    try testing.expect(action.open == null);
+}
+
+test "Action parse open with template" {
+    const testing = std.testing;
+    const action = try Action.parse("open:vscode://file\\1:\\2:\\3");
+    try testing.expect(action == .open);
+    try testing.expectEqualStrings("vscode://file\\1:\\2:\\3", action.open.?);
+}
+
+test "Action parse invalid" {
+    const testing = std.testing;
+    try testing.expectError(Action.Error.InvalidFormat, Action.parse("nope"));
+    try testing.expectError(Action.Error.InvalidFormat, Action.parse("_open_osc8"));
 }

--- a/src/renderer/link.zig
+++ b/src/renderer/link.zig
@@ -158,13 +158,13 @@ test "renderCellMap" {
     var set = try Set.fromConfig(alloc, &.{
         .{
             .regex = "AB",
-            .action = .{ .open = {} },
+            .action = .{ .open = null },
             .highlight = .{ .always = {} },
         },
 
         .{
             .regex = "EF",
-            .action = .{ .open = {} },
+            .action = .{ .open = null },
             .highlight = .{ .always = {} },
         },
     });
@@ -211,13 +211,13 @@ test "renderCellMap hover links" {
     var set = try Set.fromConfig(alloc, &.{
         .{
             .regex = "AB",
-            .action = .{ .open = {} },
+            .action = .{ .open = null },
             .highlight = .{ .hover = {} },
         },
 
         .{
             .regex = "EF",
-            .action = .{ .open = {} },
+            .action = .{ .open = null },
             .highlight = .{ .always = {} },
         },
     });
@@ -289,13 +289,13 @@ test "renderCellMap mods no match" {
     var set = try Set.fromConfig(alloc, &.{
         .{
             .regex = "AB",
-            .action = .{ .open = {} },
+            .action = .{ .open = null },
             .highlight = .{ .always = {} },
         },
 
         .{
             .regex = "EF",
-            .action = .{ .open = {} },
+            .action = .{ .open = null },
             .highlight = .{ .always_mods = .{ .ctrl = true } },
         },
     });


### PR DESCRIPTION
`link` has been unsettable since it was added (parseCLI returned error.NotImplemented), so there was no way to customize path/URL matching beyond the built-in URL regex. This finishes the feature: `link` now parses `regex=action` config lines, and `open` gained an optional template (`open:template`) that substitutes `\0`-`\9` with the match and its capture groups before opening. This lets users wire up editor URL schemes (e.g. `vscode://file\1:\2:\3`) to jump to a specific file/line/column from compiler or linter output, the same way iTerm2's Semantic History works.

For example, cmd/ctrl-clicking output like this from `golangci-lint` previously matched the whole `file:line:col` span as one "path" and tried to open it verbatim, which always failed since no file is actually named `cmd-device-type.go:229:32`:

    internal/app/cmd-device-type.go:229:32: G115: integer overflow conversion int -> int32 (gosec)
    internal/app/job-printers.go:176:23: G115: integer overflow conversion int -> int32 (gosec)

With a `link` entry like:

    link = ([\w./-]+\.\w+):(\d+)(?::(\d+))?=open:vscode://file\1:\2:\3

clicking those paths now opens the file in VS Code at the exact line and column instead.

Also fixes a latent ordering bug: the built-in URL matcher was always inserted first (highest priority), contradicting the `link-url` doc comment's promise that it's "always lowest priority" of configured links. It's now appended in `finalize`, after user-configured entries.