### PR TITLE
lib-vt: expose selection gesture to Zig

### DIFF
--- a/src/lib_vt.zig
+++ b/src/lib_vt.zig
@@ -71,6 +71,7 @@ pub const RenderState = terminal.RenderState;
 pub const Screen = terminal.Screen;
 pub const ScreenSet = terminal.ScreenSet;
 pub const Selection = terminal.Selection;
+pub const SelectionGesture = terminal.SelectionGesture;
 pub const size_report = terminal.size_report;
 pub const SizeReportStyle = terminal.SizeReportStyle;
 pub const StringMap = terminal.StringMap;


### PR DESCRIPTION
Selection gestures are already part of the libghostty-vt C API, but the native Zig module did not re-export the underlying terminal type. Zig consumers that implement mouse selection had to reach into terminal internals instead of using @import("ghostty-vt").

Re-export SelectionGesture from lib_vt alongside the other terminal selection and screen types.

AI Disclosure: I used AI. Yes, for +1