### PR TITLE
Manually vouch `eunos-1128` & denounce `VectorPeak`

### DIFF
--- a/.github/VOUCHED.td
+++ b/.github/VOUCHED.td
@@ -103,7 +103,7 @@ ephemera
 -eric-assetpass Try talking, not botting
 eriksremess
 erral
--eunos-1128 VectorPeak Cosplaying as a maintainer isn't cool.
+eunos-1128
 exlee
 -f1813483-netizen
 faukah
@@ -273,6 +273,7 @@ unphased
 uzaaft
 vancluever
 vaughanandrews
+-vectorpeak Stupid bot cosplaying as a maintainer
 viruslobster
 vlsi
 voidnv


### PR DESCRIPTION
See #13163

The `!denounce` command should ideally not ban the OP when a manual target has been specified...