### PR TITLE
macOS: only read file urls for new-terminal services

### DIFF
--- a/macos/Sources/Features/Services/ServiceProvider.swift
+++ b/macos/Sources/Features/Services/ServiceProvider.swift
@@ -33,7 +33,7 @@ class ServiceProvider: NSObject {
     ) {
         guard let delegate = NSApp.delegate as? AppDelegate else { return }
 
-        guard let pathURLs = pasteboard.readObjects(forClasses: [NSURL.self]) as? [URL] else {
+        guard let pathURLs = pasteboard.readObjects(forClasses: [NSURL.self], options: [.urlReadingFileURLsOnly: true]) as? [URL] else {
             error.pointee = Self.errorNoString
             return
         }


### PR DESCRIPTION
macOS is already guarding this in Services settings, but guarding what we actually need anyway