### PR TITLE
macos/applescript: derive key event text and codepoint

### DIFF
--- a/macos/Sources/Features/AppleScript/ScriptKeyEventCommand.swift
+++ b/macos/Sources/Features/AppleScript/ScriptKeyEventCommand.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Carbon
 
 /// Handler for the `send key` AppleScript command defined in `Ghostty.sdef`.
 ///
@@ -64,11 +65,54 @@ final class ScriptKeyEventCommand: NSScriptCommand {
             mods = []
         }
 
+        // derive text and unshifted codepoint via `UCKeyTranslate`
+        let text: String?
+        let unshiftedCodepoint: UInt32
+        if let keyCode = key.keyCode {
+            let source = TISCopyCurrentKeyboardLayoutInputSource().takeRetainedValue()
+            let layoutData = TISGetInputSourceProperty(source, kTISPropertyUnicodeKeyLayoutData)
+            let layoutPtr = unsafeBitCast(layoutData, to: CFData.self)
+            let keyboardLayout = unsafeBitCast(CFDataGetBytePtr(layoutPtr), to: UnsafePointer<UCKeyboardLayout>.self)
+
+            var deadKeyState: UInt32 = 0
+            var unicodeLength = 0
+            var unicodeBuffer = [UniChar](repeating: 0, count: 4)
+
+            let shiftedModifiers = mods.contains(.shift) ? UInt32(shiftKey >> 8) : 0
+            let kbdType = UInt32(LMGetKbdType())
+
+            // source terminal already resolved any dead keys; bypass dead-key state entirely.
+            let noDeadKeys = OptionBits(kUCKeyTranslateNoDeadKeysBit)
+
+            UCKeyTranslate(
+                keyboardLayout, UInt16(keyCode),
+                UInt16(kUCKeyActionDown), shiftedModifiers,
+                kbdType, noDeadKeys,
+                &deadKeyState, 4, &unicodeLength, &unicodeBuffer)
+            text = unicodeLength > 0 ? String(utf16CodeUnits: unicodeBuffer, count: unicodeLength) : nil
+
+            deadKeyState = 0
+            UCKeyTranslate(
+                keyboardLayout, UInt16(keyCode),
+                UInt16(kUCKeyActionDown), 0,
+                kbdType, noDeadKeys,
+                &deadKeyState, 4, &unicodeLength, &unicodeBuffer)
+            let unshiftedChar = unicodeLength > 0 ? String(utf16CodeUnits: unicodeBuffer, count: unicodeLength) : nil
+
+            unshiftedCodepoint = unshiftedChar?.unicodeScalars.first?.value ?? 0
+        } else {
+            text = nil
+            unshiftedCodepoint = 0
+        }
+
         let keyEvent = Ghostty.Input.KeyEvent(
             key: key,
             action: action,
-            mods: mods
+            text: text,
+            mods: mods,
+            unshiftedCodepoint: unshiftedCodepoint
         )
+
         surface.sendKeyEvent(keyEvent)
 
         return nil

--- a/macos/Sources/Features/AppleScript/ScriptKeyEventCommand.swift
+++ b/macos/Sources/Features/AppleScript/ScriptKeyEventCommand.swift
@@ -66,8 +66,29 @@ final class ScriptKeyEventCommand: NSScriptCommand {
         }
 
         // derive text and unshifted codepoint via `UCKeyTranslate`
+        let (text, unshiftedCodepoint) = ScriptKeyEventTranslator.translate(key: key, mods: mods)
+
+        let keyEvent = Ghostty.Input.KeyEvent(
+            key: key,
+            action: action,
+            text: text,
+            mods: mods,
+            unshiftedCodepoint: unshiftedCodepoint
+        )
+
+        surface.sendKeyEvent(keyEvent)
+
+        return nil
+    }
+}
+
+/// extracted translation logic to map a Ghostty key to its generated text and unshifted codepoint,
+/// primarily so it can be unit-tested without instantiating an `NSScriptCommand`.
+struct ScriptKeyEventTranslator {
+    static func translate(key: Ghostty.Input.Key, mods: Ghostty.Input.Mods) -> (text: String?, unshiftedCodepoint: UInt32) {
         let text: String?
         let unshiftedCodepoint: UInt32
+
         if let keyCode = key.keyCode {
             let source = TISCopyCurrentKeyboardLayoutInputSource().takeRetainedValue()
             let layoutData = TISGetInputSourceProperty(source, kTISPropertyUnicodeKeyLayoutData)
@@ -105,16 +126,6 @@ final class ScriptKeyEventCommand: NSScriptCommand {
             unshiftedCodepoint = 0
         }
 
-        let keyEvent = Ghostty.Input.KeyEvent(
-            key: key,
-            action: action,
-            text: text,
-            mods: mods,
-            unshiftedCodepoint: unshiftedCodepoint
-        )
-
-        surface.sendKeyEvent(keyEvent)
-
-        return nil
+        return (text, unshiftedCodepoint)
     }
 }

--- a/macos/Tests/AppleScript/KeyEventCommandTests.swift
+++ b/macos/Tests/AppleScript/KeyEventCommandTests.swift
@@ -1,0 +1,74 @@
+import Testing
+@testable import Ghostty
+
+fileprivate extension Ghostty.Input.Key {
+    var printableCharacter: String? {
+        switch self {
+        case .a: return "a"
+        case .b: return "b"
+        case .c: return "c"
+        case .d: return "d"
+        case .e: return "e"
+        case .f: return "f"
+        case .g: return "g"
+        case .h: return "h"
+        case .i: return "i"
+        case .j: return "j"
+        case .k: return "k"
+        case .l: return "l"
+        case .m: return "m"
+        case .n: return "n"
+        case .o: return "o"
+        case .p: return "p"
+        case .q: return "q"
+        case .r: return "r"
+        case .s: return "s"
+        case .t: return "t"
+        case .u: return "u"
+        case .v: return "v"
+        case .w: return "w"
+        case .x: return "x"
+        case .y: return "y"
+        case .z: return "z"
+        case .space: return " "
+        default: return nil
+        }
+    }
+}
+
+@Suite
+struct ScriptKeyEventTranslatorTests {
+    typealias Key = Ghostty.Input.Key
+
+    @Test func letterKeyTranslation() {
+        let a = ScriptKeyEventTranslator.translate(key: .a, mods: [])
+        #expect(a.text == "a")
+        #expect(a.unshiftedCodepoint == UInt32(("a" as UnicodeScalar).value))
+
+        let shiftedA = ScriptKeyEventTranslator.translate(key: .a, mods: [.shift])
+        #expect(shiftedA.text == "A")
+        #expect(shiftedA.unshiftedCodepoint == UInt32(("a" as UnicodeScalar).value))
+
+        let j = ScriptKeyEventTranslator.translate(key: .j, mods: [])
+        #expect(j.text == "j")
+        #expect(j.unshiftedCodepoint == UInt32(("j" as UnicodeScalar).value))
+    }
+
+    @Test func spaceKeyTranslation() {
+        let space = ScriptKeyEventTranslator.translate(key: .space, mods: [])
+        #expect(space.text == " ")
+        #expect(space.unshiftedCodepoint == 32)
+    }
+
+    @Test func enterKeyTranslation() {
+        let enter = ScriptKeyEventTranslator.translate(key: .enter, mods: [])
+        #expect(enter.text == "\r")
+        #expect(enter.unshiftedCodepoint == 13) // Carriage Return
+    }
+
+    @Test func tabKeyTranslation() {
+        let tab = ScriptKeyEventTranslator.translate(key: .tab, mods: [])
+        #expect(tab.text == "\t")
+        #expect(tab.unshiftedCodepoint == 9)
+    }
+}


### PR DESCRIPTION
Executing the  `send` key  **AppleScript** command is  _broken_ for printable characters. The generated `KeyEvent` lacks both _text representation_ and `unshiftedCodepoint`. Consequently, **Ghostty** ignores or failed to process letters and spaces sent via **AppleScript**.

Minimal repro (**doesn't** work as expected with `stable` and `tip`):

> [!WARNING]
> This sends `date` to all opened terminals/surfaces

```applescript
tell application "Ghostty"
    set allTerms to terminals

    repeat with t in allTerms
        send key "d" to t -- doesn't work 
        send key "a" to t -- ditto
        send key "t" to t -- ditto
        send key "e" to t -- ditto
        send key "enter" to t
    end repeat

   display dialog ("Broadcasted to " & (count of allTerms) & " terminal(s).")
end tell
```

This, however, **does** work (from [documentation](https://ghostty.org/docs/features/applescript#broadcast-a-command-to-every-terminal)):

```applescript
set cmd to "date"

tell application "Ghostty"
    set allTerms to terminals

    repeat with t in allTerms
        input text cmd to t
        send key "enter" to t
    end repeat

    display dialog ("Broadcasted to " & (count of allTerms) & " terminal(s).")
end tell
```

It has a different effect when one wants to broadcast on _character per character_ (e.g. synchronise 
two or more **Kakoune** or **NeoVim**, etc)

This PR fixes that by using  `UCKeyTranslate`  to retrieve the current keyboard layout, translate the simulated keycodes, and correctly populate these missing fields before sending the key event.

I have tested this locally using the **US International** keyboard layout as well as **US** proper, and it successfully translates the keycodes. I'd appreciate if someone with German or French layout test it.

I have also added some smoke tests to verify the AppleScript key event mapping. These are isolated in a separate commit; if you find them too noisy, I am happy to get rid of them.

An **AppleScript** `send` key command that cannot type standard letters is not particularly useful. Ensuring key events carry their respective text and codepoints is necessary for basic automation to function.

> [!NOTE]
> I am also happy to create a tracking issue if Ghosttty's workflow requires it.

#### Changes

  •  **ScriptKeyEventCommand.swift** : Translated key codes to character text and unshifted codepoints using  UCKeyTranslate .
  •  **KeyEventCommandTests.swift**: Added basic unit tests
  
### AI Disclosure
  
> [!IMPORTANT]
> This PR was prepared using **Antigravity CLI**. The AI helped to discover `UCKeyTranslate` Carbon API.