### PR TITLE
macos: activate quick terminal outside fullscreen spaces

### DIFF
--- a/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
@@ -496,27 +496,39 @@ class QuickTerminalController: BaseTerminalController {
                 // focus of a non-visible window.
                 self.makeWindowKey(window)
 
-                // If our application is not active, then we grab focus. Its important
+                // If our application is not frontmost, then we grab focus. Its important
                 // we do this AFTER our window is animated in and focused because
                 // otherwise macOS will bring forward another window.
-                if !NSApp.isActive {
+                //
+                // We skip activation on fullscreen Spaces so the quick terminal can
+                // remain a fullscreen auxiliary panel over the current application.
+                if Self.shouldActivateApplication(activeSpaceType: CGSSpace.active().type),
+                   !Self.isCurrentProcessFrontmost {
                     NSApp.activate(ignoringOtherApps: true)
+                }
 
-                    // This works around a really funky bug where if the terminal is
-                    // shown on a screen that has no other Ghostty windows, it takes
-                    // a few (variable) event loop ticks until we can actually focus it.
-                    // https://github.com/ghostty-org/ghostty/issues/2409
-                    //
-                    // We wait one event loop tick to try it because under the happy
-                    // path (we have windows on this screen) it takes one event loop
-                    // tick for window.isKeyWindow to return true.
-                    DispatchQueue.main.async {
-                        guard !window.isKeyWindow else { return }
-                        self.makeWindowKey(window, retries: 10)
-                    }
+                // This works around a really funky bug where if the terminal is
+                // shown on a screen that has no other Ghostty windows, it takes
+                // a few (variable) event loop ticks until we can actually focus it.
+                // https://github.com/ghostty-org/ghostty/issues/2409
+                //
+                // We wait one event loop tick to try it because under the happy
+                // path (we have windows on this screen) it takes one event loop
+                // tick for window.isKeyWindow to return true.
+                DispatchQueue.main.async {
+                    guard !window.isKeyWindow else { return }
+                    self.makeWindowKey(window, retries: 10)
                 }
             }
         })
+    }
+
+    static func shouldActivateApplication(activeSpaceType: CGSSpaceType) -> Bool {
+        activeSpaceType != .fullscreen
+    }
+
+    private static var isCurrentProcessFrontmost: Bool {
+        NSWorkspace.shared.frontmostApplication?.processIdentifier == ProcessInfo.processInfo.processIdentifier
     }
 
     /// Attempt to make a window key, supporting retries if necessary. The retries will be attempted

--- a/macos/Sources/Features/QuickTerminal/QuickTerminalScreen.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalScreen.swift
@@ -24,7 +24,15 @@ enum QuickTerminalScreen {
     var screen: NSScreen? {
         switch self {
         case .main:
-            return NSScreen.main
+            let activeSpace = CGSSpace.active()
+            return Self.resolveMainScreen(
+                activeSpaceType: activeSpace.type,
+                activeSpaceScreen: activeSpace.screen,
+                fullscreenSpaceScreen: CGSSpace.currentFullscreenScreen(
+                    frontmostApplicationProcessIdentifier: NSWorkspace.shared.frontmostApplication?.processIdentifier
+                ),
+                mainScreen: NSScreen.main
+            )
 
         case .mouse:
             let mouseLoc = NSEvent.mouseLocation
@@ -33,5 +41,18 @@ enum QuickTerminalScreen {
         case .menuBar:
             return NSScreen.screens.first
         }
+    }
+
+    static func resolveMainScreen<Screen>(
+        activeSpaceType: CGSSpaceType,
+        activeSpaceScreen: Screen?,
+        fullscreenSpaceScreen: Screen?,
+        mainScreen: Screen?
+    ) -> Screen? {
+        if activeSpaceType == .fullscreen {
+            return activeSpaceScreen ?? fullscreenSpaceScreen ?? mainScreen
+        }
+
+        return fullscreenSpaceScreen ?? mainScreen
     }
 }

--- a/macos/Sources/Features/QuickTerminal/QuickTerminalWindow.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalWindow.swift
@@ -26,7 +26,9 @@ class QuickTerminalWindow: NSPanel {
         // window remains resizable.
         self.styleMask.remove(.titled)
 
-        // We don't want to activate the owning app when quick terminal is triggered.
+        // The quick terminal must be able to appear on another application's
+        // fullscreen Space. Activation is handled by QuickTerminalController so
+        // we can still activate Ghostty on non-fullscreen Spaces.
         self.styleMask.insert(.nonactivatingPanel)
     }
 

--- a/macos/Sources/Helpers/Private/CGS.swift
+++ b/macos/Sources/Helpers/Private/CGS.swift
@@ -14,6 +14,9 @@ private func CGSGetActiveSpace(_ cid: CGSConnectionID) -> CGSSpaceID
 @_silgen_name("CGSSpaceGetType")
 private func CGSSpaceGetType(_ cid: CGSConnectionID, _ spaceID: CGSSpaceID) -> CGSSpaceType
 
+@_silgen_name("CGSCopyManagedDisplaySpaces")
+private func CGSCopyManagedDisplaySpaces(_ cid: CGSConnectionID) -> Unmanaged<CFArray>?
+
 @_silgen_name("CGSCopySpacesForWindows")
 func CGSCopySpacesForWindows(
     _ cid: CGSConnectionID,
@@ -77,5 +80,123 @@ enum CGSSpaceType: UInt32 {
 extension CGSSpace {
     var type: CGSSpaceType {
         CGSSpaceGetType(CGSMainConnectionID(), rawValue)
+    }
+
+    var screen: NSScreen? {
+        guard let displayUUID else { return nil }
+        return NSScreen.screens.first { $0.displayUUID == displayUUID }
+    }
+
+    static func currentFullscreenScreen(frontmostApplicationProcessIdentifier: pid_t?) -> NSScreen? {
+        guard let displayUUID = currentFullscreenDisplayUUID(
+            frontmostApplicationProcessIdentifier: frontmostApplicationProcessIdentifier,
+            managedDisplaySpaces: managedDisplaySpaces()
+        ) else { return nil }
+
+        return NSScreen.screens.first { $0.displayUUID == displayUUID }
+    }
+
+    private var displayUUID: UUID? {
+        Self.displayUUID(for: self, managedDisplaySpaces: Self.managedDisplaySpaces())
+    }
+
+    static func displayUUID(for space: CGSSpace, managedDisplaySpaces: [[String: Any]]) -> UUID? {
+        for displaySpaces in managedDisplaySpaces {
+            guard
+                let displayIdentifier = displaySpaces["Display Identifier"] as? String,
+                let currentSpace = displaySpaces["Current Space"] as? [String: Any],
+                let managedSpaceID = spaceID(from: currentSpace["ManagedSpaceID"]),
+                managedSpaceID == space.rawValue
+            else { continue }
+
+            return UUID(uuidString: displayIdentifier)
+        }
+
+        return nil
+    }
+
+    static func currentFullscreenDisplayUUID(
+        frontmostApplicationProcessIdentifier: pid_t?,
+        managedDisplaySpaces: [[String: Any]]
+    ) -> UUID? {
+        var fullscreenDisplayUUIDs: [UUID] = []
+
+        for displaySpaces in managedDisplaySpaces {
+            guard
+                let displayIdentifier = displaySpaces["Display Identifier"] as? String,
+                let displayUUID = UUID(uuidString: displayIdentifier),
+                let currentSpace = displaySpaces["Current Space"] as? [String: Any],
+                spaceType(from: currentSpace["type"]) == .fullscreen
+            else { continue }
+
+            if let frontmostApplicationProcessIdentifier,
+               processIdentifier(from: currentSpace["pid"]) == frontmostApplicationProcessIdentifier {
+                return displayUUID
+            }
+
+            fullscreenDisplayUUIDs.append(displayUUID)
+        }
+
+        guard fullscreenDisplayUUIDs.count == 1 else { return nil }
+        return fullscreenDisplayUUIDs[0]
+    }
+
+    private static func managedDisplaySpaces() -> [[String: Any]] {
+        guard let spaces = CGSCopyManagedDisplaySpaces(CGSMainConnectionID()) else { return [] }
+        return spaces.takeRetainedValue() as? [[String: Any]] ?? []
+    }
+
+    private static func spaceID(from value: Any?) -> CGSSpaceID? {
+        if let value = value as? Int {
+            guard value >= 0 else { return nil }
+            return CGSSpaceID(value)
+        }
+
+        if let value = value as? UInt {
+            return CGSSpaceID(value)
+        }
+
+        if let value = value as? NSNumber {
+            return CGSSpaceID(value.uint64Value)
+        }
+
+        return nil
+    }
+
+    private static func spaceType(from value: Any?) -> CGSSpaceType? {
+        if let value = value as? UInt32 {
+            return CGSSpaceType(rawValue: value)
+        }
+
+        if let value = value as? Int {
+            guard value >= 0 else { return nil }
+            return CGSSpaceType(rawValue: UInt32(value))
+        }
+
+        if let value = value as? UInt {
+            return CGSSpaceType(rawValue: UInt32(value))
+        }
+
+        if let value = value as? NSNumber {
+            return CGSSpaceType(rawValue: value.uint32Value)
+        }
+
+        return nil
+    }
+
+    private static func processIdentifier(from value: Any?) -> pid_t? {
+        if let value = value as? pid_t {
+            return value
+        }
+
+        if let value = value as? Int {
+            return pid_t(value)
+        }
+
+        if let value = value as? NSNumber {
+            return pid_t(value.int32Value)
+        }
+
+        return nil
     }
 }

--- a/macos/Tests/Ghostty/SurfaceViewAppKitTests.swift
+++ b/macos/Tests/Ghostty/SurfaceViewAppKitTests.swift
@@ -1,4 +1,5 @@
 @testable import Ghostty
+import AppKit
 import Testing
 
 struct SurfaceViewAppKitTests {
@@ -39,6 +40,158 @@ struct SurfaceViewAppKitTests {
                 nil,
                 composing: true
             ) == false
+        )
+    }
+}
+
+@MainActor
+struct QuickTerminalWindowTests {
+    @Test func canShowOnFullscreenSpaces() {
+        let window = QuickTerminalWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 100, height: 100),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.close() }
+
+        window.awakeFromNib()
+
+        #expect(window.styleMask.contains(.nonactivatingPanel))
+    }
+
+    @Test func activatesOnlyOutsideFullscreenSpaces() {
+        #expect(QuickTerminalController.shouldActivateApplication(activeSpaceType: .user))
+        #expect(!QuickTerminalController.shouldActivateApplication(activeSpaceType: .fullscreen))
+    }
+
+    @Test func mainScreenUsesFullscreenScreenWhenAvailable() {
+        #expect(
+            QuickTerminalScreen.resolveMainScreen(
+                activeSpaceType: .fullscreen,
+                activeSpaceScreen: "external",
+                fullscreenSpaceScreen: nil,
+                mainScreen: "built-in"
+            ) == "external"
+        )
+        #expect(
+            QuickTerminalScreen.resolveMainScreen(
+                activeSpaceType: .user,
+                activeSpaceScreen: "external",
+                fullscreenSpaceScreen: nil,
+                mainScreen: "built-in"
+            ) == "built-in"
+        )
+        #expect(
+            QuickTerminalScreen.resolveMainScreen(
+                activeSpaceType: .fullscreen,
+                activeSpaceScreen: nil,
+                fullscreenSpaceScreen: nil,
+                mainScreen: "built-in"
+            ) == "built-in"
+        )
+        #expect(
+            QuickTerminalScreen.resolveMainScreen(
+                activeSpaceType: .user,
+                activeSpaceScreen: "built-in",
+                fullscreenSpaceScreen: "external",
+                mainScreen: "built-in"
+            ) == "external"
+        )
+    }
+
+    @Test func mapsManagedDisplaySpacesToActiveSpaceDisplay() {
+        let builtIn = UUID(uuidString: "37D8832A-2D66-02CA-B9F7-8F30A301B230")!
+        let external = UUID(uuidString: "B733196D-2302-4B68-ACBC-BDA73E9E24BE")!
+        let managedDisplaySpaces: [[String: Any]] = [
+            [
+                "Display Identifier": builtIn.uuidString,
+                "Current Space": [
+                    "ManagedSpaceID": 1,
+                    "type": 0,
+                ],
+            ],
+            [
+                "Display Identifier": external.uuidString,
+                "Current Space": [
+                    "ManagedSpaceID": 118,
+                    "type": 4,
+                ],
+            ],
+        ]
+
+        #expect(
+            CGSSpace.displayUUID(
+                for: CGSSpace(rawValue: 118),
+                managedDisplaySpaces: managedDisplaySpaces
+            ) == external
+        )
+    }
+
+    @Test func resolvesCurrentFullscreenDisplay() {
+        let builtIn = UUID(uuidString: "37D8832A-2D66-02CA-B9F7-8F30A301B230")!
+        let external = UUID(uuidString: "B733196D-2302-4B68-ACBC-BDA73E9E24BE")!
+        let managedDisplaySpaces: [[String: Any]] = [
+            [
+                "Display Identifier": builtIn.uuidString,
+                "Current Space": [
+                    "ManagedSpaceID": 1,
+                    "type": 0,
+                ],
+            ],
+            [
+                "Display Identifier": external.uuidString,
+                "Current Space": [
+                    "ManagedSpaceID": 118,
+                    "type": 4,
+                    "pid": 1017,
+                ],
+            ],
+        ]
+
+        #expect(
+            CGSSpace.currentFullscreenDisplayUUID(
+                frontmostApplicationProcessIdentifier: 1017,
+                managedDisplaySpaces: managedDisplaySpaces
+            ) == external
+        )
+        #expect(
+            CGSSpace.currentFullscreenDisplayUUID(
+                frontmostApplicationProcessIdentifier: nil,
+                managedDisplaySpaces: managedDisplaySpaces
+            ) == external
+        )
+
+        let multipleFullscreenDisplaySpaces: [[String: Any]] = [
+            [
+                "Display Identifier": builtIn.uuidString,
+                "Current Space": [
+                    "ManagedSpaceID": 2,
+                    "type": 4,
+                    "pid": 2000,
+                ],
+            ],
+            [
+                "Display Identifier": external.uuidString,
+                "Current Space": [
+                    "ManagedSpaceID": 118,
+                    "type": 4,
+                    "pid": 1017,
+                ],
+            ],
+        ]
+
+        #expect(
+            CGSSpace.currentFullscreenDisplayUUID(
+                frontmostApplicationProcessIdentifier: nil,
+                managedDisplaySpaces: multipleFullscreenDisplaySpaces
+            ) == nil
+        )
+        #expect(
+            CGSSpace.currentFullscreenDisplayUUID(
+                frontmostApplicationProcessIdentifier: 1017,
+                managedDisplaySpaces: multipleFullscreenDisplaySpaces
+            ) == external
         )
     }
 }


### PR DESCRIPTION
## Summary

This keeps the Quick Terminal as a non-activating fullscreen auxiliary panel, preserving the existing behavior that allows it to appear over another app's native fullscreen Space.

When the active Space is not fullscreen, Ghostty now activates after the Quick Terminal is shown. This makes the macOS menu bar and frontmost application correctly switch to Ghostty when using the Quick Terminal on normal Spaces.

The Quick Terminal `.main` screen resolution also accounts for the display that currently owns the fullscreen Space. This avoids repeated toggles on an external fullscreen app moving the Quick Terminal back to the built-in display.

## Testing

- `xcodebuild -project macos/Ghostty.xcodeproj -scheme Ghostty -configuration Debug -destination 'platform=macOS' -only-testing:GhosttyTests/QuickTerminalWindowTests test`
- `xcodebuild -project macos/Ghostty.xcodeproj -scheme Ghostty -configuration Debug SYMROOT="$PWD/macos/build" build`
- Manually verified on macOS with an external display:
  - On non-fullscreen Spaces, opening the Quick Terminal focuses Ghostty and the menu bar switches to Ghostty.
  - Over another app's native fullscreen Space, the Quick Terminal can still appear without forcing the fullscreen app's Space to lose focus.
  - Repeated toggles from an external fullscreen Space keep the Quick Terminal on the external display.