### PR TITLE
macos: preserve maximized frames across dock changes

### DIFF
--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -121,7 +121,15 @@ class BaseTerminalController: NSWindowController,
 
     struct SavedFrame {
         let window: NSRect
-        let screen: NSRect
+        let screen: ScreenBoundsSnapshot
+
+        var stableVisibleFrame: NSRect {
+            screen.stableVisibleFrame()
+        }
+
+        var isManagedMaximized: Bool {
+            window.approximatelyEqual(to: stableVisibleFrame)
+        }
     }
 
     required init?(coder: NSCoder) {
@@ -314,7 +322,7 @@ class BaseTerminalController: NSWindowController,
         // changes (see didChangeScreenParameters notification).
         savedFrame = nil
         guard let window, let screen = window.screen else { return }
-        savedFrame = .init(window: window.frame, screen: screen.visibleFrame)
+        savedFrame = .init(window: window.frame, screen: .init(screen))
     }
 
     func confirmCloseAsync(
@@ -539,7 +547,20 @@ class BaseTerminalController: NSWindowController,
         guard !window.styleMask.contains(.fullScreen) else { return }
 
         guard let screen = window.screen else { return }
-        let visibleFrame = screen.visibleFrame
+        let screenSnapshot = ScreenBoundsSnapshot(screen)
+        if let savedFrame,
+           savedFrame.screen.isDockVisibleFrameChange(comparedTo: screenSnapshot),
+           savedFrame.isManagedMaximized
+        {
+            if !window.frame.approximatelyEqual(to: savedFrame.window) {
+                window.setFrame(savedFrame.window, display: true)
+            }
+
+            self.savedFrame = .init(window: savedFrame.window, screen: screenSnapshot)
+            return
+        }
+
+        let visibleFrame = screen.visibleFrameIgnoringHiddenDock
         var newFrame = window.frame
 
         // Clamp width/height
@@ -554,14 +575,14 @@ class BaseTerminalController: NSWindowController,
         // was also on screen. If a user explicitly wanted their window off screen
         // then we let it stay that way.
         x: if newFrame.origin.x < visibleFrame.origin.x {
-            if let savedFrame, savedFrame.window.origin.x < savedFrame.screen.origin.x {
+            if let savedFrame, savedFrame.window.origin.x < savedFrame.stableVisibleFrame.origin.x {
                 break x
             }
 
             newFrame.origin.x = visibleFrame.origin.x
         }
         y: if newFrame.origin.y < visibleFrame.origin.y {
-            if let savedFrame, savedFrame.window.origin.y < savedFrame.screen.origin.y {
+            if let savedFrame, savedFrame.window.origin.y < savedFrame.stableVisibleFrame.origin.y {
                 break y
             }
 
@@ -569,7 +590,11 @@ class BaseTerminalController: NSWindowController,
         }
 
         // Apply the new window frame
-        window.setFrame(newFrame, display: true)
+        if !window.frame.approximatelyEqual(to: newFrame) {
+            window.setFrame(newFrame, display: true)
+        }
+
+        savedFrame = .init(window: newFrame, screen: screenSnapshot)
     }
 
     @objc private func ghosttyConfigDidChangeBase(_ notification: Notification) {
@@ -1203,7 +1228,7 @@ class BaseTerminalController: NSWindowController,
     /// Check whether window should be closed without showing an alert
     func windowCanBeClosedWithoutConfirmation() -> Bool {
         // We must have a window. Is it even possible not to?
-        guard let window = self.window else { return true }
+        guard self.window != nil else { return true }
 
         // If we have no surfaces, close.
         if surfaceTree.isEmpty { return true }

--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -1698,7 +1698,7 @@ extension TerminalController {
     private var defaultSize: DefaultSize? {
         if derivedConfig.maximize, let screen = window?.screen ?? NSScreen.main {
             // Maximize takes priority, we take up the full screen we're on.
-            return .frame(screen.visibleFrame)
+            return .frame(screen.visibleFrameIgnoringHiddenDock)
         } else if focusedSurface?.initialSize != nil {
             // Initial size as requested by the configuration (e.g. `window-width`)
             // takes next priority.

--- a/macos/Sources/Helpers/Extensions/NSScreen+Extension.swift
+++ b/macos/Sources/Helpers/Extensions/NSScreen+Extension.swift
@@ -1,6 +1,139 @@
 import Cocoa
 
+struct ScreenBoundsSnapshot: Equatable {
+    let displayUUID: UUID?
+    let frame: NSRect
+    let visibleFrame: NSRect
+    let topInset: CGFloat
+
+    init(_ screen: NSScreen) {
+        self.init(
+            displayUUID: screen.displayUUID,
+            frame: screen.frame,
+            visibleFrame: screen.visibleFrame,
+            topInset: max(NSApp.mainMenu?.menuBarHeight ?? 0, screen.safeAreaInsets.top))
+    }
+
+    init(
+        displayUUID: UUID? = nil,
+        frame: NSRect,
+        visibleFrame: NSRect,
+        topInset: CGFloat
+    ) {
+        self.displayUUID = displayUUID
+        self.frame = frame
+        self.visibleFrame = visibleFrame
+        self.topInset = topInset
+    }
+
+    func stableVisibleFrame(
+        dockOrientation: DockOrientation? = Dock.orientation
+    ) -> NSRect {
+        NSScreen.normalizeVisibleFrame(
+            frame: frame,
+            visibleFrame: visibleFrame,
+            topInset: topInset,
+            dockOrientation: dockOrientation,
+            includeDock: true)
+    }
+
+    func isDockVisibleFrameChange(
+        comparedTo previous: Self,
+        dockOrientation: DockOrientation? = Dock.orientation
+    ) -> Bool {
+        guard displayUUID == previous.displayUUID else { return false }
+        guard frame == previous.frame else { return false }
+        guard visibleFrame != previous.visibleFrame else { return false }
+
+        return stableVisibleFrame(dockOrientation: dockOrientation) ==
+            previous.stableVisibleFrame(dockOrientation: dockOrientation)
+    }
+
+    func isTransientVisibleFrameChange(
+        comparedTo previous: Self,
+        dockAutohides: Bool,
+        dockOrientation: DockOrientation? = Dock.orientation
+    ) -> Bool {
+        dockAutohides && isDockVisibleFrameChange(
+            comparedTo: previous,
+            dockOrientation: dockOrientation)
+    }
+}
+
+extension NSRect {
+    func approximatelyEqual(to other: NSRect, tolerance: CGFloat = 1) -> Bool {
+        abs(origin.x - other.origin.x) <= tolerance &&
+            abs(origin.y - other.origin.y) <= tolerance &&
+            abs(size.width - other.size.width) <= tolerance &&
+            abs(size.height - other.size.height) <= tolerance
+    }
+}
+
 extension NSScreen {
+    static var dockAutohides: Bool {
+        if let dockAutohide = UserDefaults.ghostty
+            .persistentDomain(forName: "com.apple.dock")?["autohide"] as? Bool
+        {
+            return dockAutohide
+        }
+
+        return Dock.autoHideEnabled
+    }
+
+    static func normalizeVisibleFrame(
+        frame: NSRect,
+        visibleFrame: NSRect,
+        topInset: CGFloat,
+        dockOrientation: DockOrientation?,
+        includeDock: Bool
+    ) -> NSRect {
+        guard includeDock else { return visibleFrame }
+
+        let leftInset = max(0, visibleFrame.minX - frame.minX)
+        let rightInset = max(0, frame.maxX - visibleFrame.maxX)
+        let bottomInset = max(0, visibleFrame.minY - frame.minY)
+        let topDockInset = max(0, frame.maxY - visibleFrame.maxY - topInset)
+
+        let effectiveOrientation: DockOrientation? = dockOrientation ?? {
+            if bottomInset > 0 { return .bottom }
+            if leftInset > 0 { return .left }
+            if rightInset > 0 { return .right }
+            if topDockInset > 0 { return .top }
+            return nil
+        }()
+
+        var rect = visibleFrame
+        switch effectiveOrientation {
+        case .bottom:
+            guard bottomInset > 0 else { return rect }
+            rect.origin.y = frame.minY
+            rect.size.height += bottomInset
+        case .left:
+            guard leftInset > 0 else { return rect }
+            rect.origin.x = frame.minX
+            rect.size.width += leftInset
+        case .right:
+            guard rightInset > 0 else { return rect }
+            rect.size.width += rightInset
+        case .top:
+            guard topDockInset > 0 else { return rect }
+            rect.size.height += topDockInset
+        case nil:
+            break
+        }
+
+        return rect
+    }
+
+    var visibleFrameIgnoringHiddenDock: NSRect {
+        Self.normalizeVisibleFrame(
+            frame: frame,
+            visibleFrame: visibleFrame,
+            topInset: max(NSApp.mainMenu?.menuBarHeight ?? 0, safeAreaInsets.top),
+            dockOrientation: Dock.orientation,
+            includeDock: Self.dockAutohides)
+    }
+
     /// The unique CoreGraphics display ID for this screen.
     var displayID: UInt32? {
         deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? UInt32
@@ -18,9 +151,7 @@ extension NSScreen {
     // AND present on this screen.
     var hasDock: Bool {
         // If the dock autohides then we don't have a dock ever.
-        if let dockAutohide = UserDefaults.ghostty.persistentDomain(forName: "com.apple.dock")?["autohide"] as? Bool {
-            if dockAutohide { return false }
-        }
+        if Self.dockAutohides { return false }
 
         // There is no public API to directly ask about dock visibility, so we have to figure it out
         // by comparing the sizes of visibleFrame (the currently usable area of the screen) and

--- a/macos/Sources/Helpers/Extensions/NSWindow+Extension.swift
+++ b/macos/Sources/Helpers/Extensions/NSWindow+Extension.swift
@@ -14,7 +14,7 @@ extension NSWindow {
     /// This constrains both the size (to not exceed the screen) and the origin (to keep the window on screen).
     func constrainToScreen() {
         guard let screen = screen ?? NSScreen.main else { return }
-        let visibleFrame = screen.visibleFrame
+        let visibleFrame = screen.visibleFrameIgnoringHiddenDock
         var windowFrame = frame
 
         windowFrame.size.width = min(windowFrame.size.width, visibleFrame.size.width)

--- a/macos/Sources/Helpers/LastWindowPosition.swift
+++ b/macos/Sources/Helpers/LastWindowPosition.swift
@@ -38,7 +38,7 @@ class LastWindowPosition {
         let lastPosition = CGPoint(x: values[0], y: values[1])
 
         guard let screen = window.screen ?? NSScreen.main else { return false }
-        let visibleFrame = screen.visibleFrame
+        let visibleFrame = screen.visibleFrameIgnoringHiddenDock
 
         var newFrame = window.frame
         if restoreOrigin {

--- a/macos/Tests/NSScreenTests.swift
+++ b/macos/Tests/NSScreenTests.swift
@@ -78,13 +78,80 @@ struct NSScreenExtensionTests {
         #expect(origin.x == 500)
         #expect(origin.y == 580)
     }
+
+    @Test func testNormalizeVisibleFrameRestoresBottomDockTriggerArea() async throws {
+        let frame = NSRect(x: 0, y: 0, width: 1728, height: 1117)
+        let visibleFrame = NSRect(x: 0, y: 4, width: 1728, height: 1080)
+
+        let normalized = NSScreen.normalizeVisibleFrame(
+            frame: frame,
+            visibleFrame: visibleFrame,
+            topInset: 33,
+            dockOrientation: .bottom,
+            includeDock: true)
+
+        #expect(normalized == NSRect(x: 0, y: 0, width: 1728, height: 1084))
+    }
+
+    @Test func testNormalizeVisibleFrameRestoresVisibleBottomDockWhenAutohideIsOn() async throws {
+        let frame = NSRect(x: 0, y: 0, width: 1728, height: 1117)
+        let visibleFrame = NSRect(x: 0, y: 79, width: 1728, height: 1005)
+
+        let normalized = NSScreen.normalizeVisibleFrame(
+            frame: frame,
+            visibleFrame: visibleFrame,
+            topInset: 33,
+            dockOrientation: .bottom,
+            includeDock: true)
+
+        #expect(normalized == NSRect(x: 0, y: 0, width: 1728, height: 1084))
+    }
+
+    @Test func testNormalizeVisibleFrameKeepsVisibleDockWhenNotIncludingDock() async throws {
+        let frame = NSRect(x: 0, y: 0, width: 1728, height: 1117)
+        let visibleFrame = NSRect(x: 0, y: 79, width: 1728, height: 1005)
+
+        let normalized = NSScreen.normalizeVisibleFrame(
+            frame: frame,
+            visibleFrame: visibleFrame,
+            topInset: 33,
+            dockOrientation: .bottom,
+            includeDock: false)
+
+        #expect(normalized == visibleFrame)
+    }
+
+    @Test func testDockVisibleFrameChangeDetectionIgnoresAutohideToggle() async throws {
+        let previous = ScreenBoundsSnapshot(
+            displayUUID: UUID(),
+            frame: NSRect(x: 0, y: 0, width: 1728, height: 1117),
+            visibleFrame: NSRect(x: 0, y: 0, width: 1728, height: 1084),
+            topInset: 33)
+        let current = ScreenBoundsSnapshot(
+            displayUUID: previous.displayUUID,
+            frame: previous.frame,
+            visibleFrame: NSRect(x: 0, y: 79, width: 1728, height: 1005),
+            topInset: 33)
+
+        #expect(current.isDockVisibleFrameChange(comparedTo: previous, dockOrientation: .bottom))
+        #expect(!current.isTransientVisibleFrameChange(
+            comparedTo: previous,
+            dockAutohides: false,
+            dockOrientation: .bottom))
+        #expect(current.isTransientVisibleFrameChange(
+            comparedTo: previous,
+            dockAutohides: true,
+            dockOrientation: .bottom))
+    }
 }
 
 /// Mock NSScreen class for testing coordinate conversion
 private class MockNSScreen: NSScreen {
+    private let mockFrame: NSRect
     private let mockVisibleFrame: NSRect
 
-    init(visibleFrame: NSRect) {
+    init(frame: NSRect? = nil, visibleFrame: NSRect) {
+        self.mockFrame = frame ?? visibleFrame
         self.mockVisibleFrame = visibleFrame
         super.init()
     }
@@ -95,5 +162,9 @@ private class MockNSScreen: NSScreen {
 
     override var visibleFrame: NSRect {
         return mockVisibleFrame
+    }
+
+    override var frame: NSRect {
+        return mockFrame
     }
 }


### PR DESCRIPTION
#9135

Ghostty currently treats Dock autohide transitions as ordinary\nscreen geometry changes. When a maximized window receives\ndidChangeScreenParameters while the Dock appears, it can persist the\nshrunk visible frame and stay shorter after the Dock hides again.\n\nTrack a screen snapshot alongside the saved window frame and\nnormalize visibleFrame when the Dock is auto-hidden. If a screen\nchange only reflects the Dock appearing or disappearing and the\nsaved frame matches a managed maximized frame, keep the existing\nframe instead of persisting the transient size. Use the normalized\nvisible frame for maximize, constrain-to-screen, and last-window\nposition restoration, and cover the Dock cases in NSScreen tests.