### PR TITLE
macOS: use the`getOpinionatedStringContents` same as paste for dragging

### DIFF
--- a/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
@@ -2220,7 +2220,6 @@ extension Ghostty.SurfaceView {
     static let dropTypes: Set<NSPasteboard.PasteboardType> = [
         .string,
         .fileURL,
-        .URL
     ]
 
     override func draggingEntered(_ sender: any NSDraggingInfo) -> NSDragOperation {
@@ -2240,24 +2239,7 @@ extension Ghostty.SurfaceView {
     override func performDragOperation(_ sender: any NSDraggingInfo) -> Bool {
         let pb = sender.draggingPasteboard
 
-        let content: String?
-        if let url = pb.string(forType: .URL) {
-            // URLs first, they get escaped as-is.
-            content = Ghostty.Shell.escape(url)
-        } else if let urls = pb.readObjects(forClasses: [NSURL.self]) as? [URL],
-           urls.count > 0 {
-            // File URLs next. They get escaped individually and then joined by a
-            // space if there are multiple.
-            content = urls
-                .map { Ghostty.Shell.escape($0.path) }
-                .joined(separator: " ")
-        } else if let str = pb.string(forType: .string) {
-            // Strings are not escaped because they may be copy/pasting a
-            // command they want to execute.
-            content = str
-        } else {
-            content = nil
-        }
+        let content = pb.getOpinionatedStringContents()
 
         if let content {
             DispatchQueue.main.async {


### PR DESCRIPTION
The only difference of getting the string contents between dragging pasteboard and general pasteboard is the URL now. It was first introduced in #4962, I don't why it was added, since `public.url` often comes with `public.utf8-plain-text` when dragging.

I also check with iTerm's [PTYTextView](https://github.com/gnachman/iTerm2/blob/f267f243e59855e2b1b44df3343d07174de7857b/sources/TerminalView/PTYTextView.m#L307), it doesn't register URL either, so I think it's safe for us to remove it.

> I checked the iTerm's source after my changes, I hope that doesn't violates any licensing