### PR TITLE
Revert "termio: bound POSIX read-ahead on non-Darwin"

### DIFF
--- a/src/termio/Exec.zig
+++ b/src/termio/Exec.zig
@@ -1281,21 +1281,15 @@ pub const ReadThread = struct {
     /// stages. The gather stage can run at most this many batches
     /// ahead of the parse stage before it blocks, which (via the
     /// kernel pty queue) is also what preserves flow control to the
-    /// child.
-    ///
-    /// The Darwin value was empirically chosen through measurements on
-    /// an M4 Max. Less than 4 there are minor slowdowns, above 4 there
-    /// are no improvements.
-    ///
-    /// Other POSIX platforms keep fewer batches in flight so terminal
-    /// parsing applies backpressure to bulk writers before frame-style
-    /// output can queue stale frames.
-    const buffer_count = if (builtin.os.tag.isDarwin()) 4 else 2;
+    /// child. Empirically chosen through measurements on an M4 Max.
+    /// Less than 4 there are minor slowdowns, above 4 there are no
+    /// improvements.
+    const buffer_count = 4;
 
     /// The capacity of each gather buffer. One batch is also the unit
     /// of work the parse stage does per terminal lock acquisition, so
     /// this bounds both gather latency and lock hold time.
-    const buffer_capacity = if (builtin.os.tag.isDarwin()) 64 * 1024 else 8 * 1024;
+    const buffer_capacity = 64 * 1024;
 
     /// How many gathered bytes mark a stream as saturated. The macOS
     /// kernel tty output queue hands the master at most about 1 KiB


### PR DESCRIPTION
This reverts commit bed47168ca7f34fe0a27e9f13c46b8df97cb77ca.

This commit reduced the buffer size and count on non-Darwin. This introduced a ~20% perf loss on linux for high throughput loads on a questionable claim. Producers of bytes should not be pacing frames based on how fast they can write to the terminal.