### PR TITLE
termio: hand off state capture to renderer under hot output

### DIFF
--- a/src/renderer/State.zig
+++ b/src/renderer/State.zig
@@ -30,6 +30,15 @@ preedit: ?Preedit = null,
 /// need about the mouse.
 mouse: Mouse = .{},
 
+/// True while a renderer wakeup has been queued but not yet consumed.
+/// This lets IO avoid issuing redundant wakeups in repaint-heavy workloads.
+render_pending: std.atomic.Value(bool) = .init(false),
+
+/// Non-zero while the renderer is waiting for, or currently holding, `mutex`
+/// to capture terminal state. Parsers check this between chunks so a hot
+/// producer doesn't repeatedly relock and starve the renderer.
+renderer_waiting_for_state: std.atomic.Value(u32) = .init(0),
+
 pub const Mouse = struct {
     /// The point on the viewport where the mouse currently is. We use
     /// viewport points to avoid the complexity of mapping the mouse to

--- a/src/renderer/Thread.zig
+++ b/src/renderer/Thread.zig
@@ -614,6 +614,7 @@ fn renderCallback(
 
     // If we're not visible there's no point spending CPU rebuilding cells —
     // we'll catch up when the .visible mailbox message flips us back on.
+    t.state.render_pending.store(false, .release);
     if (!t.flags.visible) return .disarm;
 
     // Update our frame data

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -1170,6 +1170,12 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 //     std.log.err("[updateFrame critical time] start={}\tduration={} us", .{ start_micro, end.since(start) / std.time.ns_per_us });
                 // }
 
+                state.renderer_waiting_for_state.store(1, .release);
+                defer {
+                    state.renderer_waiting_for_state.store(0, .release);
+                    std.Thread.Futex.wake(&state.renderer_waiting_for_state, std.math.maxInt(u32));
+                }
+
                 state.mutex.lock();
                 defer state.mutex.unlock();
 

--- a/src/terminal/ref_counted_set.zig
+++ b/src/terminal/ref_counted_set.zig
@@ -280,7 +280,18 @@ pub fn RefCountedSet(
                 // rehash with only a few IDs left.
                 const rehash_threshold = 0.9;
                 if (self.living < @as(Id, @intFromFloat(@as(f64, @floatFromInt(self.layout.cap)) * rehash_threshold))) {
-                    return AddError.NeedsRehash;
+                    const reuse_id = for (items[1..self.layout.cap], 1..) |item, id| {
+                        if (item.meta.ref == 0) break @as(Id, @intCast(id));
+                    } else return AddError.NeedsRehash;
+
+                    self.deleteItem(base, reuse_id, ctx);
+
+                    const id = self.insert(base, value, reuse_id, ctx);
+                    items[id].meta.ref += 1;
+                    assert(items[id].meta.ref == 1);
+                    self.living += 1;
+
+                    return id;
                 }
 
                 // If we don't have at least 10% dead items then
@@ -720,4 +731,40 @@ pub fn RefCountedSet(
             }
         }
     };
+}
+
+test "RefCountedSet reuses dead IDs when exhausted" {
+    const testing = std.testing;
+
+    const Context = struct {
+        pub fn hash(_: @This(), value: u16) u64 {
+            return value;
+        }
+
+        pub fn eql(_: @This(), a: u16, b: u16) bool {
+            return a == b;
+        }
+    };
+
+    const Set = RefCountedSet(u16, u8, u8, Context);
+    const layout: Set.Layout = .init(8);
+    const buf = try testing.allocator.alignedAlloc(u8, Set.base_align, layout.total_size);
+    defer testing.allocator.free(buf);
+
+    var set = Set.init(.init(buf), layout, .{});
+
+    var ids: [8]Set.Id = undefined;
+    var value: u16 = 1;
+    while (value < layout.cap) : (value += 1) {
+        ids[value] = try set.add(buf, value);
+    }
+
+    try testing.expectEqual(layout.cap, set.next_id);
+
+    const released_id = ids[2];
+    set.release(buf, released_id);
+
+    const reused_id = try set.add(buf, value);
+    try testing.expectEqual(released_id, reused_id);
+    try testing.expectEqual(layout.cap, set.next_id);
 }

--- a/src/termio/Termio.zig
+++ b/src/termio/Termio.zig
@@ -26,6 +26,11 @@ const log = std.log.scoped(.io_exec);
 /// Mutex state argument for queueMessage.
 pub const MutexState = enum { locked, unlocked };
 
+/// Maximum bytes of alternate-screen output to process while holding the
+/// renderer state lock. Alternate-screen programs often repaint forever, so
+/// large pty batches can otherwise keep the renderer from observing progress.
+const alternate_screen_output_chunk_size = 2 * 1024;
+
 /// Allocator
 alloc: Allocator,
 
@@ -641,18 +646,42 @@ pub fn focusGained(self: *Termio, td: *ThreadData, focused: bool) !void {
 /// call with pty data but it is also called by the read thread when using
 /// an exec subprocess.
 pub fn processOutput(self: *Termio, buf: []const u8) void {
-    // We are modifying terminal state from here on out and we need
-    // the lock to grab our read data.
-    self.renderer_state.mutex.lock();
-    defer self.renderer_state.mutex.unlock();
-    self.processOutputLocked(buf);
+    var offset: usize = 0;
+    while (offset < buf.len) {
+        const chunk_len: usize = chunk: {
+            self.waitForRendererStateCapture();
+
+            // We are modifying terminal state from here on out and we need
+            // the lock to grab our read data.
+            self.renderer_state.mutex.lock();
+            defer self.renderer_state.mutex.unlock();
+
+            const chunk_len = if (self.terminal.screens.active_key == .alternate)
+                @min(alternate_screen_output_chunk_size, buf.len - offset)
+            else
+                buf.len - offset;
+
+            self.processOutputLocked(buf[offset .. offset + chunk_len]);
+            break :chunk chunk_len;
+        };
+
+        self.terminal_stream.handler.queueRender() catch unreachable;
+
+        offset += chunk_len;
+        if (offset < buf.len) std.Thread.yield() catch {};
+    }
+}
+
+fn waitForRendererStateCapture(self: *Termio) void {
+    while (true) {
+        const value = self.renderer_state.renderer_waiting_for_state.load(.acquire);
+        if (value == 0) return;
+        std.Thread.Futex.wait(&self.renderer_state.renderer_waiting_for_state, value);
+    }
 }
 
 /// Process output from readdata but the lock is already held.
 fn processOutputLocked(self: *Termio, buf: []const u8) void {
-    // Schedule a render. We can call this first because we have the lock.
-    self.terminal_stream.handler.queueRender() catch unreachable;
-
     // Whenever a character is typed, we ensure the cursor is in the
     // non-blink state so it is rendered if visible. If we're under
     // HEAVY read load, we don't want to send a ton of these so we

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -102,7 +102,10 @@ pub const StreamHandler = struct {
     /// isn't guaranteed to happen immediately but it will happen as soon as
     /// practical.
     pub inline fn queueRender(self: *StreamHandler) !void {
-        try self.renderer_wakeup.notify();
+        if (!self.renderer_state.render_pending.swap(true, .acq_rel)) {
+            errdefer self.renderer_state.render_pending.store(false, .release);
+            try self.renderer_wakeup.notify();
+        }
     }
 
     /// Change the configuration for this handler.


### PR DESCRIPTION
When alternate-screen output saturates the terminal, the parser can repeatedly reacquire the terminal-state mutex before the renderer can snapshot state, causing frame bursts and stutters. Add a renderer-wait handoff so the parser waits briefly while the renderer is capturing, then proceed in small chunks to reduce lock contention.

Use an atomic render-pending flag to avoid redundant renderer wakeups, and update the style table growth path to reuse dead style IDs before triggering rehash when near capacity.

Everything here up for discussion, no merge expected. 

Assisted by Codex 5.5