### PR TITLE
i18n: Fix untranslated Close Split string in zh_CN.po

### DIFF
--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -171,7 +171,7 @@ msgstr "向右分屏"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:321
 msgid "Close Split"
-msgstr ""
+msgstr "关闭分屏"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:327
 msgid "Tab"


### PR DESCRIPTION
## Summary

Fix one untranslated string in the Simplified Chinese localization (`zh_CN.po`).

## Changes

- `msgid "Close Split"`: `""` → `"关闭分屏"`

This achieves terminology consistency:
- Split → 分屏 (already established)
- Close Split? → 关闭分屏吗？ (already existed)
- Close Split → 关闭分屏 (this fix)

## Stats

Translation completion: 98.6% → **100%** (69/69 strings)