### PR TITLE
macos: create new terminal window when none exist on toggle visibility

### DIFF
--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -992,6 +992,12 @@ class AppDelegate: NSObject,
             return
         }
 
+        let hasTerminalWindow = NSApp.windows.contains { $0.windowController is TerminalController }
+        if !hasTerminalWindow {
+            _ = TerminalController.newWindow(ghostty)
+            return
+        }
+
         // If we're not active, we want to become active
         NSApp.activate(ignoringOtherApps: true)
 


### PR DESCRIPTION
Previously, toggleVisibility only checked whether the app was active. If Ghostty had no terminal windows, it would proceed to activate the app and attempt to restore a hidden state that didn't exist, leaving no visible window.

Now, when the app is not active and there are no terminal windows, toggleVisibility creates a new terminal window via TerminalController.newWindow so the user gets a usable Ghostty window.