### PR TITLE
add nushell complete attribute

### DIFF
--- a/src/shell-integration/nushell/vendor/autoload/ghostty.nu
+++ b/src/shell-integration/nushell/vendor/autoload/ghostty.nu
@@ -6,6 +6,8 @@ export module ghostty {
 
   # Wrap `ssh` with `ghostty +ssh` and translate the shell-integration
   # feature flags into command options.
+  # Add attribute so nushell completion can function correctly
+  @complete external
   export def --wrapped ssh [...args] {
     if not ((has_feature "ssh-env") or (has_feature "ssh-terminfo")) {
       ^ssh ...$args
@@ -24,6 +26,8 @@ export module ghostty {
   }
 
   # Wrap `sudo` to preserve Ghostty's TERMINFO environment variable
+  # Add attribute so nushell completion can function correctly
+  @complete external
   export def --wrapped sudo [...args] {
     mut sudo_args = $args
 

--- a/src/shell-integration/nushell/vendor/autoload/ghostty.nu
+++ b/src/shell-integration/nushell/vendor/autoload/ghostty.nu
@@ -6,7 +6,6 @@ export module ghostty {
 
   # Wrap `ssh` with `ghostty +ssh` and translate the shell-integration
   # feature flags into command options.
-  # Add attribute so nushell completion can function correctly
   @complete external
   export def --wrapped ssh [...args] {
     if not ((has_feature "ssh-env") or (has_feature "ssh-terminfo")) {
@@ -26,7 +25,6 @@ export module ghostty {
   }
 
   # Wrap `sudo` to preserve Ghostty's TERMINFO environment variable
-  # Add attribute so nushell completion can function correctly
   @complete external
   export def --wrapped sudo [...args] {
     mut sudo_args = $args


### PR DESCRIPTION
Added correct attribute so nushell can generate completions for ghostty redefined commands (i.e., `ssh` and `sudo`).

Fixes #12008 