### PR TITLE
terminal: report modifyOtherKeys state via XTQMODKEYS

### DIFF
--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -3628,6 +3628,17 @@ pub fn printAttributes(self: *Terminal, buf: []u8) ![]const u8 {
     return writer.buffered();
 }
 
+/// Writes the XTMODKEYS report for modifyOtherKeys into buf and returns the
+/// written slice. This is the payload for XTQMODKEYS (both the `CSI ? 4 m`
+/// and `DCS $ q > 4 m ST` query forms) and is formatted as an XTMODKEYS
+/// control: `> 4 ; Pv m`. Ghostty's default encoder already emits the
+/// numeric form for ambiguous keys (mode 1), so the floor is 1; mode 2
+/// reports 2.
+pub fn modifyOtherKeysReport(self: *Terminal, buf: []u8) ![]const u8 {
+    const pv: u8 = if (self.flags.modify_other_keys_2) 2 else 1;
+    return try std.fmt.bufPrint(buf, ">4;{d}m", .{pv});
+}
+
 /// The modes for DECCOLM.
 pub const DeccolmMode = enum(u1) {
     @"80_cols" = 0,
@@ -13771,6 +13782,27 @@ test "Terminal: printAttributes" {
         const buf = try t.printAttributes(&storage);
         try testing.expectEqualStrings("0", buf);
     }
+}
+
+test "Terminal: modifyOtherKeysReport" {
+    const alloc = testing.allocator;
+    const io_impl = testing.io;
+    var t = try init(io_impl, alloc, .{ .rows = 5, .cols = 5 });
+    defer t.deinit(alloc);
+
+    var storage: [16]u8 = undefined;
+
+    // Default (mode 1): Ghostty always encodes ambiguous keys in the
+    // numeric form, so the floor is 1.
+    try testing.expectEqualStrings(">4;1m", try t.modifyOtherKeysReport(&storage));
+
+    // Mode 2.
+    t.flags.modify_other_keys_2 = true;
+    try testing.expectEqualStrings(">4;2m", try t.modifyOtherKeysReport(&storage));
+
+    // Back to mode 1.
+    t.flags.modify_other_keys_2 = false;
+    try testing.expectEqualStrings(">4;1m", try t.modifyOtherKeysReport(&storage));
 }
 
 test "Terminal: eraseDisplay simple erase below" {

--- a/src/terminal/dcs.zig
+++ b/src/terminal/dcs.zig
@@ -178,23 +178,33 @@ pub const Handler = struct {
                 break :xtgettcap .{ .xtgettcap = .{ .data = list.* } };
             },
 
-            .decrqss => |buffer| .{ .decrqss = switch (buffer.len) {
-                0 => .none,
-                1 => switch (buffer.data[0]) {
-                    'm' => .sgr,
-                    'r' => .decstbm,
-                    's' => .decslrm,
-                    else => .none,
-                },
-                2 => switch (buffer.data[0]) {
-                    ' ' => switch (buffer.data[1]) {
-                        'q' => .decscusr,
+            .decrqss => |buffer| .{
+                .decrqss = switch (buffer.len) {
+                    0 => .none,
+                    1 => switch (buffer.data[0]) {
+                        'm' => .sgr,
+                        'r' => .decstbm,
+                        's' => .decslrm,
                         else => .none,
                     },
-                    else => .none,
+                    2 => switch (buffer.data[0]) {
+                        ' ' => switch (buffer.data[1]) {
+                            'q' => .decscusr,
+                            else => .none,
+                        },
+                        else => .none,
+                    },
+                    // XTQMODKEYS: `> Pp m`. We only report modifyOtherKeys
+                    // (resource 4).
+                    3 => if (buffer.data[0] == '>' and buffer.data[2] == 'm')
+                        switch (buffer.data[1]) {
+                            '4' => .modify_other_keys,
+                            else => .none,
+                        }
+                    else
+                        .none,
                 },
-                else => unreachable,
-            } },
+            },
         };
     }
 
@@ -254,6 +264,7 @@ pub const Command = union(enum) {
         decscusr,
         decstbm,
         decslrm,
+        modify_other_keys,
 
         /// Fixed upper bound for an encoded DECRPSS response. The comptime
         /// calculated max at the time of writing this was around 63 so this
@@ -300,6 +311,12 @@ pub const Command = union(enum) {
                         t.scrolling_region.right + 1,
                     });
                 },
+                .modify_other_keys => {
+                    const report = try t.modifyOtherKeysReport(
+                        writer.buffer[writer.end..],
+                    );
+                    writer.end += report.len;
+                },
             }
 
             const valid = writer.end > prefix_len;
@@ -327,7 +344,7 @@ const State = union(enum) {
 
     /// DECRQSS
     decrqss: struct {
-        data: [2]u8 = undefined,
+        data: [3]u8 = undefined,
         len: u2 = 0,
     },
 
@@ -455,9 +472,11 @@ test "DECRQSS invalid command" {
 
     h.discard();
 
+    // A Pt longer than the buffer overflows and is discarded entirely.
     try testing.expect(h.hook(alloc, .{ .intermediates = "$", .final = 'q' }) == null);
     _ = h.put('"');
     _ = h.put(' ');
+    _ = h.put('q');
     _ = h.put('q');
     try testing.expect(h.unhook() == null);
 }
@@ -543,6 +562,38 @@ test "DECRQSS largest response fits fixed buffer" {
         ";48:2::255:255:255m\x1B\\";
     try testing.expectEqualStrings(expected, encoded);
     try testing.expect(encoded.len <= Command.DECRQSS.max_response_bytes);
+}
+
+test "DECRQSS XTQMODKEYS modifyOtherKeys" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var h: Handler = .{};
+    defer h.deinit();
+    try testing.expect(h.hook(alloc, .{ .intermediates = "$", .final = 'q' }) == null);
+    _ = h.put('>');
+    _ = h.put('4');
+    _ = h.put('m');
+    var cmd = h.unhook().?;
+    defer cmd.deinit();
+    try testing.expect(cmd == .decrqss);
+    try testing.expect(cmd.decrqss == .modify_other_keys);
+}
+
+test "DECRQSS XTQMODKEYS unsupported resource" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var h: Handler = .{};
+    defer h.deinit();
+    try testing.expect(h.hook(alloc, .{ .intermediates = "$", .final = 'q' }) == null);
+    _ = h.put('>');
+    _ = h.put('0');
+    _ = h.put('m');
+    var cmd = h.unhook().?;
+    defer cmd.deinit();
+    try testing.expect(cmd == .decrqss);
+    try testing.expect(cmd.decrqss == .none);
 }
 
 test "tmux enter and implicit exit" {

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -89,6 +89,7 @@ pub const Action = union(Key) {
     save_cursor,
     restore_cursor,
     modify_key_format: ansi.ModifyKeyFormat,
+    modify_key_query,
     mouse_shift_capture: bool,
     protected_mode_off,
     protected_mode_iso,
@@ -188,6 +189,7 @@ pub const Action = union(Key) {
             "save_cursor",
             "restore_cursor",
             "modify_key_format",
+            "modify_key_query",
             "mouse_shift_capture",
             "protected_mode_off",
             "protected_mode_iso",
@@ -1802,6 +1804,24 @@ pub fn Stream(comptime H: type) type {
                                 self.handler.vt(.modify_key_format, format);
                             },
 
+                            // XTQMODKEYS: query key modifier options. We only
+                            // support modifyOtherKeys (resource 4); `vim --clean`
+                            // sends `CSI ? 4 m`. Reply is `CSI > 4 ; Pv m`.
+                            '?' => switch (input.params.len) {
+                                1 => switch (input.params[0]) {
+                                    4 => self.handler.vt(.modify_key_query, {}),
+                                    else => logUnsupportedOnce(
+                                        "unsupported XTQMODKEYS resource: {f}",
+                                        .{input},
+                                        @intCast(input.params[0]),
+                                    ),
+                                },
+                                else => log.warn(
+                                    "invalid XTQMODKEYS: {f}",
+                                    .{input},
+                                ),
+                            },
+
                             else => logUnsupportedOnce(
                                 "unknown CSI m with intermediate: {}",
                                 .{input.intermediates[0]},
@@ -1809,16 +1829,10 @@ pub fn Stream(comptime H: type) type {
                             ),
                         },
 
-                        else => {
-                            // Nothing, but I wanted a place to put this comment:
-                            // there are others forms of CSI m that have intermediates.
-                            // `vim --clean` uses `CSI ? 4 m` and I don't know what
-                            // that means.
-                            log.warn(
-                                "ignoring unimplemented CSI m with intermediates: {s}",
-                                .{input.intermediates},
-                            );
-                        },
+                        else => log.warn(
+                            "ignoring unimplemented CSI m with intermediates: {s}",
+                            .{input.intermediates},
+                        ),
                     }
                 },
 

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -2901,6 +2901,40 @@ test "stream: cursor right (CUF)" {
     try testing.expectEqual(@as(u16, 0), s.handler.amount);
 }
 
+test "stream: XTQMODKEYS query modifyOtherKeys (CSI ? 4 m)" {
+    const H = struct {
+        queries: u32 = 0,
+
+        pub fn vt(
+            self: *@This(),
+            comptime action: Action.Tag,
+            value: Action.Value(action),
+        ) void {
+            _ = value;
+            switch (action) {
+                .modify_key_query => self.queries += 1,
+                else => {},
+            }
+        }
+    };
+
+    var s: Stream(H) = .init(.{});
+
+    // Resource 4 (modifyOtherKeys) is the only one we answer.
+    s.nextSlice("\x1B[?4m");
+    try testing.expectEqual(@as(u32, 1), s.handler.queries);
+
+    // Other resources are ignored (no reply).
+    s.nextSlice("\x1B[?0m");
+    s.nextSlice("\x1B[?1m");
+    s.nextSlice("\x1B[?2m");
+    try testing.expectEqual(@as(u32, 1), s.handler.queries);
+
+    // Multiple params is invalid and ignored.
+    s.nextSlice("\x1B[?4;2m");
+    try testing.expectEqual(@as(u32, 1), s.handler.queries);
+}
+
 test "stream: dec set mode (SM) and reset mode (RM)" {
     const H = struct {
         mode: modes.Mode = @as(modes.Mode, @enumFromInt(1)),

--- a/src/terminal/stream_terminal.zig
+++ b/src/terminal/stream_terminal.zig
@@ -627,6 +627,7 @@ pub const Handler = struct {
     }
 
     fn queryModifyOtherKeys(self: *Handler) void {
+        if (self.effects.write_pty == null) return;
         // XTQMODKEYS reply for modifyOtherKeys: `CSI > 4 ; Pv m`. Ghostty's
         // default encoder already emits the numeric form for ambiguous keys
         // (mode 1), so the floor is 1; mode 2 (`>4;2m`) reports 2.

--- a/src/terminal/stream_terminal.zig
+++ b/src/terminal/stream_terminal.zig
@@ -628,12 +628,11 @@ pub const Handler = struct {
 
     fn queryModifyOtherKeys(self: *Handler) void {
         if (self.effects.write_pty == null) return;
-        // XTQMODKEYS reply for modifyOtherKeys: `CSI > 4 ; Pv m`. Ghostty's
-        // default encoder already emits the numeric form for ambiguous keys
-        // (mode 1), so the floor is 1; mode 2 (`>4;2m`) reports 2.
-        const pv: u8 = if (self.terminal.flags.modify_other_keys_2) 2 else 1;
-        var buf: [16]u8 = undefined;
-        const resp = std.fmt.bufPrintZ(&buf, "\x1b[>4;{d}m", .{pv}) catch return;
+        // XTQMODKEYS reply: `CSI > 4 ; Pv m`.
+        var report_buf: [16]u8 = undefined;
+        const report = self.terminal.modifyOtherKeysReport(&report_buf) catch return;
+        var buf: [24]u8 = undefined;
+        const resp = std.fmt.bufPrintZ(&buf, "\x1b[{s}", .{report}) catch return;
         self.writePty(resp);
     }
 
@@ -1415,7 +1414,7 @@ test "DECRQSS responses" {
 
     // Requests larger than the parser's fixed request buffer are ignored,
     // and the next DCS command must still be processed normally.
-    s.nextSlice("\x1BP$qfoo\x1B\\");
+    s.nextSlice("\x1BP$qfoob\x1B\\");
     try testing.expectEqual(@as(usize, 0), S.calls);
     try testing.expect(!s.handler.semantic_failure);
     s.nextSlice("\x1BP$qm\x1B\\");

--- a/src/terminal/stream_terminal.zig
+++ b/src/terminal/stream_terminal.zig
@@ -318,6 +318,7 @@ pub const Handler = struct {
             .device_status => self.deviceStatus(value.request),
             .enquiry => self.reportEnquiry(),
             .kitty_keyboard_query => self.queryKittyKeyboard(),
+            .modify_key_query => self.queryModifyOtherKeys(),
             .request_mode => self.requestMode(value.mode),
             .request_mode_unknown => self.requestModeUnknown(value.mode, value.ansi),
             .size_report => self.reportSize(value),
@@ -622,6 +623,16 @@ pub const Handler = struct {
         const resp = std.fmt.bufPrintZ(&buf, "\x1b[?{}u", .{
             self.terminal.screens.active.kitty_keyboard.current().int(),
         }) catch return;
+        self.writePty(resp);
+    }
+
+    fn queryModifyOtherKeys(self: *Handler) void {
+        // XTQMODKEYS reply for modifyOtherKeys: `CSI > 4 ; Pv m`. Ghostty's
+        // default encoder already emits the numeric form for ambiguous keys
+        // (mode 1), so the floor is 1; mode 2 (`>4;2m`) reports 2.
+        const pv: u8 = if (self.terminal.flags.modify_other_keys_2) 2 else 1;
+        var buf: [16]u8 = undefined;
+        const resp = std.fmt.bufPrintZ(&buf, "\x1b[>4;{d}m", .{pv}) catch return;
         self.writePty(resp);
     }
 
@@ -2315,6 +2326,41 @@ test "window_title effect with empty title" {
     s.nextSlice("\x1b]2;\x1b\\");
     try testing.expect(t.getTitle() == null);
     try testing.expectEqual(@as(usize, 1), S.title_changed_count);
+}
+
+test "modifyOtherKeys query XTQMODKEYS" {
+    var t: Terminal = try .init(testing.io, testing.allocator, .{ .cols = 80, .rows = 24 });
+    defer t.deinit(testing.allocator);
+
+    const S = struct {
+        var written: ?[:0]const u8 = null;
+        fn writePty(_: *Handler, data: [:0]const u8) void {
+            written = data;
+        }
+    };
+    S.written = null;
+
+    var handler: Handler = .init(&t);
+    handler.effects.write_pty = &S.writePty;
+
+    var s: Stream = .initAlloc(testing.allocator, handler);
+    defer s.deinit();
+
+    // Default modifyOtherKeys is mode 1 (ambiguous keys already numeric)
+    s.nextSlice("\x1b[?4m");
+    try testing.expectEqualStrings("\x1b[>4;1m", S.written.?);
+
+    // Enable numeric (mode 2) form and query again
+    S.written = null;
+    s.nextSlice("\x1b[>4;2m");
+    s.nextSlice("\x1b[?4m");
+    try testing.expectEqualStrings("\x1b[>4;2m", S.written.?);
+
+    // Reset back to default and confirm we report mode 1 again
+    S.written = null;
+    s.nextSlice("\x1b[>4m");
+    s.nextSlice("\x1b[?4m");
+    try testing.expectEqualStrings("\x1b[>4;1m", S.written.?);
 }
 
 test "kitty_keyboard_query" {

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -293,6 +293,7 @@ pub const StreamHandler = struct {
             .device_attributes => try self.deviceAttributes(value),
             .device_status => try self.deviceStatusReport(value.request),
             .kitty_keyboard_query => try self.queryKittyKeyboard(),
+            .modify_key_query => try self.queryModifyOtherKeys(),
             .kitty_keyboard_push => {
                 log.debug("pushing kitty keyboard mode: {}", .{value.flags});
                 self.terminal.screens.active.kitty_keyboard.push(value.flags);
@@ -868,6 +869,22 @@ pub const StreamHandler = struct {
             self.terminal.screens.active.kitty_keyboard.current().int(),
         });
 
+        self.messageWriter(.{
+            .write_small = .{
+                .data = data,
+                .len = @intCast(resp.len),
+            },
+        });
+    }
+
+    pub fn queryModifyOtherKeys(self: *StreamHandler) !void {
+        log.debug("querying modifyOtherKeys", .{});
+        // XTQMODKEYS reply: `CSI > 4 ; Pv m`. Ghostty's default encoder already
+        // emits the numeric form for ambiguous keys (mode 1), so the floor is
+        // 1; mode 2 (`>4;2m`) reports 2.
+        const pv: u8 = if (self.terminal.flags.modify_other_keys_2) 2 else 1;
+        var data: termio.Message.WriteReq.Small.Array = undefined;
+        const resp = try std.fmt.bufPrint(&data, "\x1b[>4;{d}m", .{pv});
         self.messageWriter(.{
             .write_small = .{
                 .data = data,

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -878,12 +878,11 @@ pub const StreamHandler = struct {
     }
 
     pub fn queryModifyOtherKeys(self: *StreamHandler) !void {
-        // XTQMODKEYS reply: `CSI > 4 ; Pv m`. Ghostty's default encoder already
-        // emits the numeric form for ambiguous keys (mode 1), so the floor is
-        // 1; mode 2 (`>4;2m`) reports 2.
-        const pv: u8 = if (self.terminal.flags.modify_other_keys_2) 2 else 1;
+        // XTQMODKEYS reply: `CSI > 4 ; Pv m`.
+        var buf: [16]u8 = undefined;
+        const report = try self.terminal.modifyOtherKeysReport(&buf);
         var data: termio.Message.WriteReq.Small.Array = undefined;
-        const resp = try std.fmt.bufPrint(&data, "\x1b[>4;{d}m", .{pv});
+        const resp = try std.fmt.bufPrint(&data, "\x1b[{s}", .{report});
         self.messageWriter(.{
             .write_small = .{
                 .data = data,

--- a/src/termio/stream_handler.zig
+++ b/src/termio/stream_handler.zig
@@ -878,7 +878,6 @@ pub const StreamHandler = struct {
     }
 
     pub fn queryModifyOtherKeys(self: *StreamHandler) !void {
-        log.debug("querying modifyOtherKeys", .{});
         // XTQMODKEYS reply: `CSI > 4 ; Pv m`. Ghostty's default encoder already
         // emits the numeric form for ambiguous keys (mode 1), so the floor is
         // 1; mode 2 (`>4;2m`) reports 2.


### PR DESCRIPTION
Implements querying support for xterm `modifyOtherKeys` (XTQMODKEYS resource 4) via two forms:

- `CSI ? 4 m` — the XTQMODKEYS query.
- `DCS $ q > 4 m ST` — the DECRQSS form. `CSI ? 4 m` is technically a private `SGR` sequence (historically a superscript rendition), so DECRQSS is offered as a safer alternative per review feedback. Both forms are kept.

Ghostty implements mode 1 by default (ambiguous modified keys use the `CSI 27` numeric form) and mode 2 when enabled, but never responded to either query, so applications could not detect support or the active mode.

Both forms reply with the XTMODKEYS control `> 4 ; Pv m` (CSI-prefixed for `CSI ? 4 m`, wrapped in `DCS 1 $ r … ST` for DECRQSS), where `Pv` is `2` when mode 2 is active and `1` otherwise. `Pv` is never `0` because the mode 1 encoding is always active and cannot be disabled. The reply payload is shared via `Terminal.modifyOtherKeysReport` and unit tested.

Discussion: https://github.com/ghostty-org/ghostty/discussions/13331

## AI disclosure
Implemented with AI assistance (GitHub Copilot CLI, model Claude Opus 4.8). I reviewed, understand, and can explain all of the code and its interaction with the key encoder without AI aid, per the AI Usage Policy.