### PR TITLE
macos: resync appearance after showing a window

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -1154,6 +1154,9 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
         }
 
         super.showWindow(sender)
+
+        // Some appearance updates only work once the window is visible.
+        syncAppearance()
     }
 
     // Shows the "+" button in the tab bar, responds to that click.

--- a/macos/Tests/Terminal/TerminalControllerTests.swift
+++ b/macos/Tests/Terminal/TerminalControllerTests.swift
@@ -1,0 +1,37 @@
+import AppKit
+import Testing
+@testable import Ghostty
+
+@Suite
+struct TerminalControllerTests {
+    @MainActor
+    @Test func showWindowSyncsAppearanceAfterWindowIsVisible() throws {
+        let appDelegate = try #require(NSApp.delegate as? AppDelegate)
+        let controller = AppearanceSyncTerminalController(appDelegate.ghostty)
+        let window = TerminalWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 800, height: 600),
+            styleMask: [.titled, .closable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.isReleasedWhenClosed = false
+        controller.window = window
+        defer { window.close() }
+
+        #expect(!window.isVisible)
+        controller.appearanceSyncVisibility.removeAll()
+
+        controller.showWindow(nil)
+
+        #expect(controller.appearanceSyncVisibility == [true])
+    }
+}
+
+@MainActor
+private final class AppearanceSyncTerminalController: TerminalController {
+    var appearanceSyncVisibility: [Bool] = []
+
+    override func syncAppearance() {
+        appearanceSyncVisibility.append(window?.isVisible ?? false)
+    }
+}


### PR DESCRIPTION
## Summary

- resync the focused surface appearance after `NSWindowController` makes the terminal window visible
- keep the `.dropFirst()` subscriptions that prevent stale appearance updates during tab changes
- add a lifecycle regression test that verifies the sync happens with a visible window

## Why

`TerminalWindow.syncAppearance` intentionally skips hidden windows. The initial appearance sync happens before presentation, and the `.dropFirst()` change in #12828 removed the later Combine emission that had accidentally retried it. As a result, settings such as `background-opacity` were not applied to a newly opened hidden-titlebar window.

## Testing

- `PATH=/opt/homebrew/opt/zig@0.15/bin:$PATH zig build -Demit-macos-app=false`
- `macos/build.nu --action test` (222 passed, 1 skipped)
- SwiftLint on the changed Swift files
- manual comparison with the issue configuration: baseline remained opaque/black, while the patched cold-open and second window both applied the configured opacity

Fixes #13324

AI disclosure: Codex was used to investigate, implement, and test this change.
