### PR TITLE
libghostty-vt: preserve PNG allocation capacity

### DIFF
--- a/example/c-vt-kitty-graphics/src/main.c
+++ b/example/c-vt-kitty-graphics/src/main.c
@@ -40,6 +40,7 @@ bool decode_png(void* userdata,
   out->height = 1;
   out->data = pixels;
   out->data_len = pixel_len;
+  out->data_cap = pixel_len;
   return true;
 }
 //! [kitty-graphics-decode-png]

--- a/include/ghostty/vt/sys.h
+++ b/include/ghostty/vt/sys.h
@@ -48,7 +48,7 @@ extern "C" {
  *
  * The `data` buffer must be allocated through the allocator provided to
  * the decode callback. The library takes ownership and will free it
- * with the same allocator.
+ * with the same allocator, using `data_cap` as the allocation length.
  */
 typedef struct {
     /** Image width in pixels. */
@@ -62,6 +62,17 @@ typedef struct {
 
     /** Length of the pixel data in bytes. */
     size_t data_len;
+
+    /**
+     * Capacity of the pixel data allocation in bytes.
+     *
+     * This must be greater than or equal to `data_len` and must match the
+     * length originally passed to the allocator. It may be larger than
+     * `data_len` so decoders can transfer ownership of over-allocated buffers.
+     * A value of zero is treated as `data_len` for compatibility with decoders
+     * built against older headers and should only be used for exact-size data.
+     */
+    size_t data_cap;
 } GhosttySysImage;
 
 /**
@@ -108,7 +119,9 @@ typedef void (*GhosttySysLogFn)(
  *
  * Decodes raw PNG data into RGBA pixels. The output pixel data must be
  * allocated through the provided allocator. The library takes ownership
- * of the buffer and will free it with the same allocator.
+ * of the buffer and will free it with the same allocator. `data_cap` must
+ * contain the allocation length and may be greater than `data_len`. A value
+ * of zero is treated as `data_len` for compatibility with older decoders.
  *
  * @param userdata  The userdata pointer set via GHOSTTY_SYS_OPT_USERDATA
  * @param allocator The allocator to use for the output pixel buffer

--- a/src/terminal/c/sys.zig
+++ b/src/terminal/c/sys.zig
@@ -11,6 +11,7 @@ pub const Image = extern struct {
     height: u32,
     data: ?[*]u8,
     data_len: usize,
+    data_cap: usize,
 };
 
 /// C: GhosttySysDecodePngFn
@@ -85,15 +86,27 @@ fn decodePngWrapper(
     const func = global.decode_png orelse return error.InvalidData;
 
     const c_alloc = CAllocator.fromZig(&alloc);
-    var out: Image = undefined;
+    var out: Image = .{
+        .width = 0,
+        .height = 0,
+        .data = null,
+        .data_len = 0,
+        .data_cap = 0,
+    };
     if (!func(global.userdata, &c_alloc, data.ptr, data.len, &out)) return error.InvalidData;
 
     const result_data = out.data orelse return error.InvalidData;
+    const data_cap = if (out.data_cap == 0) out.data_len else out.data_cap;
+    if (data_cap < out.data_len) {
+        alloc.free(result_data[0..data_cap]);
+        return error.InvalidData;
+    }
 
     return .{
         .width = out.width,
         .height = out.height,
         .data = result_data[0..out.data_len],
+        .data_cap = data_cap,
     };
 }
 
@@ -262,7 +275,13 @@ test "set decode_png with null clears" {
 test "set decode_png installs wrapper" {
     const S = struct {
         fn decode(_: ?*anyopaque, _: *const CAllocator, _: [*]const u8, _: usize, out: *Image) callconv(lib.calling_conv) bool {
-            out.* = .{ .width = 1, .height = 1, .data = null, .data_len = 0 };
+            out.* = .{
+                .width = 1,
+                .height = 1,
+                .data = null,
+                .data_len = 0,
+                .data_cap = 0,
+            };
             return true;
         }
     };
@@ -276,6 +295,103 @@ test "set decode_png installs wrapper" {
     // Clear it again.
     try std.testing.expectEqual(Result.success, set(.decode_png, null));
     try std.testing.expect(terminal_sys.decode_png == null);
+}
+
+test "decode_png preserves allocation capacity" {
+    const S = struct {
+        fn decode(
+            _: ?*anyopaque,
+            allocator: *const CAllocator,
+            _: [*]const u8,
+            _: usize,
+            out: *Image,
+        ) callconv(lib.calling_conv) bool {
+            const pixels = allocator.zig().alloc(u8, 8) catch return false;
+            const rgba: [4]u8 = .{ 0xFF, 0, 0, 0xFF };
+            @memcpy(pixels[0..4], &rgba);
+            out.* = .{
+                .width = 1,
+                .height = 1,
+                .data = pixels.ptr,
+                .data_len = 4,
+                .data_cap = pixels.len,
+            };
+            return true;
+        }
+    };
+
+    const old_decode_png = global.decode_png;
+    global.decode_png = &S.decode;
+    defer global.decode_png = old_decode_png;
+
+    const result = try decodePngWrapper(std.testing.allocator, "png");
+    defer std.testing.allocator.free(result.data.ptr[0..result.data_cap]);
+
+    try std.testing.expectEqual(@as(usize, 4), result.data.len);
+    try std.testing.expectEqual(@as(usize, 8), result.data_cap);
+    try std.testing.expectEqualSlices(u8, &.{ 0xFF, 0, 0, 0xFF }, result.data);
+}
+
+test "decode_png defaults zero allocation capacity to data length" {
+    const S = struct {
+        fn decode(
+            _: ?*anyopaque,
+            allocator: *const CAllocator,
+            _: [*]const u8,
+            _: usize,
+            out: *Image,
+        ) callconv(lib.calling_conv) bool {
+            const pixels = allocator.zig().alloc(u8, 4) catch return false;
+            out.* = .{
+                .width = 1,
+                .height = 1,
+                .data = pixels.ptr,
+                .data_len = pixels.len,
+                .data_cap = 0,
+            };
+            return true;
+        }
+    };
+
+    const old_decode_png = global.decode_png;
+    global.decode_png = &S.decode;
+    defer global.decode_png = old_decode_png;
+
+    const result = try decodePngWrapper(std.testing.allocator, "png");
+    defer std.testing.allocator.free(result.data.ptr[0..result.data_cap]);
+
+    try std.testing.expectEqual(result.data.len, result.data_cap);
+}
+
+test "decode_png rejects data length greater than allocation capacity" {
+    const S = struct {
+        fn decode(
+            _: ?*anyopaque,
+            allocator: *const CAllocator,
+            _: [*]const u8,
+            _: usize,
+            out: *Image,
+        ) callconv(lib.calling_conv) bool {
+            const pixels = allocator.zig().alloc(u8, 8) catch return false;
+            out.* = .{
+                .width = 1,
+                .height = 1,
+                .data = pixels.ptr,
+                .data_len = 9,
+                .data_cap = pixels.len,
+            };
+            return true;
+        }
+    };
+
+    const old_decode_png = global.decode_png;
+    global.decode_png = &S.decode;
+    defer global.decode_png = old_decode_png;
+
+    try std.testing.expectError(
+        error.InvalidData,
+        decodePngWrapper(std.testing.allocator, "png"),
+    );
 }
 
 test "set log with null clears" {

--- a/src/terminal/kitty/graphics_image.zig
+++ b/src/terminal/kitty/graphics_image.zig
@@ -36,6 +36,11 @@ pub const LoadingImage = struct {
     /// The data that is being built up.
     data: std.ArrayListUnmanaged(u8) = .{},
 
+    /// Preserve the allocation capacity when completing the image. PNG
+    /// decoders may intentionally return an over-allocated buffer whose
+    /// ownership can be transferred directly into image storage.
+    preserve_data_capacity: bool = false,
+
     /// This is non-null when a transmit and display command is given
     /// so that we display the image after it is fully loaded.
     display: ?command.Display = null,
@@ -401,10 +406,18 @@ pub const LoadingImage = struct {
             return error.InvalidData;
         }
 
-        // Everything looks good, copy the image data over.
+        // Everything looks good, transfer the image data over. PNG decoders
+        // can return an over-allocated buffer, in which case we preserve its
+        // capacity so ownership can be transferred without a copy.
         var result = self.image;
-        result.data = try self.data.toOwnedSlice(alloc);
-        errdefer result.deinit(alloc);
+        if (self.preserve_data_capacity) {
+            result.data = self.data.items;
+            result.data_cap = self.data.capacity;
+            self.data = .{};
+        } else {
+            result.data = try self.data.toOwnedSlice(alloc);
+            result.data_cap = result.data.len;
+        }
         self.image = .{};
         return result;
     }
@@ -477,7 +490,15 @@ pub const LoadingImage = struct {
             error.InvalidData => return error.InvalidData,
             error.OutOfMemory => return error.OutOfMemory,
         };
-        defer alloc.free(result.data);
+        errdefer alloc.free(result.data.ptr[0..result.data_cap]);
+
+        if (result.data_cap < result.data.len) {
+            log.warn(
+                "png image capacity smaller than data size cap={} size={}",
+                .{ result.data_cap, result.data.len },
+            );
+            return error.InvalidData;
+        }
 
         if (result.data.len > max_size) {
             log.warn("png image too large size={} max_size={}", .{ result.data.len, max_size });
@@ -486,9 +507,11 @@ pub const LoadingImage = struct {
 
         // Replace our data
         self.data.deinit(alloc);
-        self.data = .{};
-        try self.data.ensureUnusedCapacity(alloc, result.data.len);
-        try self.data.appendSlice(alloc, result.data[0..result.data.len]);
+        self.data = .{
+            .items = result.data,
+            .capacity = result.data_cap,
+        };
+        self.preserve_data_capacity = true;
 
         // Store updated image dimensions
         self.image.width = result.width;
@@ -512,6 +535,7 @@ pub const Image = struct {
     format: command.Transmission.Format = .rgb,
     compression: command.Transmission.Compression = .none,
     data: []const u8 = "",
+    data_cap: usize = 0,
 
     /// Unique, monotonically increasing stamp assigned each time an
     /// image is added to (or replaced in) an ImageStorage. A changed
@@ -541,13 +565,17 @@ pub const Image = struct {
     };
 
     pub fn deinit(self: *Image, alloc: Allocator) void {
-        if (self.data.len > 0) alloc.free(self.data);
+        const cap = if (self.data_cap > 0) self.data_cap else self.data.len;
+        if (cap > 0) {
+            alloc.free(@constCast(self.data.ptr)[0..cap]);
+        }
     }
 
     /// Mostly for logging
     pub fn withoutData(self: *const Image) Image {
         var copy = self.*;
         copy.data = "";
+        copy.data_cap = 0;
         return copy;
     }
 };
@@ -889,6 +917,51 @@ test "image load: png, not compressed, regular file" {
     try testing.expect(img.compression == .none);
     try testing.expect(img.format == .rgba);
     try tmp_dir.dir.access(path, .{});
+}
+
+test "image load: png preserves decoder allocation capacity" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    const S = struct {
+        var decoded_ptr: [*]u8 = undefined;
+
+        fn decode(allocator: Allocator, _: []const u8) sys.DecodeError!sys.Image {
+            const pixels = try allocator.alloc(u8, 8);
+            const rgba: [4]u8 = .{ 0xFF, 0, 0, 0xFF };
+            @memcpy(pixels[0..4], &rgba);
+            decoded_ptr = pixels.ptr;
+            return .{
+                .width = 1,
+                .height = 1,
+                .data = pixels[0..4],
+                .data_cap = pixels.len,
+            };
+        }
+    };
+
+    const old_decode_png = sys.decode_png;
+    sys.decode_png = &S.decode;
+    defer sys.decode_png = old_decode_png;
+
+    var cmd: command.Command = .{
+        .control = .{ .transmit = .{
+            .format = .png,
+            .medium = .direct,
+            .image_id = 31,
+        } },
+        .data = try alloc.dupe(u8, "png"),
+    };
+    defer cmd.deinit(alloc);
+
+    var loading = try LoadingImage.init(alloc, &cmd, .direct);
+    defer loading.deinit(alloc);
+    var img = try loading.complete(alloc);
+    defer img.deinit(alloc);
+
+    try testing.expectEqual(@intFromPtr(S.decoded_ptr), @intFromPtr(img.data.ptr));
+    try testing.expectEqual(@as(usize, 4), img.data.len);
+    try testing.expectEqual(@as(usize, 8), img.data_cap);
 }
 
 test "limits: direct medium always allowed" {

--- a/src/terminal/sys.zig
+++ b/src/terminal/sys.zig
@@ -30,6 +30,7 @@ pub const Image = struct {
     width: u32,
     height: u32,
     data: []u8,
+    data_cap: usize,
 };
 
 fn decodePngWuffs(
@@ -50,5 +51,6 @@ fn decodePngWuffs(
         .width = result.width,
         .height = result.height,
         .data = result.data,
+        .data_cap = result.data.len,
     };
 }


### PR DESCRIPTION
## Summary

- add `data_cap` to the C and Zig PNG decode results
- validate `data_len <= data_cap` and free decoder buffers with their actual allocation length
- transfer over-allocated PNG buffers into final image storage without copying
- document the capacity contract and update the C Kitty Graphics example

For compatibility with callbacks built against the older header, a zero capacity is treated as an exact-size allocation (`data_cap == data_len`). New callbacks can report a larger capacity explicitly.

## Testing

- `zig build test-lib-vt`
- targeted decode, invalid-capacity, pointer-identity, PNG loading, and storage-ownership tests
- `zig build -Demit-lib-vt`
- C Kitty Graphics example build and runtime
- `zig fmt --check` and `git diff --check`

Fixes #12163

AI disclosure: Codex was used to investigate, implement, and test this change.
