### PR TITLE
macos: make AppleScript tab names writable

### DIFF
--- a/macos/Ghostty.sdef
+++ b/macos/Ghostty.sdef
@@ -64,7 +64,7 @@
     <class name="tab" code="Gtab" plural="tabs" description="A tab within a Ghostty window.">
       <cocoa class="GhosttyScriptTab"/>
       <property name="id" code="ID  " type="text" access="r" description="Stable ID for this tab."/>
-      <property name="name" code="pnam" type="text" access="r" description="The title of the tab.">
+      <property name="name" code="pnam" type="text" access="rw" description="The title override of the tab. Set to an empty string to clear the override.">
         <cocoa key="title"/>
       </property>
       <property name="index" code="pidx" type="integer" access="r" description="1-based index of this tab in its window."/>

--- a/macos/Sources/Features/AppleScript/ScriptTab.swift
+++ b/macos/Sources/Features/AppleScript/ScriptTab.swift
@@ -40,11 +40,19 @@ final class ScriptTab: NSObject {
 
     /// Exposed as the AppleScript `title` property.
     ///
-    /// Returns the title of the tab's window.
+    /// Reads the title of the tab's window and writes its title override.
+    /// An empty value clears the override and restores the computed title.
     @objc(title)
     var title: String {
-        guard NSApp.isAppleScriptEnabled else { return "" }
-        return controller?.window?.title ?? ""
+        get {
+            guard NSApp.isAppleScriptEnabled else { return "" }
+            return controller?.window?.title ?? ""
+        }
+
+        set {
+            guard NSApp.isAppleScriptEnabled else { return }
+            controller?.titleOverride = newValue.isEmpty ? nil : newValue
+        }
     }
 
     /// Exposed as the AppleScript `index` property.


### PR DESCRIPTION
## Summary

- mark AppleScript `tab.name` as writable
- route writes to the existing `titleOverride` model
- treat an empty string as clearing the override and restoring the computed title

The scope follows the issue body and its AppleScript/JXA examples: writable tab names only.

## Testing

- `macos/build.nu --action test`
- SwiftLint and `xmllint --noout macos/Ghostty.sdef`
- AppleScript set/read/clear against the built app
- JXA set/read/clear against the built app
- two-tab check confirming that changing one tab does not affect the other

Fixes #12048

AI disclosure: Codex was used to investigate, implement, and test this change.
