### PR TITLE
cleanup: remove dead code line

### DIFF
--- a/src/crash/dir.zig
+++ b/src/crash/dir.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const assert = std.debug.assert;
 const Allocator = std.mem.Allocator;
 const internal_os = @import("../os/main.zig");
 


### PR DESCRIPTION
Pointed out on Discord, this code is dead, `std.debug.assert` is imported, but never used. 