### PR TITLE
macOS: sync appearance after screen parameters change

### DIFF
--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -534,6 +534,13 @@ class BaseTerminalController: NSWindowController,
         guard let window else { return }
         guard window.isVisible else { return }
 
+        defer {
+            // Always resync appearance. A display change can leave window
+            // appearance in a stale state (e.g. a black/hidden tab bar):
+            // https://github.com/ghostty-org/ghostty/discussions/5389
+            syncAppearance()
+        }
+
         // We ignore fullscreen windows because macOS automatically resizes
         // those back to the fullscreen bounds.
         guard !window.styleMask.contains(.fullScreen) else { return }
@@ -1024,6 +1031,7 @@ class BaseTerminalController: NSWindowController,
     /// as we add new things:
     ///
     ///  - ``toggleBackgroundOpacity``
+    ///  - ``didChangeScreenParametersNotification``
     func syncAppearance() {
         // Purposely a no-op. This lets subclasses override this and we can call
         // it virtually from here.


### PR DESCRIPTION
In #5389 there are multiple reports of tab bars appearing incorrectly after disconnecting an external monitor when Ghostty is in fullscreen.

BaseTerminalController handles the notfiication from AppKit about a screen change and, for non-fullscreen windows, it calls setFrame, which triggers windowDidMove, which calls fixTabBar. But for fullscreen windows, none of this happens, we skip clamping because macOS handles the sizing and the tab bar doesn't get fixed.

I've restructured the handler so that the clamping is conditional on the window being non-fullscreen and window.screen being defined, and regardless of the clamping, called syncAppearance at the end of the handler.

This has fixed the issue for me, reproduced locally using BetterDisplay to create a virtual second display and with my external monitor.

AI disclosure: I used GLM 5.2 and Claude Opus 4.8 in OpenCode to investigate the issue and the call chain, but I fully understand what is going on and wrote this PR and my commit message and the comment and the code myself.