### PR TITLE
fix(terminal): fix kitty temp directory copy length mismatch

### DIFF
--- a/src/terminal/c/terminal.zig
+++ b/src/terminal/c/terminal.zig
@@ -587,7 +587,7 @@ fn setTyped(
             if (comptime !build_options.kitty_graphics) return .success;
             if (value) |v| {
                 if (v.len > wrapper.tmp_dir_path.len) return .out_of_memory;
-                @memcpy(&wrapper.tmp_dir_path, v.ptr[0..v.len]);
+                @memcpy(wrapper.tmp_dir_path[0..v.len], v.ptr[0..v.len]);
                 var it = wrapper.terminal.screens.all.iterator();
                 while (it.next()) |entry| {
                     const screen = entry.value.*;


### PR DESCRIPTION
EDIT: [exposed](https://github.com/elias8/libghostty/actions/runs/29996356691/job/89171182671?pr=113#step:12:447) while syncing libghostty dart bindings to latest main.