### PR TITLE
config: add `extend` value to `right-click-action`

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -4072,6 +4072,41 @@ pub fn mouseButtonCallback(
 
         switch (self.config.right_click_action) {
             .ignore => {},
+            .extend => {
+                // Extend to the clicked location from the last left-click
+                // anchor, reusing the same gesture-drag mechanism as
+                // shift+left-click. The anchor is kept fixed and the other end
+                // moves to the click. Note the anchor exists after any
+                // left-click, even a bare click that produced no selection
+                // object (e.g. a single click), so the classic xterm workflow
+                // of "click one end, right-click the other" works without a
+                // drag. We consume the event either way so we never fall back
+                // to the context menu.
+                const t: *terminal.Terminal = self.renderer_state.terminal;
+                const drag_selection = self.mouse.selection_gesture.drag(t, .{
+                    .pin = pin,
+                    .xpos = pos.x,
+                    .ypos = pos.y,
+                    .rectangle = SurfaceMouse.isRectangleSelectState(self.mouse.mods),
+                    .word_boundary_codepoints = self.config.selection_word_chars,
+                    .geometry = .{
+                        .columns = @intCast(self.size.grid().columns),
+                        .cell_width = self.size.cell.width,
+                        .padding_left = self.size.padding.left,
+                        .screen_height = self.size.screen.height,
+                    },
+                });
+
+                // `drag` returns null when there is no live left-click anchor
+                // (no prior left-click this session, or the selection was made
+                // some other way such as select-all/keyboard). In that case
+                // there is nothing to extend from, so leave any existing
+                // selection untouched.
+                if (drag_selection) |sel| {
+                    try self.setSelectionAndCopy(sel);
+                    try self.queueRender();
+                }
+            },
             .@"context-menu" => {
                 // If we already have a selection and the selection contains
                 // where we clicked then we don't want to modify the selection.

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2445,6 +2445,13 @@ keybind: Keybinds = .{},
 ///   * `copy` - Copy the selected text to the clipboard.
 ///   * `copy-or-paste` - If there is a selection, copy the selected text to
 ///      the clipboard; otherwise, paste the contents of the clipboard.
+///   * `extend` - Extend the selection to the clicked location, matching the
+///      classic xterm/rxvt right-button behavior. This uses the same mechanism
+///      as shift+left-click: the anchor from the most recent left-click is
+///      kept fixed and the other end is moved to the click. Because a bare
+///      left-click sets that anchor, you can left-click one end of a region
+///      and right-click the other to select it without dragging. If there has
+///      been no left-click to anchor from, this does nothing.
 ///   * `ignore` - Do nothing, ignore the right-click.
 ///
 /// The default value is `context-menu`.
@@ -8640,6 +8647,11 @@ pub const RightClickAction = enum {
     /// Copies the selected text to the system clipboard and
     /// pastes the clipboard if no text is selected.
     @"copy-or-paste",
+
+    /// Extends the selection to the clicked location from the most recent
+    /// left-click anchor, matching the classic xterm/rxvt right-button
+    /// behavior. Does nothing if there has been no left-click to anchor from.
+    extend,
 
     /// Shows a context menu with options.
     @"context-menu",


### PR DESCRIPTION
Add a new `extend` action for `right-click-action` that extends the current selection to the clicked location, matching the classic xterm/rxvt right-button behavior.

It reuses the same gesture-drag mechanism as shift+left-click: the anchor from the most recent left-click is held fixed and the other end of the selection is moved to the click point. Because a bare left-click sets that anchor without necessarily creating a selection, you can left-click one end of a region and right-click the other to select it without dragging.

When there is no left-click anchor to extend from (for example a selection made via select-all or the keyboard), the click is a no-op and leaves any existing selection untouched.

Implements the request in ghostty-org/ghostty#11890.