### PR TITLE
macOS: change split drag's point style to match HIG

### DIFF
--- a/macos/Sources/Helpers/Backport.swift
+++ b/macos/Sources/Helpers/Backport.swift
@@ -107,12 +107,12 @@ enum BackportPointerStyle {
         case .horizontalText: return .horizontalText
         case .verticalText: return .verticalText
         case .link: return .link
-        case .resizeLeft: return .frameResize(position: .trailing, directions: [.inward])
-        case .resizeRight: return .frameResize(position: .leading, directions: [.inward])
-        case .resizeUp: return .frameResize(position: .bottom, directions: [.inward])
-        case .resizeDown: return .frameResize(position: .top, directions: [.inward])
-        case .resizeUpDown: return .frameResize(position: .top)
-        case .resizeLeftRight: return .frameResize(position: .trailing)
+        case .resizeLeft: return .columnResize(directions: .leading)
+        case .resizeRight: return .columnResize(directions: .trailing)
+        case .resizeUp: return .rowResize(directions: .up)
+        case .resizeDown: return .rowResize(directions: .down)
+        case .resizeUpDown: return .rowResize
+        case .resizeLeftRight: return .columnResize
         }
     }
     #endif


### PR DESCRIPTION
<img width="637" height="373" alt="image" src="https://github.com/user-attachments/assets/bdcd25f1-7755-47d0-8582-26ea8a00a0ca" />

Previously there's mismatch with [`CursorStyle.cursor`](https://github.com/ghostty-org/ghostty/blob/15484b607eb5a518dedf1548247c923b8abaae7c/macos/Sources/Helpers/Cursor.swift#L74-L109)

> https://developer.apple.com/design/human-interface-guidelines/pointing-devices#Pointers