### PR TITLE
feat: implement global shortcuts through vicinae-hotkey-v1

### DIFF
--- a/po/be.po
+++ b/po/be.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-02-17 23:16+0100\n"
+"POT-Creation-Date: 2026-07-26 04:59+0200\n"
 "PO-Revision-Date: 2026-04-14 00:00+0000\n"
 "Last-Translator: Illia Krauchanka <illiakrauchanka@gmail.com>\n"
 "Language-Team: Belarusian\n"
@@ -15,7 +15,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 #: dist/linux/ghostty_nautilus.py:53
 msgid "Open in Ghostty"
@@ -66,15 +67,15 @@ msgid ""
 "One or more configuration errors were found. Please review the errors below, "
 "and either reload your configuration or ignore these errors."
 msgstr ""
-"Знойдзена адна або некалькі канфігурацыйных памылак. Прагледзьце памылкі ніжэй "
-"і альбо перазагрузіце канфігурацыю, альбо ігнаруйце гэтыя памылкі."
+"Знойдзена адна або некалькі канфігурацыйных памылак. Прагледзьце памылкі "
+"ніжэй і альбо перазагрузіце канфігурацыю, альбо ігнаруйце гэтыя памылкі."
 
 #: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:10
 msgid "Ignore"
 msgstr "Ігнараваць"
 
 #: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:366 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
 msgid "Reload Configuration"
 msgstr "Перазагрузіць канфігурацыю"
 
@@ -109,7 +110,7 @@ msgstr "Ой."
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "Не ўдалося атрымаць кантэкст OpenGL для адмалёўкі."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:97
+#: src/apprt/gtk/ui/1.2/surface.blp:99
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -119,93 +120,97 @@ msgstr ""
 "праглядаць, вылучаць і пракручваць змест, але ніякія падзеі ўводу не будуць "
 "адпраўлены ў запушчаную праграму."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:107
+#: src/apprt/gtk/ui/1.2/surface.blp:109
 msgid "Read-only"
 msgstr "Толькі для чытання"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:260 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
 msgid "Copy"
 msgstr "Скапіяваць"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:265 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
 msgid "Paste"
 msgstr "Уставіць"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:270
+#: src/apprt/gtk/ui/1.2/surface.blp:272
 msgid "Notify on Next Command Finish"
 msgstr "Апавясціць пры завяршэнні наступнай каманды"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:277 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
 msgid "Clear"
 msgstr "Ачысціць"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:282 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
 msgid "Reset"
 msgstr "Скінуць"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:289 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
 msgid "Split"
 msgstr "Падзяліць"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:292 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Change Title…"
 msgstr "Змяніць назву…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:297 src/apprt/gtk/ui/1.5/window.blp:177
+#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
 #: src/apprt/gtk/ui/1.5/window.blp:250
 msgid "Split Up"
 msgstr "Падзяліць уверх"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:303 src/apprt/gtk/ui/1.5/window.blp:182
+#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
 #: src/apprt/gtk/ui/1.5/window.blp:255
 msgid "Split Down"
 msgstr "Падзяліць уніз"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:309 src/apprt/gtk/ui/1.5/window.blp:187
+#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
 #: src/apprt/gtk/ui/1.5/window.blp:260
 msgid "Split Left"
 msgstr "Падзяліць улева"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:315 src/apprt/gtk/ui/1.5/window.blp:192
+#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
 #: src/apprt/gtk/ui/1.5/window.blp:265
 msgid "Split Right"
 msgstr "Падзяліць управа"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:322
+#: src/apprt/gtk/ui/1.2/surface.blp:323
+msgid "Close Split"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.2/surface.blp:329
 msgid "Tab"
 msgstr "Укладка"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:325 src/apprt/gtk/ui/1.5/window.blp:224
+#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
 #: src/apprt/gtk/ui/1.5/window.blp:320
 msgid "Change Tab Title…"
 msgstr "Змяніць назву ўкладкі…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:330 src/apprt/gtk/ui/1.5/window.blp:57
+#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
 msgid "New Tab"
 msgstr "Новая ўкладка"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:335 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
 msgid "Close Tab"
 msgstr "Закрыць укладку"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:342
+#: src/apprt/gtk/ui/1.2/surface.blp:349
 msgid "Window"
 msgstr "Акно"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:345 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
 msgid "New Window"
 msgstr "Новае акно"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:350 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
 msgid "Close Window"
 msgstr "Закрыць акно"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:358
+#: src/apprt/gtk/ui/1.2/surface.blp:365
 msgid "Config"
 msgstr "Налады"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:361 src/apprt/gtk/ui/1.5/window.blp:295
+#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
 msgid "Open Configuration"
 msgstr "Адкрыць канфігурацыю"
 
@@ -237,7 +242,7 @@ msgstr "Палітра каманд"
 msgid "Terminal Inspector"
 msgstr "Інспектар тэрмінала"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1727
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
 msgid "About Ghostty"
 msgstr "Пра Ghostty"
 
@@ -248,6 +253,18 @@ msgstr "Выйсці"
 #: src/apprt/gtk/ui/1.5/command-palette.blp:17
 msgid "Execute a command…"
 msgstr "Выканаць каманду…"
+
+#: src/apprt/gtk/class/application.zig:1708
+msgid "The keybind was revoked by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1710
+msgid "The keybind was denied by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1721
+msgid "Global keybind unavailable"
+msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
 msgid ""
@@ -262,8 +279,8 @@ msgid ""
 "An application is attempting to read from the clipboard. The current "
 "clipboard contents are shown below."
 msgstr ""
-"Праграма спрабуе чытаць з буфера абмену. Бягучы змест буфера абмену "
-"паказаны ніжэй."
+"Праграма спрабуе чытаць з буфера абмену. Бягучы змест буфера абмену паказаны "
+"ніжэй."
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:205
 msgid "Warning: Potentially Unsafe Paste"
@@ -309,15 +326,15 @@ msgstr "Усе сесіі тэрмінала ў гэтым акне будуць
 msgid "The currently running process in this split will be terminated."
 msgstr "Бягучы працэс у гэтым падзеле будзе завершаны."
 
-#: src/apprt/gtk/class/surface.zig:1108
+#: src/apprt/gtk/class/surface.zig:1170
 msgid "Command Finished"
 msgstr "Каманда завершана"
 
-#: src/apprt/gtk/class/surface.zig:1109
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Succeeded"
 msgstr "Каманда выканана паспяхова"
 
-#: src/apprt/gtk/class/surface.zig:1110
+#: src/apprt/gtk/class/surface.zig:1172
 msgid "Command Failed"
 msgstr "Каманда завершылася з памылкай"
 
@@ -337,18 +354,18 @@ msgstr "Змяніць назву тэрмінала"
 msgid "Change Tab Title"
 msgstr "Змяніць назву ўкладкі"
 
-#: src/apprt/gtk/class/window.zig:1007
+#: src/apprt/gtk/class/window.zig:1102
 msgid "Reloaded the configuration"
 msgstr "Канфігурацыя перазагружана"
 
-#: src/apprt/gtk/class/window.zig:1566
+#: src/apprt/gtk/class/window.zig:1705
 msgid "Copied to clipboard"
 msgstr "Скапіявана ў буфер абмену"
 
-#: src/apprt/gtk/class/window.zig:1568
+#: src/apprt/gtk/class/window.zig:1707
 msgid "Cleared clipboard"
 msgstr "Буфер абмену ачышчаны"
 
-#: src/apprt/gtk/class/window.zig:1708
+#: src/apprt/gtk/class/window.zig:1847
 msgid "Ghostty Developers"
 msgstr "Распрацоўшчыкі Ghostty"

--- a/po/bg.po
+++ b/po/bg.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-03-25 16:24-0700\n"
+"POT-Creation-Date: 2026-07-26 04:59+0200\n"
 "PO-Revision-Date: 2026-02-09 22:07+0200\n"
 "Last-Translator: reo101 <pavel.atanasov2001@gmail.com>\n"
 "Language-Team: Bulgarian <dict@ludost.net>\n"
@@ -75,7 +75,7 @@ msgid "Ignore"
 msgstr "Игнорирай"
 
 #: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
 msgid "Reload Configuration"
 msgstr "Презареди конфигурацията"
 
@@ -110,7 +110,7 @@ msgstr "О, не."
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "Неуспешно придобиване на OpenGL контекст за рендиране."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:97
+#: src/apprt/gtk/ui/1.2/surface.blp:99
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -120,97 +120,97 @@ msgstr ""
 "селектирате и превъртате съдържанието, но към работещото приложение няма да "
 "бъдат изпращани входни събития."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:107
+#: src/apprt/gtk/ui/1.2/surface.blp:109
 msgid "Read-only"
 msgstr "Само за четене"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:260 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
 msgid "Copy"
 msgstr "Копирай"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:265 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
 msgid "Paste"
 msgstr "Постави"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:270
+#: src/apprt/gtk/ui/1.2/surface.blp:272
 msgid "Notify on Next Command Finish"
 msgstr "Уведомяване при завършване на следващата команда"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:277 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
 msgid "Clear"
 msgstr "Изчисти"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:282 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
 msgid "Reset"
 msgstr "Нулирай"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:289 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
 msgid "Split"
 msgstr "Раздели"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:292 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Change Title…"
 msgstr "Промени заглавие…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:297 src/apprt/gtk/ui/1.5/window.blp:177
+#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
 #: src/apprt/gtk/ui/1.5/window.blp:250
 msgid "Split Up"
 msgstr "Раздели нагоре"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:303 src/apprt/gtk/ui/1.5/window.blp:182
+#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
 #: src/apprt/gtk/ui/1.5/window.blp:255
 msgid "Split Down"
 msgstr "Раздели надолу"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:309 src/apprt/gtk/ui/1.5/window.blp:187
+#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
 #: src/apprt/gtk/ui/1.5/window.blp:260
 msgid "Split Left"
 msgstr "Раздели наляво"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:315 src/apprt/gtk/ui/1.5/window.blp:192
+#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
 #: src/apprt/gtk/ui/1.5/window.blp:265
 msgid "Split Right"
 msgstr "Раздели надясно"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:321
+#: src/apprt/gtk/ui/1.2/surface.blp:323
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:327
+#: src/apprt/gtk/ui/1.2/surface.blp:329
 msgid "Tab"
 msgstr "Раздел"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:330 src/apprt/gtk/ui/1.5/window.blp:224
+#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
 #: src/apprt/gtk/ui/1.5/window.blp:320
 msgid "Change Tab Title…"
 msgstr "Смени името на таба…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:335 src/apprt/gtk/ui/1.5/window.blp:57
+#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
 msgid "New Tab"
 msgstr "Нов раздел"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:340 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
 msgid "Close Tab"
 msgstr "Затвори раздел"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:347
+#: src/apprt/gtk/ui/1.2/surface.blp:349
 msgid "Window"
 msgstr "Прозорец"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:350 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
 msgid "New Window"
 msgstr "Нов прозорец"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:355 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
 msgid "Close Window"
 msgstr "Затвори прозорец"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:363
+#: src/apprt/gtk/ui/1.2/surface.blp:365
 msgid "Config"
 msgstr "Конфигурация"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:366 src/apprt/gtk/ui/1.5/window.blp:295
+#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
 msgid "Open Configuration"
 msgstr "Отвори конфигурацията"
 
@@ -242,7 +242,7 @@ msgstr "Командна палитра"
 msgid "Terminal Inspector"
 msgstr "Инспектор на терминала"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1772
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
 msgid "About Ghostty"
 msgstr "За Ghostty"
 
@@ -253,6 +253,18 @@ msgstr "Изход"
 #: src/apprt/gtk/ui/1.5/command-palette.blp:17
 msgid "Execute a command…"
 msgstr "Изпълни команда…"
+
+#: src/apprt/gtk/class/application.zig:1708
+msgid "The keybind was revoked by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1710
+msgid "The keybind was denied by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1721
+msgid "Global keybind unavailable"
+msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
 msgid ""
@@ -314,15 +326,15 @@ msgstr "Всички терминални сесии в този прозоре�
 msgid "The currently running process in this split will be terminated."
 msgstr "Текущият процес в това разделяне ще бъде прекратен."
 
-#: src/apprt/gtk/class/surface.zig:1141
+#: src/apprt/gtk/class/surface.zig:1170
 msgid "Command Finished"
 msgstr "Командата завърши"
 
-#: src/apprt/gtk/class/surface.zig:1142
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Succeeded"
 msgstr "Командата завърши успешно"
 
-#: src/apprt/gtk/class/surface.zig:1143
+#: src/apprt/gtk/class/surface.zig:1172
 msgid "Command Failed"
 msgstr "Командата завърши неуспешно"
 
@@ -342,18 +354,18 @@ msgstr "Промяна на заглавието на терминала"
 msgid "Change Tab Title"
 msgstr "Смени името на таба"
 
-#: src/apprt/gtk/class/window.zig:1067
+#: src/apprt/gtk/class/window.zig:1102
 msgid "Reloaded the configuration"
 msgstr "Конфигурацията е презаредена"
 
-#: src/apprt/gtk/class/window.zig:1611
+#: src/apprt/gtk/class/window.zig:1705
 msgid "Copied to clipboard"
 msgstr "Копирано в клипборда"
 
-#: src/apprt/gtk/class/window.zig:1613
+#: src/apprt/gtk/class/window.zig:1707
 msgid "Cleared clipboard"
 msgstr "Клипбордът е изчистен"
 
-#: src/apprt/gtk/class/window.zig:1753
+#: src/apprt/gtk/class/window.zig:1847
 msgid "Ghostty Developers"
 msgstr "Разработчици на Ghostty"

--- a/po/ca.po
+++ b/po/ca.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-03-25 16:24-0700\n"
+"POT-Creation-Date: 2026-07-26 04:59+0200\n"
 "PO-Revision-Date: 2025-08-24 19:22+0200\n"
 "Last-Translator: Kristofer Soler "
 "<31729650+KristoferSoler@users.noreply.github.com>\n"
@@ -76,7 +76,7 @@ msgid "Ignore"
 msgstr "Ignora"
 
 #: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
 msgid "Reload Configuration"
 msgstr "Carrega la configuració"
 
@@ -112,7 +112,7 @@ msgstr "Oh, no."
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "No s'ha pogut obtenir un context OpenGL per al renderitzat."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:97
+#: src/apprt/gtk/ui/1.2/surface.blp:99
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -122,97 +122,97 @@ msgstr ""
 "i desplaçar-te pel contingut, però no s'enviaran esdeveniments d'entrada a "
 "l'aplicació en execució."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:107
+#: src/apprt/gtk/ui/1.2/surface.blp:109
 msgid "Read-only"
 msgstr "Només lectura"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:260 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
 msgid "Copy"
 msgstr "Copia"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:265 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
 msgid "Paste"
 msgstr "Enganxa"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:270
+#: src/apprt/gtk/ui/1.2/surface.blp:272
 msgid "Notify on Next Command Finish"
 msgstr "Notifica en finalitzar la propera comanda"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:277 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
 msgid "Clear"
 msgstr "Neteja"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:282 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
 msgid "Reset"
 msgstr "Reinicia"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:289 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
 msgid "Split"
 msgstr "Divideix"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:292 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Change Title…"
 msgstr "Canvia el títol…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:297 src/apprt/gtk/ui/1.5/window.blp:177
+#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
 #: src/apprt/gtk/ui/1.5/window.blp:250
 msgid "Split Up"
 msgstr "Divideix cap amunt"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:303 src/apprt/gtk/ui/1.5/window.blp:182
+#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
 #: src/apprt/gtk/ui/1.5/window.blp:255
 msgid "Split Down"
 msgstr "Divideix cap avall"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:309 src/apprt/gtk/ui/1.5/window.blp:187
+#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
 #: src/apprt/gtk/ui/1.5/window.blp:260
 msgid "Split Left"
 msgstr "Divideix a l'esquerra"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:315 src/apprt/gtk/ui/1.5/window.blp:192
+#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
 #: src/apprt/gtk/ui/1.5/window.blp:265
 msgid "Split Right"
 msgstr "Divideix a la dreta"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:321
+#: src/apprt/gtk/ui/1.2/surface.blp:323
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:327
+#: src/apprt/gtk/ui/1.2/surface.blp:329
 msgid "Tab"
 msgstr "Pestanya"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:330 src/apprt/gtk/ui/1.5/window.blp:224
+#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
 #: src/apprt/gtk/ui/1.5/window.blp:320
 msgid "Change Tab Title…"
 msgstr "Canvia el títol de la pestanya…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:335 src/apprt/gtk/ui/1.5/window.blp:57
+#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
 msgid "New Tab"
 msgstr "Nova pestanya"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:340 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
 msgid "Close Tab"
 msgstr "Tanca la pestanya"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:347
+#: src/apprt/gtk/ui/1.2/surface.blp:349
 msgid "Window"
 msgstr "Finestra"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:350 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
 msgid "New Window"
 msgstr "Nova finestra"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:355 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
 msgid "Close Window"
 msgstr "Tanca la finestra"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:363
+#: src/apprt/gtk/ui/1.2/surface.blp:365
 msgid "Config"
 msgstr "Configuració"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:366 src/apprt/gtk/ui/1.5/window.blp:295
+#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
 msgid "Open Configuration"
 msgstr "Obre la configuració"
 
@@ -244,7 +244,7 @@ msgstr "Paleta de comandes"
 msgid "Terminal Inspector"
 msgstr "Inspector de terminal"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1772
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
 msgid "About Ghostty"
 msgstr "Sobre Ghostty"
 
@@ -255,6 +255,18 @@ msgstr "Surt"
 #: src/apprt/gtk/ui/1.5/command-palette.blp:17
 msgid "Execute a command…"
 msgstr "Executa una ordre…"
+
+#: src/apprt/gtk/class/application.zig:1708
+msgid "The keybind was revoked by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1710
+msgid "The keybind was denied by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1721
+msgid "Global keybind unavailable"
+msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
 msgid ""
@@ -316,15 +328,15 @@ msgstr "Totes les sessions del terminal en aquesta finestra es tancaran."
 msgid "The currently running process in this split will be terminated."
 msgstr "El procés actualment en execució en aquesta divisió es tancarà."
 
-#: src/apprt/gtk/class/surface.zig:1141
+#: src/apprt/gtk/class/surface.zig:1170
 msgid "Command Finished"
 msgstr "Comanda finalitzada"
 
-#: src/apprt/gtk/class/surface.zig:1142
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Succeeded"
 msgstr "Comanda completada amb èxit"
 
-#: src/apprt/gtk/class/surface.zig:1143
+#: src/apprt/gtk/class/surface.zig:1172
 msgid "Command Failed"
 msgstr "Comanda fallida"
 
@@ -344,18 +356,18 @@ msgstr "Canvia el títol del terminal"
 msgid "Change Tab Title"
 msgstr "Canvia el títol de la pestanya"
 
-#: src/apprt/gtk/class/window.zig:1067
+#: src/apprt/gtk/class/window.zig:1102
 msgid "Reloaded the configuration"
 msgstr "S'ha tornat a carregar la configuració"
 
-#: src/apprt/gtk/class/window.zig:1611
+#: src/apprt/gtk/class/window.zig:1705
 msgid "Copied to clipboard"
 msgstr "Copiat al porta-retalls"
 
-#: src/apprt/gtk/class/window.zig:1613
+#: src/apprt/gtk/class/window.zig:1707
 msgid "Cleared clipboard"
 msgstr "Porta-retalls netejat"
 
-#: src/apprt/gtk/class/window.zig:1753
+#: src/apprt/gtk/class/window.zig:1847
 msgid "Ghostty Developers"
 msgstr "Desenvolupadors de Ghostty"

--- a/po/com.mitchellh.ghostty.pot
+++ b/po/com.mitchellh.ghostty.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-03-25 16:24-0700\n"
+"POT-Creation-Date: 2026-07-26 04:59+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -72,7 +72,7 @@ msgid "Ignore"
 msgstr ""
 
 #: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
 msgid "Reload Configuration"
 msgstr ""
 
@@ -106,104 +106,104 @@ msgstr ""
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:97
+#: src/apprt/gtk/ui/1.2/surface.blp:99
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
 "application."
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:107
+#: src/apprt/gtk/ui/1.2/surface.blp:109
 msgid "Read-only"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:260 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
 msgid "Copy"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:265 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
 msgid "Paste"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:270
+#: src/apprt/gtk/ui/1.2/surface.blp:272
 msgid "Notify on Next Command Finish"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:277 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
 msgid "Clear"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:282 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
 msgid "Reset"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:289 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
 msgid "Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:292 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Change Title…"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:297 src/apprt/gtk/ui/1.5/window.blp:177
+#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
 #: src/apprt/gtk/ui/1.5/window.blp:250
 msgid "Split Up"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:303 src/apprt/gtk/ui/1.5/window.blp:182
+#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
 #: src/apprt/gtk/ui/1.5/window.blp:255
 msgid "Split Down"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:309 src/apprt/gtk/ui/1.5/window.blp:187
+#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
 #: src/apprt/gtk/ui/1.5/window.blp:260
 msgid "Split Left"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:315 src/apprt/gtk/ui/1.5/window.blp:192
+#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
 #: src/apprt/gtk/ui/1.5/window.blp:265
 msgid "Split Right"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:321
+#: src/apprt/gtk/ui/1.2/surface.blp:323
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:327
+#: src/apprt/gtk/ui/1.2/surface.blp:329
 msgid "Tab"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:330 src/apprt/gtk/ui/1.5/window.blp:224
+#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
 #: src/apprt/gtk/ui/1.5/window.blp:320
 msgid "Change Tab Title…"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:335 src/apprt/gtk/ui/1.5/window.blp:57
+#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
 msgid "New Tab"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:340 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
 msgid "Close Tab"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:347
+#: src/apprt/gtk/ui/1.2/surface.blp:349
 msgid "Window"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:350 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
 msgid "New Window"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:355 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
 msgid "Close Window"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:363
+#: src/apprt/gtk/ui/1.2/surface.blp:365
 msgid "Config"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:366 src/apprt/gtk/ui/1.5/window.blp:295
+#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
 msgid "Open Configuration"
 msgstr ""
 
@@ -235,7 +235,7 @@ msgstr ""
 msgid "Terminal Inspector"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1772
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
 msgid "About Ghostty"
 msgstr ""
 
@@ -245,6 +245,18 @@ msgstr ""
 
 #: src/apprt/gtk/ui/1.5/command-palette.blp:17
 msgid "Execute a command…"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1708
+msgid "The keybind was revoked by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1710
+msgid "The keybind was denied by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1721
+msgid "Global keybind unavailable"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -301,15 +313,15 @@ msgstr ""
 msgid "The currently running process in this split will be terminated."
 msgstr ""
 
-#: src/apprt/gtk/class/surface.zig:1141
+#: src/apprt/gtk/class/surface.zig:1170
 msgid "Command Finished"
 msgstr ""
 
-#: src/apprt/gtk/class/surface.zig:1142
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Succeeded"
 msgstr ""
 
-#: src/apprt/gtk/class/surface.zig:1143
+#: src/apprt/gtk/class/surface.zig:1172
 msgid "Command Failed"
 msgstr ""
 
@@ -329,18 +341,18 @@ msgstr ""
 msgid "Change Tab Title"
 msgstr ""
 
-#: src/apprt/gtk/class/window.zig:1067
+#: src/apprt/gtk/class/window.zig:1102
 msgid "Reloaded the configuration"
 msgstr ""
 
-#: src/apprt/gtk/class/window.zig:1611
+#: src/apprt/gtk/class/window.zig:1705
 msgid "Copied to clipboard"
 msgstr ""
 
-#: src/apprt/gtk/class/window.zig:1613
+#: src/apprt/gtk/class/window.zig:1707
 msgid "Cleared clipboard"
 msgstr ""
 
-#: src/apprt/gtk/class/window.zig:1753
+#: src/apprt/gtk/class/window.zig:1847
 msgid "Ghostty Developers"
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-03-25 16:24-0700\n"
+"POT-Creation-Date: 2026-07-26 04:59+0200\n"
 "PO-Revision-Date: 2026-02-13 08:05+0100\n"
 "Last-Translator: Klaus Hipp <khipp@users.noreply.github.com>\n"
 "Language-Team: German <translation-team-de@lists.sourceforge.net>\n"
@@ -79,7 +79,7 @@ msgid "Ignore"
 msgstr "Ignorieren"
 
 #: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
 msgid "Reload Configuration"
 msgstr "Konfiguration neu laden"
 
@@ -115,7 +115,7 @@ msgstr "Oh nein."
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "Es kann kein OpenGL-Kontext für das Rendering abgerufen werden."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:97
+#: src/apprt/gtk/ui/1.2/surface.blp:99
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -125,97 +125,97 @@ msgstr ""
 "Inhalt weiterhin anzeigen, auswählen und durchscrollen, es werden jedoch "
 "keine Eingabeereignisse an die laufende Anwendung gesendet."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:107
+#: src/apprt/gtk/ui/1.2/surface.blp:109
 msgid "Read-only"
 msgstr "Schreibgeschützt"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:260 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
 msgid "Copy"
 msgstr "Kopieren"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:265 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
 msgid "Paste"
 msgstr "Einfügen"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:270
+#: src/apprt/gtk/ui/1.2/surface.blp:272
 msgid "Notify on Next Command Finish"
 msgstr "Bei Abschluss des nächsten Befehls benachrichtigen"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:277 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
 msgid "Clear"
 msgstr "Leeren"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:282 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
 msgid "Reset"
 msgstr "Zurücksetzen"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:289 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
 msgid "Split"
 msgstr "Fenster teilen"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:292 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Change Title…"
 msgstr "Titel bearbeiten…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:297 src/apprt/gtk/ui/1.5/window.blp:177
+#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
 #: src/apprt/gtk/ui/1.5/window.blp:250
 msgid "Split Up"
 msgstr "Fenster nach oben teilen"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:303 src/apprt/gtk/ui/1.5/window.blp:182
+#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
 #: src/apprt/gtk/ui/1.5/window.blp:255
 msgid "Split Down"
 msgstr "Fenster nach unten teilen"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:309 src/apprt/gtk/ui/1.5/window.blp:187
+#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
 #: src/apprt/gtk/ui/1.5/window.blp:260
 msgid "Split Left"
 msgstr "Fenter nach links teilen"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:315 src/apprt/gtk/ui/1.5/window.blp:192
+#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
 #: src/apprt/gtk/ui/1.5/window.blp:265
 msgid "Split Right"
 msgstr "Fenster nach rechts teilen"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:321
+#: src/apprt/gtk/ui/1.2/surface.blp:323
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:327
+#: src/apprt/gtk/ui/1.2/surface.blp:329
 msgid "Tab"
 msgstr "Tab"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:330 src/apprt/gtk/ui/1.5/window.blp:224
+#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
 #: src/apprt/gtk/ui/1.5/window.blp:320
 msgid "Change Tab Title…"
 msgstr "Tab-Titel ändern…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:335 src/apprt/gtk/ui/1.5/window.blp:57
+#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
 msgid "New Tab"
 msgstr "Neuer Tab"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:340 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
 msgid "Close Tab"
 msgstr "Tab schließen"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:347
+#: src/apprt/gtk/ui/1.2/surface.blp:349
 msgid "Window"
 msgstr "Fenster"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:350 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
 msgid "New Window"
 msgstr "Neues Fenster"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:355 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
 msgid "Close Window"
 msgstr "Fenster schließen"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:363
+#: src/apprt/gtk/ui/1.2/surface.blp:365
 msgid "Config"
 msgstr "Konfiguration"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:366 src/apprt/gtk/ui/1.5/window.blp:295
+#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
 msgid "Open Configuration"
 msgstr "Konfiguration öffnen"
 
@@ -247,7 +247,7 @@ msgstr "Befehlspalette"
 msgid "Terminal Inspector"
 msgstr "Terminalinspektor"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1772
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
 msgid "About Ghostty"
 msgstr "Über Ghostty"
 
@@ -258,6 +258,18 @@ msgstr "Beenden"
 #: src/apprt/gtk/ui/1.5/command-palette.blp:17
 msgid "Execute a command…"
 msgstr "Einen Befehl ausführen…"
+
+#: src/apprt/gtk/class/application.zig:1708
+msgid "The keybind was revoked by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1710
+msgid "The keybind was denied by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1721
+msgid "Global keybind unavailable"
+msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
 msgid ""
@@ -319,15 +331,15 @@ msgstr "Alle Terminalsitzungen in diesem Fenster werden beendet."
 msgid "The currently running process in this split will be terminated."
 msgstr "Der aktuell laufende Prozess in diesem geteilten Fenster wird beendet."
 
-#: src/apprt/gtk/class/surface.zig:1141
+#: src/apprt/gtk/class/surface.zig:1170
 msgid "Command Finished"
 msgstr "Befehl abgeschlossen"
 
-#: src/apprt/gtk/class/surface.zig:1142
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Succeeded"
 msgstr "Befehl erfolgreich"
 
-#: src/apprt/gtk/class/surface.zig:1143
+#: src/apprt/gtk/class/surface.zig:1172
 msgid "Command Failed"
 msgstr "Befehl fehlgeschlagen"
 
@@ -347,18 +359,18 @@ msgstr "Terminaltitel bearbeiten"
 msgid "Change Tab Title"
 msgstr "Tab-Titel ändern"
 
-#: src/apprt/gtk/class/window.zig:1067
+#: src/apprt/gtk/class/window.zig:1102
 msgid "Reloaded the configuration"
 msgstr "Konfiguration wurde neu geladen"
 
-#: src/apprt/gtk/class/window.zig:1611
+#: src/apprt/gtk/class/window.zig:1705
 msgid "Copied to clipboard"
 msgstr "In die Zwischenablage kopiert"
 
-#: src/apprt/gtk/class/window.zig:1613
+#: src/apprt/gtk/class/window.zig:1707
 msgid "Cleared clipboard"
 msgstr "Zwischenablage geleert"
 
-#: src/apprt/gtk/class/window.zig:1753
+#: src/apprt/gtk/class/window.zig:1847
 msgid "Ghostty Developers"
 msgstr "Ghostty-Entwickler"

--- a/po/es_AR.po
+++ b/po/es_AR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-03-25 16:24-0700\n"
+"POT-Creation-Date: 2026-07-26 04:59+0200\n"
 "PO-Revision-Date: 2026-02-19 13:34-0300\n"
 "Last-Translator: Alan Moyano <alanmoyano203@gmail.com>\n"
 "Language-Team: Argentinian <es@tp.org.es>\n"
@@ -74,7 +74,7 @@ msgid "Ignore"
 msgstr "Ignorar"
 
 #: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
 msgid "Reload Configuration"
 msgstr "Recargar configuración"
 
@@ -110,7 +110,7 @@ msgstr "Uy, no."
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "No se pudo obtener un contexto de OpenGL para el renderizado"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:97
+#: src/apprt/gtk/ui/1.2/surface.blp:99
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -120,97 +120,97 @@ msgstr ""
 "desplazarte por el contenido, pero no se enviarán los eventos de entrada a "
 "la aplicación en ejecución."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:107
+#: src/apprt/gtk/ui/1.2/surface.blp:109
 msgid "Read-only"
 msgstr "Solo lectura"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:260 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
 msgid "Copy"
 msgstr "Copiar"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:265 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
 msgid "Paste"
 msgstr "Pegar"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:270
+#: src/apprt/gtk/ui/1.2/surface.blp:272
 msgid "Notify on Next Command Finish"
 msgstr "Notificar al finalizar el siguiente comando"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:277 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
 msgid "Clear"
 msgstr "Limpiar"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:282 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
 msgid "Reset"
 msgstr "Reiniciar"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:289 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
 msgid "Split"
 msgstr "Dividir"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:292 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Change Title…"
 msgstr "Cambiar título…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:297 src/apprt/gtk/ui/1.5/window.blp:177
+#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
 #: src/apprt/gtk/ui/1.5/window.blp:250
 msgid "Split Up"
 msgstr "Dividir arriba"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:303 src/apprt/gtk/ui/1.5/window.blp:182
+#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
 #: src/apprt/gtk/ui/1.5/window.blp:255
 msgid "Split Down"
 msgstr "Dividir abajo"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:309 src/apprt/gtk/ui/1.5/window.blp:187
+#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
 #: src/apprt/gtk/ui/1.5/window.blp:260
 msgid "Split Left"
 msgstr "Dividir a la izquierda"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:315 src/apprt/gtk/ui/1.5/window.blp:192
+#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
 #: src/apprt/gtk/ui/1.5/window.blp:265
 msgid "Split Right"
 msgstr "Dividir a la derecha"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:321
+#: src/apprt/gtk/ui/1.2/surface.blp:323
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:327
+#: src/apprt/gtk/ui/1.2/surface.blp:329
 msgid "Tab"
 msgstr "Pestaña"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:330 src/apprt/gtk/ui/1.5/window.blp:224
+#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
 #: src/apprt/gtk/ui/1.5/window.blp:320
 msgid "Change Tab Title…"
 msgstr "Cambiar título de la pestaña…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:335 src/apprt/gtk/ui/1.5/window.blp:57
+#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
 msgid "New Tab"
 msgstr "Nueva pestaña"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:340 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
 msgid "Close Tab"
 msgstr "Cerrar pestaña"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:347
+#: src/apprt/gtk/ui/1.2/surface.blp:349
 msgid "Window"
 msgstr "Ventana"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:350 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
 msgid "New Window"
 msgstr "Nueva ventana"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:355 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
 msgid "Close Window"
 msgstr "Cerrar ventana"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:363
+#: src/apprt/gtk/ui/1.2/surface.blp:365
 msgid "Config"
 msgstr "Configuración"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:366 src/apprt/gtk/ui/1.5/window.blp:295
+#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
 msgid "Open Configuration"
 msgstr "Abrir configuración"
 
@@ -242,7 +242,7 @@ msgstr "Paleta de comandos"
 msgid "Terminal Inspector"
 msgstr "Inspector de la terminal"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1772
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
 msgid "About Ghostty"
 msgstr "Acerca de Ghostty"
 
@@ -253,6 +253,18 @@ msgstr "Salir"
 #: src/apprt/gtk/ui/1.5/command-palette.blp:17
 msgid "Execute a command…"
 msgstr "Ejecutar un comando…"
+
+#: src/apprt/gtk/class/application.zig:1708
+msgid "The keybind was revoked by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1710
+msgid "The keybind was denied by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1721
+msgid "Global keybind unavailable"
+msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
 msgid ""
@@ -314,15 +326,15 @@ msgstr "Todas las sesiones de terminal en esta ventana serán terminadas."
 msgid "The currently running process in this split will be terminated."
 msgstr "El proceso actualmente en ejecución en esta división será terminado."
 
-#: src/apprt/gtk/class/surface.zig:1141
+#: src/apprt/gtk/class/surface.zig:1170
 msgid "Command Finished"
 msgstr "Comando finalizado"
 
-#: src/apprt/gtk/class/surface.zig:1142
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Succeeded"
 msgstr "Comando ejecutado correctamente"
 
-#: src/apprt/gtk/class/surface.zig:1143
+#: src/apprt/gtk/class/surface.zig:1172
 msgid "Command Failed"
 msgstr "Comando fallido"
 
@@ -342,18 +354,18 @@ msgstr "Cambiar título de la terminal"
 msgid "Change Tab Title"
 msgstr "Cambiar título de la pestaña"
 
-#: src/apprt/gtk/class/window.zig:1067
+#: src/apprt/gtk/class/window.zig:1102
 msgid "Reloaded the configuration"
 msgstr "Configuración recargada"
 
-#: src/apprt/gtk/class/window.zig:1611
+#: src/apprt/gtk/class/window.zig:1705
 msgid "Copied to clipboard"
 msgstr "Copiado al portapapeles"
 
-#: src/apprt/gtk/class/window.zig:1613
+#: src/apprt/gtk/class/window.zig:1707
 msgid "Cleared clipboard"
 msgstr "Portapapeles limpiado"
 
-#: src/apprt/gtk/class/window.zig:1753
+#: src/apprt/gtk/class/window.zig:1847
 msgid "Ghostty Developers"
 msgstr "Desarrolladores de Ghostty"

--- a/po/es_BO.po
+++ b/po/es_BO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-03-25 16:24-0700\n"
+"POT-Creation-Date: 2026-07-26 04:59+0200\n"
 "PO-Revision-Date: 2026-02-12 17:46+0200\n"
 "Last-Translator: Miguel Peredo <miguelp@quientienemail.com>\n"
 "Language-Team: Spanish <es@tp.org.es>\n"
@@ -74,7 +74,7 @@ msgid "Ignore"
 msgstr "Ignorar"
 
 #: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
 msgid "Reload Configuration"
 msgstr "Recargar configuración"
 
@@ -110,7 +110,7 @@ msgstr "¡Epa!"
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "No se puede iniciar OpenGL para rendering."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:97
+#: src/apprt/gtk/ui/1.2/surface.blp:99
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -120,97 +120,97 @@ msgstr ""
 "través del contenido, pero ninguna entrada (evento) va a ser enviada a la "
 "aplicación que se está ejecutando."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:107
+#: src/apprt/gtk/ui/1.2/surface.blp:109
 msgid "Read-only"
 msgstr "Solo lectura"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:260 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
 msgid "Copy"
 msgstr "Copiar"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:265 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
 msgid "Paste"
 msgstr "Pegar"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:270
+#: src/apprt/gtk/ui/1.2/surface.blp:272
 msgid "Notify on Next Command Finish"
 msgstr "Notificar cuando el próximo comando finalice"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:277 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
 msgid "Clear"
 msgstr "Limpiar"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:282 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
 msgid "Reset"
 msgstr "Reiniciar"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:289 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
 msgid "Split"
 msgstr "Dividir"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:292 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Change Title…"
 msgstr "Cambiar título…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:297 src/apprt/gtk/ui/1.5/window.blp:177
+#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
 #: src/apprt/gtk/ui/1.5/window.blp:250
 msgid "Split Up"
 msgstr "Dividir arriba"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:303 src/apprt/gtk/ui/1.5/window.blp:182
+#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
 #: src/apprt/gtk/ui/1.5/window.blp:255
 msgid "Split Down"
 msgstr "Dividir abajo"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:309 src/apprt/gtk/ui/1.5/window.blp:187
+#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
 #: src/apprt/gtk/ui/1.5/window.blp:260
 msgid "Split Left"
 msgstr "Dividir a la izquierda"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:315 src/apprt/gtk/ui/1.5/window.blp:192
+#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
 #: src/apprt/gtk/ui/1.5/window.blp:265
 msgid "Split Right"
 msgstr "Dividir a la derecha"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:321
+#: src/apprt/gtk/ui/1.2/surface.blp:323
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:327
+#: src/apprt/gtk/ui/1.2/surface.blp:329
 msgid "Tab"
 msgstr "Pestaña"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:330 src/apprt/gtk/ui/1.5/window.blp:224
+#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
 #: src/apprt/gtk/ui/1.5/window.blp:320
 msgid "Change Tab Title…"
 msgstr "Cambiar el título de la pestaña…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:335 src/apprt/gtk/ui/1.5/window.blp:57
+#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
 msgid "New Tab"
 msgstr "Nueva pestaña"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:340 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
 msgid "Close Tab"
 msgstr "Cerrar pestaña"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:347
+#: src/apprt/gtk/ui/1.2/surface.blp:349
 msgid "Window"
 msgstr "Ventana"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:350 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
 msgid "New Window"
 msgstr "Nueva ventana"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:355 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
 msgid "Close Window"
 msgstr "Cerrar ventana"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:363
+#: src/apprt/gtk/ui/1.2/surface.blp:365
 msgid "Config"
 msgstr "Configuración"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:366 src/apprt/gtk/ui/1.5/window.blp:295
+#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
 msgid "Open Configuration"
 msgstr "Abrir configuración"
 
@@ -242,7 +242,7 @@ msgstr "Paleta de comandos"
 msgid "Terminal Inspector"
 msgstr "Inspector de la terminal"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1772
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
 msgid "About Ghostty"
 msgstr "Acerca de Ghostty"
 
@@ -253,6 +253,18 @@ msgstr "Salir"
 #: src/apprt/gtk/ui/1.5/command-palette.blp:17
 msgid "Execute a command…"
 msgstr "Ejecutar comando…"
+
+#: src/apprt/gtk/class/application.zig:1708
+msgid "The keybind was revoked by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1710
+msgid "The keybind was denied by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1721
+msgid "Global keybind unavailable"
+msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
 msgid ""
@@ -314,15 +326,15 @@ msgstr "Todas las sesiones de terminal en esta ventana serán terminadas."
 msgid "The currently running process in this split will be terminated."
 msgstr "El proceso actualmente en ejecución en esta división será terminado."
 
-#: src/apprt/gtk/class/surface.zig:1141
+#: src/apprt/gtk/class/surface.zig:1170
 msgid "Command Finished"
 msgstr "Comando finalizado"
 
-#: src/apprt/gtk/class/surface.zig:1142
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Succeeded"
 msgstr "Comando exitoso"
 
-#: src/apprt/gtk/class/surface.zig:1143
+#: src/apprt/gtk/class/surface.zig:1172
 msgid "Command Failed"
 msgstr "Comando fallido"
 
@@ -342,18 +354,18 @@ msgstr "Cambiar el título de la terminal"
 msgid "Change Tab Title"
 msgstr "Cambiar el título de la pestaña"
 
-#: src/apprt/gtk/class/window.zig:1067
+#: src/apprt/gtk/class/window.zig:1102
 msgid "Reloaded the configuration"
 msgstr "Configuración recargada"
 
-#: src/apprt/gtk/class/window.zig:1611
+#: src/apprt/gtk/class/window.zig:1705
 msgid "Copied to clipboard"
 msgstr "Copiado al portapapeles"
 
-#: src/apprt/gtk/class/window.zig:1613
+#: src/apprt/gtk/class/window.zig:1707
 msgid "Cleared clipboard"
 msgstr "El portapapeles está limpio"
 
-#: src/apprt/gtk/class/window.zig:1753
+#: src/apprt/gtk/class/window.zig:1847
 msgid "Ghostty Developers"
 msgstr "Desarrolladores de Ghostty"

--- a/po/es_ES.po
+++ b/po/es_ES.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-03-25 16:24-0700\n"
+"POT-Creation-Date: 2026-07-26 04:59+0200\n"
 "PO-Revision-Date: 2026-02-18 10:57+0100\n"
 "Last-Translator: José Miguel Sarasola <alosarjos@gmail.com>\n"
 "Language-Team: \n"
@@ -75,7 +75,7 @@ msgid "Ignore"
 msgstr "Ignorar"
 
 #: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
 msgid "Reload Configuration"
 msgstr "Recargar configuración"
 
@@ -111,7 +111,7 @@ msgstr "Oh, no."
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "No se pudo obtener un contexto de OpenGL para el renderizado."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:97
+#: src/apprt/gtk/ui/1.2/surface.blp:99
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -121,97 +121,97 @@ msgstr ""
 "scroll del contenido, pero no se enviarán eventos de entrada a la aplicación "
 "en ejecución."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:107
+#: src/apprt/gtk/ui/1.2/surface.blp:109
 msgid "Read-only"
 msgstr "Solo lectura"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:260 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
 msgid "Copy"
 msgstr "Copiar"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:265 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
 msgid "Paste"
 msgstr "Pegar"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:270
+#: src/apprt/gtk/ui/1.2/surface.blp:272
 msgid "Notify on Next Command Finish"
 msgstr "Notificar al finalizar el siguiente comando"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:277 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
 msgid "Clear"
 msgstr "Limpiar"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:282 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
 msgid "Reset"
 msgstr "Reiniciar"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:289 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
 msgid "Split"
 msgstr "Dividir"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:292 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Change Title…"
 msgstr "Cambiar título…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:297 src/apprt/gtk/ui/1.5/window.blp:177
+#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
 #: src/apprt/gtk/ui/1.5/window.blp:250
 msgid "Split Up"
 msgstr "Dividir arriba"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:303 src/apprt/gtk/ui/1.5/window.blp:182
+#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
 #: src/apprt/gtk/ui/1.5/window.blp:255
 msgid "Split Down"
 msgstr "Dividir abajo"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:309 src/apprt/gtk/ui/1.5/window.blp:187
+#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
 #: src/apprt/gtk/ui/1.5/window.blp:260
 msgid "Split Left"
 msgstr "Dividir a la izquierda"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:315 src/apprt/gtk/ui/1.5/window.blp:192
+#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
 #: src/apprt/gtk/ui/1.5/window.blp:265
 msgid "Split Right"
 msgstr "Dividir a la derecha"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:321
+#: src/apprt/gtk/ui/1.2/surface.blp:323
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:327
+#: src/apprt/gtk/ui/1.2/surface.blp:329
 msgid "Tab"
 msgstr "Pestaña"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:330 src/apprt/gtk/ui/1.5/window.blp:224
+#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
 #: src/apprt/gtk/ui/1.5/window.blp:320
 msgid "Change Tab Title…"
 msgstr "Cambiar título de la pestaña…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:335 src/apprt/gtk/ui/1.5/window.blp:57
+#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
 msgid "New Tab"
 msgstr "Nueva pestaña"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:340 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
 msgid "Close Tab"
 msgstr "Cerrar pestaña"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:347
+#: src/apprt/gtk/ui/1.2/surface.blp:349
 msgid "Window"
 msgstr "Ventana"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:350 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
 msgid "New Window"
 msgstr "Nueva ventana"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:355 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
 msgid "Close Window"
 msgstr "Cerrar ventana"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:363
+#: src/apprt/gtk/ui/1.2/surface.blp:365
 msgid "Config"
 msgstr "Configuración"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:366 src/apprt/gtk/ui/1.5/window.blp:295
+#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
 msgid "Open Configuration"
 msgstr "Abrir configuración"
 
@@ -243,7 +243,7 @@ msgstr "Paleta de comandos"
 msgid "Terminal Inspector"
 msgstr "Inspector de terminal"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1772
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
 msgid "About Ghostty"
 msgstr "Acerca de Ghostty"
 
@@ -254,6 +254,18 @@ msgstr "Salir"
 #: src/apprt/gtk/ui/1.5/command-palette.blp:17
 msgid "Execute a command…"
 msgstr "Ejecutar un comando…"
+
+#: src/apprt/gtk/class/application.zig:1708
+msgid "The keybind was revoked by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1710
+msgid "The keybind was denied by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1721
+msgid "Global keybind unavailable"
+msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
 msgid ""
@@ -315,15 +327,15 @@ msgstr "Todas las sesiones del terminal en esta ventana serán finalizadas."
 msgid "The currently running process in this split will be terminated."
 msgstr "El proceso ejecutándose en esta división será finalizado."
 
-#: src/apprt/gtk/class/surface.zig:1141
+#: src/apprt/gtk/class/surface.zig:1170
 msgid "Command Finished"
 msgstr "Comando finalizado"
 
-#: src/apprt/gtk/class/surface.zig:1142
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Succeeded"
 msgstr "Comando completado"
 
-#: src/apprt/gtk/class/surface.zig:1143
+#: src/apprt/gtk/class/surface.zig:1172
 msgid "Command Failed"
 msgstr "Comando fallido"
 
@@ -343,18 +355,18 @@ msgstr "Cambiar el título del terminal"
 msgid "Change Tab Title"
 msgstr "Cambiar el título de la pestaña"
 
-#: src/apprt/gtk/class/window.zig:1067
+#: src/apprt/gtk/class/window.zig:1102
 msgid "Reloaded the configuration"
 msgstr "Configuración recargada"
 
-#: src/apprt/gtk/class/window.zig:1611
+#: src/apprt/gtk/class/window.zig:1705
 msgid "Copied to clipboard"
 msgstr "Copiado al portapapeles"
 
-#: src/apprt/gtk/class/window.zig:1613
+#: src/apprt/gtk/class/window.zig:1707
 msgid "Cleared clipboard"
 msgstr "Portapapeles vaciado"
 
-#: src/apprt/gtk/class/window.zig:1753
+#: src/apprt/gtk/class/window.zig:1847
 msgid "Ghostty Developers"
 msgstr "Desarrolladores de Ghostty"

--- a/po/eu.po
+++ b/po/eu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-02-17 23:16+0100\n"
+"POT-Creation-Date: 2026-07-26 04:59+0200\n"
 "PO-Revision-Date: 2026-05-01 12:56+0200\n"
 "Last-Translator: Mikel Larreategi <mlarreategi@codesyntax.com>\n"
 "Language-Team: Language eu\n"
@@ -73,7 +73,7 @@ msgid "Ignore"
 msgstr "Baztertu"
 
 #: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:366 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
 msgid "Reload Configuration"
 msgstr "Birkargatu konfigurazioa"
 
@@ -109,7 +109,7 @@ msgstr "Oh, ez!"
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "Ezin izan da OpenGL kontestua erabili."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:97
+#: src/apprt/gtk/ui/1.2/surface.blp:99
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -118,93 +118,97 @@ msgstr ""
 "Terminal hau irakurtzeko moduan dago. Ikusi, aukeratu eta kontestuan zehar "
 "gora eta behera ibili zaitezke, baina ez da sarrera ekintzarik bidaliko."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:107
+#: src/apprt/gtk/ui/1.2/surface.blp:109
 msgid "Read-only"
 msgstr "Irakurtzeko-bakarrik"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:260 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
 msgid "Copy"
 msgstr "Kopiatu"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:265 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
 msgid "Paste"
 msgstr "Itsatsi"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:270
+#: src/apprt/gtk/ui/1.2/surface.blp:272
 msgid "Notify on Next Command Finish"
 msgstr "Jakinarazi hurrengo komandoa amaitzean"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:277 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
 msgid "Clear"
 msgstr "Garbitu"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:282 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
 msgid "Reset"
 msgstr "Berrezarri"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:289 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
 msgid "Split"
 msgstr "Zatitu"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:292 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Change Title…"
 msgstr "Aldatu izenburua…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:297 src/apprt/gtk/ui/1.5/window.blp:177
+#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
 #: src/apprt/gtk/ui/1.5/window.blp:250
 msgid "Split Up"
 msgstr "Zatitu gorantz"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:303 src/apprt/gtk/ui/1.5/window.blp:182
+#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
 #: src/apprt/gtk/ui/1.5/window.blp:255
 msgid "Split Down"
 msgstr "Zatitu beherantz"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:309 src/apprt/gtk/ui/1.5/window.blp:187
+#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
 #: src/apprt/gtk/ui/1.5/window.blp:260
 msgid "Split Left"
 msgstr "Zatitu ezkerrera"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:315 src/apprt/gtk/ui/1.5/window.blp:192
+#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
 #: src/apprt/gtk/ui/1.5/window.blp:265
 msgid "Split Right"
 msgstr "Zatitu eskumara"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:322
+#: src/apprt/gtk/ui/1.2/surface.blp:323
+msgid "Close Split"
+msgstr ""
+
+#: src/apprt/gtk/ui/1.2/surface.blp:329
 msgid "Tab"
 msgstr "Fitxa"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:325 src/apprt/gtk/ui/1.5/window.blp:224
+#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
 #: src/apprt/gtk/ui/1.5/window.blp:320
 msgid "Change Tab Title…"
 msgstr "Aldatu fitxaren izenburua…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:330 src/apprt/gtk/ui/1.5/window.blp:57
+#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
 msgid "New Tab"
 msgstr "Fitxa berria"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:335 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
 msgid "Close Tab"
 msgstr "Itxi fitxa"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:342
+#: src/apprt/gtk/ui/1.2/surface.blp:349
 msgid "Window"
 msgstr "Leihoa"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:345 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
 msgid "New Window"
 msgstr "Leiho berria"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:350 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
 msgid "Close Window"
 msgstr "Itxi leihoa"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:358
+#: src/apprt/gtk/ui/1.2/surface.blp:365
 msgid "Config"
 msgstr "Konfigurazioa"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:361 src/apprt/gtk/ui/1.5/window.blp:295
+#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
 msgid "Open Configuration"
 msgstr "Ireki konfigurazioa"
 
@@ -236,7 +240,7 @@ msgstr "Komando paleta"
 msgid "Terminal Inspector"
 msgstr "Terminal ikuskatzailea"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1727
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
 msgid "About Ghostty"
 msgstr "Ghosttyri buruz"
 
@@ -248,13 +252,24 @@ msgstr "Irten"
 msgid "Execute a command…"
 msgstr "Exekutatu komando bat…"
 
+#: src/apprt/gtk/class/application.zig:1708
+msgid "The keybind was revoked by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1710
+msgid "The keybind was denied by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1721
+msgid "Global keybind unavailable"
+msgstr ""
+
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
 msgid ""
 "An application is attempting to write to the clipboard. The current "
 "clipboard contents are shown below."
 msgstr ""
-"Aplikazio bat arbelean idatzi nahian dabil. Hau da arbelaren uneko "
-"edukia."
+"Aplikazio bat arbelean idatzi nahian dabil. Hau da arbelaren uneko edukia."
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:202
 msgid ""
@@ -308,15 +323,15 @@ msgstr "Leiho honetako terminal saio guztiak itxi egingo dira."
 msgid "The currently running process in this split will be terminated."
 msgstr "Zatikatze honetan martxan dagoen prozesua itxi egingo da."
 
-#: src/apprt/gtk/class/surface.zig:1108
+#: src/apprt/gtk/class/surface.zig:1170
 msgid "Command Finished"
 msgstr "Komandoa amaitu da"
 
-#: src/apprt/gtk/class/surface.zig:1109
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Succeeded"
 msgstr "Komandoa ondo amaitu da"
 
-#: src/apprt/gtk/class/surface.zig:1110
+#: src/apprt/gtk/class/surface.zig:1172
 msgid "Command Failed"
 msgstr "Komandoak huts egin du"
 
@@ -336,18 +351,18 @@ msgstr "Aldatu terminalaren izenburua"
 msgid "Change Tab Title"
 msgstr "Aldatu fitxaren izenburua"
 
-#: src/apprt/gtk/class/window.zig:1007
+#: src/apprt/gtk/class/window.zig:1102
 msgid "Reloaded the configuration"
 msgstr "Konfigurazioa berriz kargatu da"
 
-#: src/apprt/gtk/class/window.zig:1566
+#: src/apprt/gtk/class/window.zig:1705
 msgid "Copied to clipboard"
 msgstr "Arbelera kopiatu da"
 
-#: src/apprt/gtk/class/window.zig:1568
+#: src/apprt/gtk/class/window.zig:1707
 msgid "Cleared clipboard"
 msgstr "Arbela garbitu da"
 
-#: src/apprt/gtk/class/window.zig:1708
+#: src/apprt/gtk/class/window.zig:1847
 msgid "Ghostty Developers"
 msgstr "Ghostty garatzaileak"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-03-25 16:24-0700\n"
+"POT-Creation-Date: 2026-07-26 04:59+0200\n"
 "PO-Revision-Date: 2026-02-18 15:03+0200\n"
 "Last-Translator: Pangoraw <naydex.mc+github@gmail.com>\n"
 "Language-Team: French <traduc@traduc.org>\n"
@@ -75,7 +75,7 @@ msgid "Ignore"
 msgstr "Ignorer"
 
 #: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
 msgid "Reload Configuration"
 msgstr "Recharger la configuration"
 
@@ -111,7 +111,7 @@ msgstr "Oh, non."
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "Impossible d'obtenir un contexte OpenGL pour le rendu."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:97
+#: src/apprt/gtk/ui/1.2/surface.blp:99
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -121,97 +121,97 @@ msgstr ""
 "sélectionner, et naviguer dans son contenu, mais aucune entrée ne sera "
 "envoyée à l'application en cours."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:107
+#: src/apprt/gtk/ui/1.2/surface.blp:109
 msgid "Read-only"
 msgstr "Lecture seule"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:260 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
 msgid "Copy"
 msgstr "Copier"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:265 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
 msgid "Paste"
 msgstr "Coller"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:270
+#: src/apprt/gtk/ui/1.2/surface.blp:272
 msgid "Notify on Next Command Finish"
 msgstr "Notifier à la complétion de la prochaine commande"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:277 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
 msgid "Clear"
 msgstr "Tout effacer"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:282 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
 msgid "Reset"
 msgstr "Réinitialiser"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:289 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
 msgid "Split"
 msgstr "Créer panneau"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:292 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Change Title…"
 msgstr "Changer le titre…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:297 src/apprt/gtk/ui/1.5/window.blp:177
+#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
 #: src/apprt/gtk/ui/1.5/window.blp:250
 msgid "Split Up"
 msgstr "Panneau en haut"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:303 src/apprt/gtk/ui/1.5/window.blp:182
+#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
 #: src/apprt/gtk/ui/1.5/window.blp:255
 msgid "Split Down"
 msgstr "Panneau en bas"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:309 src/apprt/gtk/ui/1.5/window.blp:187
+#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
 #: src/apprt/gtk/ui/1.5/window.blp:260
 msgid "Split Left"
 msgstr "Panneau à gauche"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:315 src/apprt/gtk/ui/1.5/window.blp:192
+#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
 #: src/apprt/gtk/ui/1.5/window.blp:265
 msgid "Split Right"
 msgstr "Panneau à droite"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:321
+#: src/apprt/gtk/ui/1.2/surface.blp:323
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:327
+#: src/apprt/gtk/ui/1.2/surface.blp:329
 msgid "Tab"
 msgstr "Onglet"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:330 src/apprt/gtk/ui/1.5/window.blp:224
+#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
 #: src/apprt/gtk/ui/1.5/window.blp:320
 msgid "Change Tab Title…"
 msgstr "Changer le titre de l'onglet…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:335 src/apprt/gtk/ui/1.5/window.blp:57
+#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
 msgid "New Tab"
 msgstr "Nouvel onglet"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:340 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
 msgid "Close Tab"
 msgstr "Fermer l'onglet"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:347
+#: src/apprt/gtk/ui/1.2/surface.blp:349
 msgid "Window"
 msgstr "Fenêtre"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:350 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
 msgid "New Window"
 msgstr "Nouvelle fenêtre"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:355 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
 msgid "Close Window"
 msgstr "Fermer la fenêtre"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:363
+#: src/apprt/gtk/ui/1.2/surface.blp:365
 msgid "Config"
 msgstr "Config"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:366 src/apprt/gtk/ui/1.5/window.blp:295
+#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
 msgid "Open Configuration"
 msgstr "Ouvrir la configuration"
 
@@ -243,7 +243,7 @@ msgstr "Palette de commandes"
 msgid "Terminal Inspector"
 msgstr "Inspecteur de terminal"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1772
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
 msgid "About Ghostty"
 msgstr "À propos de Ghostty"
 
@@ -254,6 +254,18 @@ msgstr "Quitter"
 #: src/apprt/gtk/ui/1.5/command-palette.blp:17
 msgid "Execute a command…"
 msgstr "Exécuter une commande…"
+
+#: src/apprt/gtk/class/application.zig:1708
+msgid "The keybind was revoked by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1710
+msgid "The keybind was denied by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1721
+msgid "Global keybind unavailable"
+msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
 msgid ""
@@ -315,15 +327,15 @@ msgstr "Toutes les sessions de cette fenêtre vont être arrêtées."
 msgid "The currently running process in this split will be terminated."
 msgstr "Le processus en cours dans ce panneau va être arrêté."
 
-#: src/apprt/gtk/class/surface.zig:1141
+#: src/apprt/gtk/class/surface.zig:1170
 msgid "Command Finished"
 msgstr "Commande terminée"
 
-#: src/apprt/gtk/class/surface.zig:1142
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Succeeded"
 msgstr "Commande réussie"
 
-#: src/apprt/gtk/class/surface.zig:1143
+#: src/apprt/gtk/class/surface.zig:1172
 msgid "Command Failed"
 msgstr "La commande a échoué"
 
@@ -343,18 +355,18 @@ msgstr "Changer le nom du terminal"
 msgid "Change Tab Title"
 msgstr "Changer le titre de l'onglet"
 
-#: src/apprt/gtk/class/window.zig:1067
+#: src/apprt/gtk/class/window.zig:1102
 msgid "Reloaded the configuration"
 msgstr "Configuration rechargée"
 
-#: src/apprt/gtk/class/window.zig:1611
+#: src/apprt/gtk/class/window.zig:1705
 msgid "Copied to clipboard"
 msgstr "Copié dans le presse-papiers"
 
-#: src/apprt/gtk/class/window.zig:1613
+#: src/apprt/gtk/class/window.zig:1707
 msgid "Cleared clipboard"
 msgstr "Presse-papiers vidé"
 
-#: src/apprt/gtk/class/window.zig:1753
+#: src/apprt/gtk/class/window.zig:1847
 msgid "Ghostty Developers"
 msgstr "Les développeurs de Ghostty"

--- a/po/ga.po
+++ b/po/ga.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-03-25 16:24-0700\n"
+"POT-Creation-Date: 2026-07-26 04:59+0200\n"
 "PO-Revision-Date: 2026-02-18 14:32+0000\n"
 "Last-Translator: Aindriú Mac Giolla Eoin <aindriu80@yahoo.com>\n"
 "Language-Team: Irish <gaeilge-gnulinux@lists.sourceforge.net>\n"
@@ -74,7 +74,7 @@ msgid "Ignore"
 msgstr "Déan neamhaird de"
 
 #: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
 msgid "Reload Configuration"
 msgstr "Athlódáil cumraíocht"
 
@@ -109,7 +109,7 @@ msgstr "Ó, fadbh."
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "Ní féidir comhthéacs OpenGL a fháil le haghaidh rindreála."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:97
+#: src/apprt/gtk/ui/1.2/surface.blp:99
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -119,97 +119,97 @@ msgstr ""
 "roghnú agus scroláil tríd an ábhar, ach ní seolfar aon teagmhais ionchuir "
 "chuig an bhfeidhmchlár atá ag rith."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:107
+#: src/apprt/gtk/ui/1.2/surface.blp:109
 msgid "Read-only"
 msgstr "Inléite amháin"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:260 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
 msgid "Copy"
 msgstr "Cóipeáil"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:265 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
 msgid "Paste"
 msgstr "Greamaigh"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:270
+#: src/apprt/gtk/ui/1.2/surface.blp:272
 msgid "Notify on Next Command Finish"
 msgstr "Seol fógra nuair a chríochnaíonn an chéad ordú eile"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:277 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
 msgid "Clear"
 msgstr "Glan"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:282 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
 msgid "Reset"
 msgstr "Athshocraigh"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:289 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
 msgid "Split"
 msgstr "Scoilt"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:292 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Change Title…"
 msgstr "Athraigh teideal…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:297 src/apprt/gtk/ui/1.5/window.blp:177
+#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
 #: src/apprt/gtk/ui/1.5/window.blp:250
 msgid "Split Up"
 msgstr "Scoilt suas"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:303 src/apprt/gtk/ui/1.5/window.blp:182
+#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
 #: src/apprt/gtk/ui/1.5/window.blp:255
 msgid "Split Down"
 msgstr "Scoilt síos"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:309 src/apprt/gtk/ui/1.5/window.blp:187
+#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
 #: src/apprt/gtk/ui/1.5/window.blp:260
 msgid "Split Left"
 msgstr "Scoilt ar chlé"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:315 src/apprt/gtk/ui/1.5/window.blp:192
+#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
 #: src/apprt/gtk/ui/1.5/window.blp:265
 msgid "Split Right"
 msgstr "Scoilt ar dheis"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:321
+#: src/apprt/gtk/ui/1.2/surface.blp:323
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:327
+#: src/apprt/gtk/ui/1.2/surface.blp:329
 msgid "Tab"
 msgstr "Táb"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:330 src/apprt/gtk/ui/1.5/window.blp:224
+#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
 #: src/apprt/gtk/ui/1.5/window.blp:320
 msgid "Change Tab Title…"
 msgstr "Athraigh teideal an táb…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:335 src/apprt/gtk/ui/1.5/window.blp:57
+#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
 msgid "New Tab"
 msgstr "Táb nua"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:340 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
 msgid "Close Tab"
 msgstr "Dún táb"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:347
+#: src/apprt/gtk/ui/1.2/surface.blp:349
 msgid "Window"
 msgstr "Fuinneog"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:350 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
 msgid "New Window"
 msgstr "Fuinneog nua"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:355 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
 msgid "Close Window"
 msgstr "Dún fuinneog"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:363
+#: src/apprt/gtk/ui/1.2/surface.blp:365
 msgid "Config"
 msgstr "Cumraíocht"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:366 src/apprt/gtk/ui/1.5/window.blp:295
+#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
 msgid "Open Configuration"
 msgstr "Oscail cumraíocht"
 
@@ -241,7 +241,7 @@ msgstr "Pailéad ordaithe"
 msgid "Terminal Inspector"
 msgstr "Cigire teirminéil"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1772
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
 msgid "About Ghostty"
 msgstr "Maidir le Ghostty"
 
@@ -252,6 +252,18 @@ msgstr "Scoir"
 #: src/apprt/gtk/ui/1.5/command-palette.blp:17
 msgid "Execute a command…"
 msgstr "Rith ordú…"
+
+#: src/apprt/gtk/class/application.zig:1708
+msgid "The keybind was revoked by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1710
+msgid "The keybind was denied by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1721
+msgid "Global keybind unavailable"
+msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
 msgid ""
@@ -314,15 +326,15 @@ msgid "The currently running process in this split will be terminated."
 msgstr ""
 "Cuirfear deireadh leis an bpróiseas atá ar siúl faoi láthair sa scoilt seo."
 
-#: src/apprt/gtk/class/surface.zig:1141
+#: src/apprt/gtk/class/surface.zig:1170
 msgid "Command Finished"
 msgstr "Ordú críochnaithe"
 
-#: src/apprt/gtk/class/surface.zig:1142
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Succeeded"
 msgstr "D’éirigh leis an ordú"
 
-#: src/apprt/gtk/class/surface.zig:1143
+#: src/apprt/gtk/class/surface.zig:1172
 msgid "Command Failed"
 msgstr "Theip ar an ordú"
 
@@ -342,18 +354,18 @@ msgstr "Athraigh teideal teirminéil"
 msgid "Change Tab Title"
 msgstr "Athraigh teideal an táb"
 
-#: src/apprt/gtk/class/window.zig:1067
+#: src/apprt/gtk/class/window.zig:1102
 msgid "Reloaded the configuration"
 msgstr "Tá an chumraíocht athlódáilte"
 
-#: src/apprt/gtk/class/window.zig:1611
+#: src/apprt/gtk/class/window.zig:1705
 msgid "Copied to clipboard"
 msgstr "Cóipeáilte chuig an ghearrthaisce"
 
-#: src/apprt/gtk/class/window.zig:1613
+#: src/apprt/gtk/class/window.zig:1707
 msgid "Cleared clipboard"
 msgstr "Gearrthaisce glanta"
 
-#: src/apprt/gtk/class/window.zig:1753
+#: src/apprt/gtk/class/window.zig:1847
 msgid "Ghostty Developers"
 msgstr "Forbróirí Ghostty"

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-03-25 16:24-0700\n"
+"POT-Creation-Date: 2026-07-26 04:59+0200\n"
 "PO-Revision-Date: 2026-02-18 18:14+0300\n"
 "Last-Translator: Sl (Shahaf Levi), Sl's Repository Ltd "
 "<ghostty@slsrepo.com>\n"
@@ -77,7 +77,7 @@ msgid "Ignore"
 msgstr "התעלמות"
 
 #: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
 msgid "Reload Configuration"
 msgstr "טעינה מחדש של ההגדרות"
 
@@ -111,7 +111,7 @@ msgstr "אוי, לא"
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "לא ניתן לקבל הקשר OpenGL לצורך רינדור."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:97
+#: src/apprt/gtk/ui/1.2/surface.blp:99
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -120,97 +120,97 @@ msgstr ""
 "מסוף זה נמצא במצב קריאה בלבד. עדיין תוכל/י לצפות, לבחור ולגלול בתוכן, אך לא "
 "יישלחו אירועי קלט לאפליקציה הפעילה."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:107
+#: src/apprt/gtk/ui/1.2/surface.blp:109
 msgid "Read-only"
 msgstr "לקריאה בלבד"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:260 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
 msgid "Copy"
 msgstr "העתקה"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:265 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
 msgid "Paste"
 msgstr "הדבקה"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:270
+#: src/apprt/gtk/ui/1.2/surface.blp:272
 msgid "Notify on Next Command Finish"
 msgstr "תזכורת בסיום הפקודה הבאה"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:277 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
 msgid "Clear"
 msgstr "ניקוי"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:282 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
 msgid "Reset"
 msgstr "איפוס"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:289 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
 msgid "Split"
 msgstr "פיצול"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:292 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Change Title…"
 msgstr "שינוי כותרת…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:297 src/apprt/gtk/ui/1.5/window.blp:177
+#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
 #: src/apprt/gtk/ui/1.5/window.blp:250
 msgid "Split Up"
 msgstr "פיצול למעלה"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:303 src/apprt/gtk/ui/1.5/window.blp:182
+#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
 #: src/apprt/gtk/ui/1.5/window.blp:255
 msgid "Split Down"
 msgstr "פיצול למטה"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:309 src/apprt/gtk/ui/1.5/window.blp:187
+#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
 #: src/apprt/gtk/ui/1.5/window.blp:260
 msgid "Split Left"
 msgstr "פיצול שמאלה"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:315 src/apprt/gtk/ui/1.5/window.blp:192
+#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
 #: src/apprt/gtk/ui/1.5/window.blp:265
 msgid "Split Right"
 msgstr "פיצול ימינה"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:321
+#: src/apprt/gtk/ui/1.2/surface.blp:323
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:327
+#: src/apprt/gtk/ui/1.2/surface.blp:329
 msgid "Tab"
 msgstr "כרטיסייה"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:330 src/apprt/gtk/ui/1.5/window.blp:224
+#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
 #: src/apprt/gtk/ui/1.5/window.blp:320
 msgid "Change Tab Title…"
 msgstr "שנה/י את כותרת הכרטיסייה…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:335 src/apprt/gtk/ui/1.5/window.blp:57
+#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
 msgid "New Tab"
 msgstr "כרטיסייה חדשה"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:340 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
 msgid "Close Tab"
 msgstr "סגור/י כרטיסייה"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:347
+#: src/apprt/gtk/ui/1.2/surface.blp:349
 msgid "Window"
 msgstr "חלון"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:350 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
 msgid "New Window"
 msgstr "חלון חדש"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:355 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
 msgid "Close Window"
 msgstr "סגור/י חלון"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:363
+#: src/apprt/gtk/ui/1.2/surface.blp:365
 msgid "Config"
 msgstr "הגדרות"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:366 src/apprt/gtk/ui/1.5/window.blp:295
+#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
 msgid "Open Configuration"
 msgstr "פתיחת ההגדרות"
 
@@ -242,7 +242,7 @@ msgstr "לוח פקודות"
 msgid "Terminal Inspector"
 msgstr "בודק המסוף"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1772
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
 msgid "About Ghostty"
 msgstr "אודות Ghostty"
 
@@ -253,6 +253,18 @@ msgstr "יציאה"
 #: src/apprt/gtk/ui/1.5/command-palette.blp:17
 msgid "Execute a command…"
 msgstr "הרץ/י פקודה…"
+
+#: src/apprt/gtk/class/application.zig:1708
+msgid "The keybind was revoked by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1710
+msgid "The keybind was denied by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1721
+msgid "Global keybind unavailable"
+msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
 msgid ""
@@ -311,15 +323,15 @@ msgstr "כל הפעלות המסוף בחלון זה יסתיימו."
 msgid "The currently running process in this split will be terminated."
 msgstr "התהליך שרץ כרגע בפיצול זה יסתיים."
 
-#: src/apprt/gtk/class/surface.zig:1141
+#: src/apprt/gtk/class/surface.zig:1170
 msgid "Command Finished"
 msgstr "הפקודה הסתיימה"
 
-#: src/apprt/gtk/class/surface.zig:1142
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Succeeded"
 msgstr "הפקודה הצליחה"
 
-#: src/apprt/gtk/class/surface.zig:1143
+#: src/apprt/gtk/class/surface.zig:1172
 msgid "Command Failed"
 msgstr "הפקודה נכשלה"
 
@@ -339,18 +351,18 @@ msgstr "שינוי כותרת המסוף"
 msgid "Change Tab Title"
 msgstr "שינוי כותרת הכרטיסייה"
 
-#: src/apprt/gtk/class/window.zig:1067
+#: src/apprt/gtk/class/window.zig:1102
 msgid "Reloaded the configuration"
 msgstr "ההגדרות הוטענו מחדש"
 
-#: src/apprt/gtk/class/window.zig:1611
+#: src/apprt/gtk/class/window.zig:1705
 msgid "Copied to clipboard"
 msgstr "הועתק ללוח ההעתקה"
 
-#: src/apprt/gtk/class/window.zig:1613
+#: src/apprt/gtk/class/window.zig:1707
 msgid "Cleared clipboard"
 msgstr "לוח ההעתקה רוקן"
 
-#: src/apprt/gtk/class/window.zig:1753
+#: src/apprt/gtk/class/window.zig:1847
 msgid "Ghostty Developers"
 msgstr "המפתחים של Ghostty"

--- a/po/hr.po
+++ b/po/hr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-03-25 16:24-0700\n"
+"POT-Creation-Date: 2026-07-26 04:59+0200\n"
 "PO-Revision-Date: 2026-02-18 21:00+0200\n"
 "Last-Translator: Filip7 <filipm7@protonmail.com>\n"
 "Language-Team: Croatian <lokalizacija@linux.hr>\n"
@@ -76,7 +76,7 @@ msgid "Ignore"
 msgstr "Zanemari"
 
 #: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
 msgid "Reload Configuration"
 msgstr "Ponovno učitaj postavke"
 
@@ -110,7 +110,7 @@ msgstr "Oh, ne."
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "Neuspjelo dohvaćanje OpenGL konteksta za renderiranje."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:97
+#: src/apprt/gtk/ui/1.2/surface.blp:99
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -120,97 +120,97 @@ msgstr ""
 "odabirati i skrolati kroz sadržaj, no unos neće biti poslan pokrenutoj "
 "aplikaciji."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:107
+#: src/apprt/gtk/ui/1.2/surface.blp:109
 msgid "Read-only"
 msgstr "Samo za čitanje"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:260 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
 msgid "Copy"
 msgstr "Kopiraj"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:265 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
 msgid "Paste"
 msgstr "Zalijepi"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:270
+#: src/apprt/gtk/ui/1.2/surface.blp:272
 msgid "Notify on Next Command Finish"
 msgstr "Obavijesti kada iduća naredba završi"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:277 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
 msgid "Clear"
 msgstr "Očisti"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:282 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
 msgid "Reset"
 msgstr "Resetiraj"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:289 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
 msgid "Split"
 msgstr "Podijeli"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:292 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Change Title…"
 msgstr "Promijeni naslov…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:297 src/apprt/gtk/ui/1.5/window.blp:177
+#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
 #: src/apprt/gtk/ui/1.5/window.blp:250
 msgid "Split Up"
 msgstr "Podijeli gore"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:303 src/apprt/gtk/ui/1.5/window.blp:182
+#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
 #: src/apprt/gtk/ui/1.5/window.blp:255
 msgid "Split Down"
 msgstr "Podijeli dolje"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:309 src/apprt/gtk/ui/1.5/window.blp:187
+#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
 #: src/apprt/gtk/ui/1.5/window.blp:260
 msgid "Split Left"
 msgstr "Podijeli lijevo"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:315 src/apprt/gtk/ui/1.5/window.blp:192
+#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
 #: src/apprt/gtk/ui/1.5/window.blp:265
 msgid "Split Right"
 msgstr "Podijeli desno"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:321
+#: src/apprt/gtk/ui/1.2/surface.blp:323
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:327
+#: src/apprt/gtk/ui/1.2/surface.blp:329
 msgid "Tab"
 msgstr "Kartica"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:330 src/apprt/gtk/ui/1.5/window.blp:224
+#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
 #: src/apprt/gtk/ui/1.5/window.blp:320
 msgid "Change Tab Title…"
 msgstr "Promijeni naslov kartice…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:335 src/apprt/gtk/ui/1.5/window.blp:57
+#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
 msgid "New Tab"
 msgstr "Nova kartica"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:340 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
 msgid "Close Tab"
 msgstr "Zatvori karticu"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:347
+#: src/apprt/gtk/ui/1.2/surface.blp:349
 msgid "Window"
 msgstr "Prozor"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:350 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
 msgid "New Window"
 msgstr "Novi prozor"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:355 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
 msgid "Close Window"
 msgstr "Zatvori prozor"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:363
+#: src/apprt/gtk/ui/1.2/surface.blp:365
 msgid "Config"
 msgstr "Postavke"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:366 src/apprt/gtk/ui/1.5/window.blp:295
+#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
 msgid "Open Configuration"
 msgstr "Otvori postavke"
 
@@ -242,7 +242,7 @@ msgstr "Paleta naredbi"
 msgid "Terminal Inspector"
 msgstr "Inspektor terminala"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1772
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
 msgid "About Ghostty"
 msgstr "O Ghosttyju"
 
@@ -253,6 +253,18 @@ msgstr "Izađi"
 #: src/apprt/gtk/ui/1.5/command-palette.blp:17
 msgid "Execute a command…"
 msgstr "Izvrši naredbu…"
+
+#: src/apprt/gtk/class/application.zig:1708
+msgid "The keybind was revoked by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1710
+msgid "The keybind was denied by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1721
+msgid "Global keybind unavailable"
+msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
 msgid ""
@@ -314,15 +326,15 @@ msgstr "Sve sesije terminala u ovom prozoru će biti prekinute."
 msgid "The currently running process in this split will be terminated."
 msgstr "Pokrenuti procesi u ovoj podjeli će biti prekinuti."
 
-#: src/apprt/gtk/class/surface.zig:1141
+#: src/apprt/gtk/class/surface.zig:1170
 msgid "Command Finished"
 msgstr "Naredba je završena"
 
-#: src/apprt/gtk/class/surface.zig:1142
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Succeeded"
 msgstr "Naredba je uspjela"
 
-#: src/apprt/gtk/class/surface.zig:1143
+#: src/apprt/gtk/class/surface.zig:1172
 msgid "Command Failed"
 msgstr "Naredba nije uspjela"
 
@@ -342,18 +354,18 @@ msgstr "Promijeni naslov terminala"
 msgid "Change Tab Title"
 msgstr "Promijeni naslov kartice"
 
-#: src/apprt/gtk/class/window.zig:1067
+#: src/apprt/gtk/class/window.zig:1102
 msgid "Reloaded the configuration"
 msgstr "Ponovno učitane postavke"
 
-#: src/apprt/gtk/class/window.zig:1611
+#: src/apprt/gtk/class/window.zig:1705
 msgid "Copied to clipboard"
 msgstr "Kopirano u međuspremnik"
 
-#: src/apprt/gtk/class/window.zig:1613
+#: src/apprt/gtk/class/window.zig:1707
 msgid "Cleared clipboard"
 msgstr "Očišćen međuspremnik"
 
-#: src/apprt/gtk/class/window.zig:1753
+#: src/apprt/gtk/class/window.zig:1847
 msgid "Ghostty Developers"
 msgstr "Razvijatelji Ghosttyja"

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-03-25 16:24-0700\n"
+"POT-Creation-Date: 2026-07-26 04:59+0200\n"
 "PO-Revision-Date: 2026-02-26 21:00+0100\n"
 "Last-Translator: Balázs Szücs <bszucs1209@gmail.com>\n"
 "Language-Team: Hungarian <translation-team-hu@lists.sourceforge.net>\n"
@@ -75,7 +75,7 @@ msgid "Ignore"
 msgstr "Figyelmen kívül hagyás"
 
 #: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
 msgid "Reload Configuration"
 msgstr "Konfiguráció frissítése"
 
@@ -110,7 +110,7 @@ msgstr "Jaj, ne."
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "Nem sikerült OpenGL-környezetet létrehozni a megjelenítéshez."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:97
+#: src/apprt/gtk/ui/1.2/surface.blp:99
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -120,97 +120,97 @@ msgstr ""
 "megtekintheti, kijelölheti és görgetheti, de nem küld bemeneti eseményeket a "
 "futó alkalmazásnak."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:107
+#: src/apprt/gtk/ui/1.2/surface.blp:109
 msgid "Read-only"
 msgstr "Csak olvasható"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:260 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
 msgid "Copy"
 msgstr "Másolás"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:265 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
 msgid "Paste"
 msgstr "Beillesztés"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:270
+#: src/apprt/gtk/ui/1.2/surface.blp:272
 msgid "Notify on Next Command Finish"
 msgstr "Értesítés a következő parancs befejezésekor"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:277 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
 msgid "Clear"
 msgstr "Törlés"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:282 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
 msgid "Reset"
 msgstr "Visszaállítás"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:289 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
 msgid "Split"
 msgstr "Felosztás"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:292 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Change Title…"
 msgstr "Cím módosítása…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:297 src/apprt/gtk/ui/1.5/window.blp:177
+#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
 #: src/apprt/gtk/ui/1.5/window.blp:250
 msgid "Split Up"
 msgstr "Felosztás felfelé"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:303 src/apprt/gtk/ui/1.5/window.blp:182
+#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
 #: src/apprt/gtk/ui/1.5/window.blp:255
 msgid "Split Down"
 msgstr "Felosztás lefelé"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:309 src/apprt/gtk/ui/1.5/window.blp:187
+#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
 #: src/apprt/gtk/ui/1.5/window.blp:260
 msgid "Split Left"
 msgstr "Felosztás balra"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:315 src/apprt/gtk/ui/1.5/window.blp:192
+#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
 #: src/apprt/gtk/ui/1.5/window.blp:265
 msgid "Split Right"
 msgstr "Felosztás jobbra"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:321
+#: src/apprt/gtk/ui/1.2/surface.blp:323
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:327
+#: src/apprt/gtk/ui/1.2/surface.blp:329
 msgid "Tab"
 msgstr "Fül"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:330 src/apprt/gtk/ui/1.5/window.blp:224
+#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
 #: src/apprt/gtk/ui/1.5/window.blp:320
 msgid "Change Tab Title…"
 msgstr "Fül címének módosítása…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:335 src/apprt/gtk/ui/1.5/window.blp:57
+#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
 msgid "New Tab"
 msgstr "Új fül"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:340 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
 msgid "Close Tab"
 msgstr "Fül bezárása"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:347
+#: src/apprt/gtk/ui/1.2/surface.blp:349
 msgid "Window"
 msgstr "Ablak"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:350 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
 msgid "New Window"
 msgstr "Új ablak"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:355 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
 msgid "Close Window"
 msgstr "Ablak bezárása"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:363
+#: src/apprt/gtk/ui/1.2/surface.blp:365
 msgid "Config"
 msgstr "Konfiguráció"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:366 src/apprt/gtk/ui/1.5/window.blp:295
+#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
 msgid "Open Configuration"
 msgstr "Konfiguráció megnyitása"
 
@@ -242,7 +242,7 @@ msgstr "Parancspaletta"
 msgid "Terminal Inspector"
 msgstr "Terminálvizsgáló"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1772
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
 msgid "About Ghostty"
 msgstr "A Ghostty névjegye"
 
@@ -253,6 +253,18 @@ msgstr "Kilépés"
 #: src/apprt/gtk/ui/1.5/command-palette.blp:17
 msgid "Execute a command…"
 msgstr "Parancs végrehajtása…"
+
+#: src/apprt/gtk/class/application.zig:1708
+msgid "The keybind was revoked by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1710
+msgid "The keybind was denied by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1721
+msgid "Global keybind unavailable"
+msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
 msgid ""
@@ -314,15 +326,15 @@ msgstr "Ebben az ablakban minden terminál munkamenet lezárul."
 msgid "The currently running process in this split will be terminated."
 msgstr "Ebben a felosztásban a jelenleg futó folyamat lezárul."
 
-#: src/apprt/gtk/class/surface.zig:1141
+#: src/apprt/gtk/class/surface.zig:1170
 msgid "Command Finished"
 msgstr "Parancs befejeződött"
 
-#: src/apprt/gtk/class/surface.zig:1142
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Succeeded"
 msgstr "Parancs sikeres"
 
-#: src/apprt/gtk/class/surface.zig:1143
+#: src/apprt/gtk/class/surface.zig:1172
 msgid "Command Failed"
 msgstr "Parancs sikertelen"
 
@@ -342,18 +354,18 @@ msgstr "Terminál címének módosítása"
 msgid "Change Tab Title"
 msgstr "Fül címének módosítása"
 
-#: src/apprt/gtk/class/window.zig:1067
+#: src/apprt/gtk/class/window.zig:1102
 msgid "Reloaded the configuration"
 msgstr "Konfiguráció frissítve"
 
-#: src/apprt/gtk/class/window.zig:1611
+#: src/apprt/gtk/class/window.zig:1705
 msgid "Copied to clipboard"
 msgstr "Vágólapra másolva"
 
-#: src/apprt/gtk/class/window.zig:1613
+#: src/apprt/gtk/class/window.zig:1707
 msgid "Cleared clipboard"
 msgstr "Vágólap törölve"
 
-#: src/apprt/gtk/class/window.zig:1753
+#: src/apprt/gtk/class/window.zig:1847
 msgid "Ghostty Developers"
 msgstr "Ghostty fejlesztők"

--- a/po/id.po
+++ b/po/id.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-03-25 16:24-0700\n"
+"POT-Creation-Date: 2026-07-26 04:59+0200\n"
 "PO-Revision-Date: 2026-03-08 20:23+0700\n"
 "Last-Translator: Mikail Muzakki <mikailmmuzakki@gmail.com>\n"
 "Language-Team: Indonesian <translation-team-id@lists.sourceforge.net>\n"
@@ -75,7 +75,7 @@ msgid "Ignore"
 msgstr "Abaikan"
 
 #: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
 msgid "Reload Configuration"
 msgstr "Muat ulang konfigurasi"
 
@@ -110,7 +110,7 @@ msgstr "Oh, tidak."
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "Tidak dapat memperoleh konteks OpenGL untuk penampilan grafis."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:97
+#: src/apprt/gtk/ui/1.2/surface.blp:99
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -120,97 +120,97 @@ msgstr ""
 "memilih, dan menggulir konten, tetapi peristiwa input tidak akan dikirim ke "
 "aplikasi berjalan."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:107
+#: src/apprt/gtk/ui/1.2/surface.blp:109
 msgid "Read-only"
 msgstr "Hanya baca"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:260 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
 msgid "Copy"
 msgstr "Salin"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:265 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
 msgid "Paste"
 msgstr "Tempel"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:270
+#: src/apprt/gtk/ui/1.2/surface.blp:272
 msgid "Notify on Next Command Finish"
 msgstr "Beri tahu saat perintah berikutnya selesai"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:277 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
 msgid "Clear"
 msgstr "Bersihkan"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:282 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
 msgid "Reset"
 msgstr "Atur ulang"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:289 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
 msgid "Split"
 msgstr "Belah"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:292 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Change Title…"
 msgstr "Ubah judul…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:297 src/apprt/gtk/ui/1.5/window.blp:177
+#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
 #: src/apprt/gtk/ui/1.5/window.blp:250
 msgid "Split Up"
 msgstr "Belah atas"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:303 src/apprt/gtk/ui/1.5/window.blp:182
+#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
 #: src/apprt/gtk/ui/1.5/window.blp:255
 msgid "Split Down"
 msgstr "Belah bawah"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:309 src/apprt/gtk/ui/1.5/window.blp:187
+#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
 #: src/apprt/gtk/ui/1.5/window.blp:260
 msgid "Split Left"
 msgstr "Belah kiri"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:315 src/apprt/gtk/ui/1.5/window.blp:192
+#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
 #: src/apprt/gtk/ui/1.5/window.blp:265
 msgid "Split Right"
 msgstr "Belah kanan"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:321
+#: src/apprt/gtk/ui/1.2/surface.blp:323
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:327
+#: src/apprt/gtk/ui/1.2/surface.blp:329
 msgid "Tab"
 msgstr "Tab"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:330 src/apprt/gtk/ui/1.5/window.blp:224
+#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
 #: src/apprt/gtk/ui/1.5/window.blp:320
 msgid "Change Tab Title…"
 msgstr "Ubah judul tab…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:335 src/apprt/gtk/ui/1.5/window.blp:57
+#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
 msgid "New Tab"
 msgstr "Tab baru"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:340 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
 msgid "Close Tab"
 msgstr "Tutup tab"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:347
+#: src/apprt/gtk/ui/1.2/surface.blp:349
 msgid "Window"
 msgstr "Jendela"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:350 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
 msgid "New Window"
 msgstr "Jendela baru"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:355 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
 msgid "Close Window"
 msgstr "Tutup jendela"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:363
+#: src/apprt/gtk/ui/1.2/surface.blp:365
 msgid "Config"
 msgstr "Konfigurasi"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:366 src/apprt/gtk/ui/1.5/window.blp:295
+#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
 msgid "Open Configuration"
 msgstr "Buka konfigurasi"
 
@@ -242,7 +242,7 @@ msgstr "Palet perintah"
 msgid "Terminal Inspector"
 msgstr "Inspektur terminal"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1772
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
 msgid "About Ghostty"
 msgstr "Tentang Ghostty"
 
@@ -253,6 +253,18 @@ msgstr "Keluar"
 #: src/apprt/gtk/ui/1.5/command-palette.blp:17
 msgid "Execute a command…"
 msgstr "Eksekusi perintah…"
+
+#: src/apprt/gtk/class/application.zig:1708
+msgid "The keybind was revoked by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1710
+msgid "The keybind was denied by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1721
+msgid "Global keybind unavailable"
+msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
 msgid ""
@@ -314,15 +326,15 @@ msgstr "Semua sesi terminal di jendela ini akan diakhiri."
 msgid "The currently running process in this split will be terminated."
 msgstr "Proses yang sedang berjalan dalam belahan ini akan diakhiri."
 
-#: src/apprt/gtk/class/surface.zig:1141
+#: src/apprt/gtk/class/surface.zig:1170
 msgid "Command Finished"
 msgstr "Perintah selesai"
 
-#: src/apprt/gtk/class/surface.zig:1142
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Succeeded"
 msgstr "Perintah berhasil"
 
-#: src/apprt/gtk/class/surface.zig:1143
+#: src/apprt/gtk/class/surface.zig:1172
 msgid "Command Failed"
 msgstr "Perintah gagal"
 
@@ -342,18 +354,18 @@ msgstr "Ubah judul terminal"
 msgid "Change Tab Title"
 msgstr "Ubah judul tab"
 
-#: src/apprt/gtk/class/window.zig:1067
+#: src/apprt/gtk/class/window.zig:1102
 msgid "Reloaded the configuration"
 msgstr "Memuat ulang konfigurasi"
 
-#: src/apprt/gtk/class/window.zig:1611
+#: src/apprt/gtk/class/window.zig:1705
 msgid "Copied to clipboard"
 msgstr "Disalin ke papan klip"
 
-#: src/apprt/gtk/class/window.zig:1613
+#: src/apprt/gtk/class/window.zig:1707
 msgid "Cleared clipboard"
 msgstr "Papan klip dibersihkan"
 
-#: src/apprt/gtk/class/window.zig:1753
+#: src/apprt/gtk/class/window.zig:1847
 msgid "Ghostty Developers"
 msgstr "Pengembang Ghostty"

--- a/po/it.po
+++ b/po/it.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-03-25 16:24-0700\n"
+"POT-Creation-Date: 2026-07-26 04:59+0200\n"
 "PO-Revision-Date: 2025-09-06 19:40+0200\n"
 "Last-Translator: Giacomo Bettini <giaco.bettini@gmail.com>\n"
 "Language-Team: Italian <tp@lists.linux.it>\n"
@@ -76,7 +76,7 @@ msgid "Ignore"
 msgstr "Ignora"
 
 #: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
 msgid "Reload Configuration"
 msgstr "Ricarica configurazione"
 
@@ -111,7 +111,7 @@ msgstr "Oh no!"
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "Impossibile ottenere un contesto OpenGL per il rendering."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:97
+#: src/apprt/gtk/ui/1.2/surface.blp:99
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -121,97 +121,97 @@ msgstr ""
 "selezionare e scorrere il contenuto, ma non verrà inviato alcun evento di "
 "input all'applicazione in esecuzione."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:107
+#: src/apprt/gtk/ui/1.2/surface.blp:109
 msgid "Read-only"
 msgstr "Sola lettura"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:260 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
 msgid "Copy"
 msgstr "Copia"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:265 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
 msgid "Paste"
 msgstr "Incolla"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:270
+#: src/apprt/gtk/ui/1.2/surface.blp:272
 msgid "Notify on Next Command Finish"
 msgstr "Notifica al termine del prossimo comando"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:277 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
 msgid "Clear"
 msgstr "Pulisci"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:282 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
 msgid "Reset"
 msgstr "Reimposta"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:289 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
 msgid "Split"
 msgstr "Divisione"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:292 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Change Title…"
 msgstr "Cambia titolo…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:297 src/apprt/gtk/ui/1.5/window.blp:177
+#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
 #: src/apprt/gtk/ui/1.5/window.blp:250
 msgid "Split Up"
 msgstr "Dividi in alto"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:303 src/apprt/gtk/ui/1.5/window.blp:182
+#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
 #: src/apprt/gtk/ui/1.5/window.blp:255
 msgid "Split Down"
 msgstr "Dividi in basso"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:309 src/apprt/gtk/ui/1.5/window.blp:187
+#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
 #: src/apprt/gtk/ui/1.5/window.blp:260
 msgid "Split Left"
 msgstr "Dividi a sinistra"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:315 src/apprt/gtk/ui/1.5/window.blp:192
+#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
 #: src/apprt/gtk/ui/1.5/window.blp:265
 msgid "Split Right"
 msgstr "Dividi a destra"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:321
+#: src/apprt/gtk/ui/1.2/surface.blp:323
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:327
+#: src/apprt/gtk/ui/1.2/surface.blp:329
 msgid "Tab"
 msgstr "Scheda"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:330 src/apprt/gtk/ui/1.5/window.blp:224
+#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
 #: src/apprt/gtk/ui/1.5/window.blp:320
 msgid "Change Tab Title…"
 msgstr "Cambia titolo scheda…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:335 src/apprt/gtk/ui/1.5/window.blp:57
+#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
 msgid "New Tab"
 msgstr "Nuova scheda"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:340 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
 msgid "Close Tab"
 msgstr "Chiudi scheda"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:347
+#: src/apprt/gtk/ui/1.2/surface.blp:349
 msgid "Window"
 msgstr "Finestra"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:350 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
 msgid "New Window"
 msgstr "Nuova finestra"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:355 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
 msgid "Close Window"
 msgstr "Chiudi finestra"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:363
+#: src/apprt/gtk/ui/1.2/surface.blp:365
 msgid "Config"
 msgstr "Configurazione"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:366 src/apprt/gtk/ui/1.5/window.blp:295
+#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
 msgid "Open Configuration"
 msgstr "Apri configurazione"
 
@@ -243,7 +243,7 @@ msgstr "Riquadro comandi"
 msgid "Terminal Inspector"
 msgstr "Ispettore del terminale"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1772
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
 msgid "About Ghostty"
 msgstr "Informazioni su Ghostty"
 
@@ -254,6 +254,18 @@ msgstr "Chiudi"
 #: src/apprt/gtk/ui/1.5/command-palette.blp:17
 msgid "Execute a command…"
 msgstr "Esegui un comando…"
+
+#: src/apprt/gtk/class/application.zig:1708
+msgid "The keybind was revoked by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1710
+msgid "The keybind was denied by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1721
+msgid "Global keybind unavailable"
+msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
 msgid ""
@@ -316,15 +328,15 @@ msgid "The currently running process in this split will be terminated."
 msgstr ""
 "Il processo attualmente in esecuzione in questa divisione sarà terminato."
 
-#: src/apprt/gtk/class/surface.zig:1141
+#: src/apprt/gtk/class/surface.zig:1170
 msgid "Command Finished"
 msgstr "Comando terminato"
 
-#: src/apprt/gtk/class/surface.zig:1142
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Succeeded"
 msgstr "Comando riuscito"
 
-#: src/apprt/gtk/class/surface.zig:1143
+#: src/apprt/gtk/class/surface.zig:1172
 msgid "Command Failed"
 msgstr "Comando fallito"
 
@@ -344,18 +356,18 @@ msgstr "Cambia il titolo del terminale"
 msgid "Change Tab Title"
 msgstr "Cambia il titolo della scheda"
 
-#: src/apprt/gtk/class/window.zig:1067
+#: src/apprt/gtk/class/window.zig:1102
 msgid "Reloaded the configuration"
 msgstr "Configurazione ricaricata"
 
-#: src/apprt/gtk/class/window.zig:1611
+#: src/apprt/gtk/class/window.zig:1705
 msgid "Copied to clipboard"
 msgstr "Copiato negli Appunti"
 
-#: src/apprt/gtk/class/window.zig:1613
+#: src/apprt/gtk/class/window.zig:1707
 msgid "Cleared clipboard"
 msgstr "Appunti svuotati"
 
-#: src/apprt/gtk/class/window.zig:1753
+#: src/apprt/gtk/class/window.zig:1847
 msgid "Ghostty Developers"
 msgstr "Sviluppatori di Ghostty"

--- a/po/ja.po
+++ b/po/ja.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-03-25 16:24-0700\n"
+"POT-Creation-Date: 2026-07-26 04:59+0200\n"
 "PO-Revision-Date: 2026-02-11 12:02+0900\n"
 "Last-Translator: Takayuki Nagatomi <tnagatomi@okweird.net>\n"
 "Language-Team: Japanese\n"
@@ -75,7 +75,7 @@ msgid "Ignore"
 msgstr "無視"
 
 #: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
 msgid "Reload Configuration"
 msgstr "設定ファイルの再読み込み"
 
@@ -110,7 +110,7 @@ msgstr "おっと。"
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "レンダリング用のOpenGLコンテキストを取得できませんでした。"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:97
+#: src/apprt/gtk/ui/1.2/surface.blp:99
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -119,97 +119,97 @@ msgstr ""
 "このターミナルは読み取り専用モードです。コンテンツの表示、選択、スクロールは"
 "可能ですが、入力イベントは実行中のアプリケーションに送信されません。"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:107
+#: src/apprt/gtk/ui/1.2/surface.blp:109
 msgid "Read-only"
 msgstr "読み取り専用"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:260 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
 msgid "Copy"
 msgstr "コピー"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:265 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
 msgid "Paste"
 msgstr "貼り付け"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:270
+#: src/apprt/gtk/ui/1.2/surface.blp:272
 msgid "Notify on Next Command Finish"
 msgstr "次のコマンド実行終了時に通知する"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:277 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
 msgid "Clear"
 msgstr "クリア"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:282 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
 msgid "Reset"
 msgstr "リセット"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:289 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
 msgid "Split"
 msgstr "分割"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:292 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Change Title…"
 msgstr "タイトルを変更…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:297 src/apprt/gtk/ui/1.5/window.blp:177
+#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
 #: src/apprt/gtk/ui/1.5/window.blp:250
 msgid "Split Up"
 msgstr "上に分割"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:303 src/apprt/gtk/ui/1.5/window.blp:182
+#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
 #: src/apprt/gtk/ui/1.5/window.blp:255
 msgid "Split Down"
 msgstr "下に分割"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:309 src/apprt/gtk/ui/1.5/window.blp:187
+#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
 #: src/apprt/gtk/ui/1.5/window.blp:260
 msgid "Split Left"
 msgstr "左に分割"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:315 src/apprt/gtk/ui/1.5/window.blp:192
+#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
 #: src/apprt/gtk/ui/1.5/window.blp:265
 msgid "Split Right"
 msgstr "右に分割"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:321
+#: src/apprt/gtk/ui/1.2/surface.blp:323
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:327
+#: src/apprt/gtk/ui/1.2/surface.blp:329
 msgid "Tab"
 msgstr "タブ"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:330 src/apprt/gtk/ui/1.5/window.blp:224
+#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
 #: src/apprt/gtk/ui/1.5/window.blp:320
 msgid "Change Tab Title…"
 msgstr "タブのタイトルを変更…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:335 src/apprt/gtk/ui/1.5/window.blp:57
+#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
 msgid "New Tab"
 msgstr "新しいタブ"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:340 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
 msgid "Close Tab"
 msgstr "タブを閉じる"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:347
+#: src/apprt/gtk/ui/1.2/surface.blp:349
 msgid "Window"
 msgstr "ウィンドウ"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:350 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
 msgid "New Window"
 msgstr "新しいウィンドウ"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:355 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
 msgid "Close Window"
 msgstr "ウィンドウを閉じる"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:363
+#: src/apprt/gtk/ui/1.2/surface.blp:365
 msgid "Config"
 msgstr "設定"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:366 src/apprt/gtk/ui/1.5/window.blp:295
+#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
 msgid "Open Configuration"
 msgstr "設定ファイルを開く"
 
@@ -241,7 +241,7 @@ msgstr "コマンドパレット"
 msgid "Terminal Inspector"
 msgstr "端末インスペクター"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1772
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
 msgid "About Ghostty"
 msgstr "Ghostty について"
 
@@ -252,6 +252,18 @@ msgstr "終了"
 #: src/apprt/gtk/ui/1.5/command-palette.blp:17
 msgid "Execute a command…"
 msgstr "コマンドを実行…"
+
+#: src/apprt/gtk/class/application.zig:1708
+msgid "The keybind was revoked by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1710
+msgid "The keybind was denied by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1721
+msgid "Global keybind unavailable"
+msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
 msgid ""
@@ -313,15 +325,15 @@ msgstr "ウィンドウ内のすべてのターミナルセッションが終了
 msgid "The currently running process in this split will be terminated."
 msgstr "分割ウィンドウ内のすべてのプロセスが終了します。"
 
-#: src/apprt/gtk/class/surface.zig:1141
+#: src/apprt/gtk/class/surface.zig:1170
 msgid "Command Finished"
 msgstr "コマンド実行終了"
 
-#: src/apprt/gtk/class/surface.zig:1142
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Succeeded"
 msgstr "コマンド実行成功"
 
-#: src/apprt/gtk/class/surface.zig:1143
+#: src/apprt/gtk/class/surface.zig:1172
 msgid "Command Failed"
 msgstr "コマンド実行失敗"
 
@@ -341,18 +353,18 @@ msgstr "ターミナルのタイトルを変更する"
 msgid "Change Tab Title"
 msgstr "タブのタイトルを変更する"
 
-#: src/apprt/gtk/class/window.zig:1067
+#: src/apprt/gtk/class/window.zig:1102
 msgid "Reloaded the configuration"
 msgstr "設定を再読み込みしました"
 
-#: src/apprt/gtk/class/window.zig:1611
+#: src/apprt/gtk/class/window.zig:1705
 msgid "Copied to clipboard"
 msgstr "クリップボードにコピーしました"
 
-#: src/apprt/gtk/class/window.zig:1613
+#: src/apprt/gtk/class/window.zig:1707
 msgid "Cleared clipboard"
 msgstr "クリップボードを空にしました"
 
-#: src/apprt/gtk/class/window.zig:1753
+#: src/apprt/gtk/class/window.zig:1847
 msgid "Ghostty Developers"
 msgstr "Ghostty 開発者"

--- a/po/kk.po
+++ b/po/kk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-03-25 16:24-0700\n"
+"POT-Creation-Date: 2026-07-26 04:59+0200\n"
 "PO-Revision-Date: 2026-06-20 17:07+0500\n"
 "Last-Translator: AnmiTaliDev <anmitalidev@nuros.org>\n"
 "Language-Team: Kazakh <kk_KZ@googlegroups.com>\n"
@@ -76,7 +76,7 @@ msgid "Ignore"
 msgstr "Елемеу"
 
 #: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
 msgid "Reload Configuration"
 msgstr "Конфигурацияны қайта жүктеу"
 
@@ -112,7 +112,7 @@ msgstr "О, жоқ."
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "Рендеринг үшін OpenGL контекстін алу мүмкін емес."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:97
+#: src/apprt/gtk/ui/1.2/surface.blp:99
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -122,97 +122,97 @@ msgstr ""
 "жылжыта аласыз, бірақ іске қосылған қолданбаға ешқандай енгізу оқиғалары "
 "жіберілмейді."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:107
+#: src/apprt/gtk/ui/1.2/surface.blp:109
 msgid "Read-only"
 msgstr "Тек оқу"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:260 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
 msgid "Copy"
 msgstr "Көшіріп алу"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:265 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
 msgid "Paste"
 msgstr "Кірістіру"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:270
+#: src/apprt/gtk/ui/1.2/surface.blp:272
 msgid "Notify on Next Command Finish"
 msgstr "Келесі команда аяқталғанда хабарлау"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:277 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
 msgid "Clear"
 msgstr "Тазарту"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:282 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
 msgid "Reset"
 msgstr "Тастау"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:289 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
 msgid "Split"
 msgstr "Бөлу"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:292 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Change Title…"
 msgstr "Тақырыпты өзгерту…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:297 src/apprt/gtk/ui/1.5/window.blp:177
+#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
 #: src/apprt/gtk/ui/1.5/window.blp:250
 msgid "Split Up"
 msgstr "Жоғарыға бөлу"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:303 src/apprt/gtk/ui/1.5/window.blp:182
+#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
 #: src/apprt/gtk/ui/1.5/window.blp:255
 msgid "Split Down"
 msgstr "Төменге бөлу"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:309 src/apprt/gtk/ui/1.5/window.blp:187
+#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
 #: src/apprt/gtk/ui/1.5/window.blp:260
 msgid "Split Left"
 msgstr "Сол жаққа бөлу"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:315 src/apprt/gtk/ui/1.5/window.blp:192
+#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
 #: src/apprt/gtk/ui/1.5/window.blp:265
 msgid "Split Right"
 msgstr "Оң жаққа бөлу"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:321
+#: src/apprt/gtk/ui/1.2/surface.blp:323
 msgid "Close Split"
 msgstr "Бөлуді жабу"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:327
+#: src/apprt/gtk/ui/1.2/surface.blp:329
 msgid "Tab"
 msgstr "Бет"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:330 src/apprt/gtk/ui/1.5/window.blp:224
+#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
 #: src/apprt/gtk/ui/1.5/window.blp:320
 msgid "Change Tab Title…"
 msgstr "Бет атауын өзгерту…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:335 src/apprt/gtk/ui/1.5/window.blp:57
+#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
 msgid "New Tab"
 msgstr "Жаңа бет"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:340 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
 msgid "Close Tab"
 msgstr "Бетті жабу"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:347
+#: src/apprt/gtk/ui/1.2/surface.blp:349
 msgid "Window"
 msgstr "Терезе"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:350 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
 msgid "New Window"
 msgstr "Жаңа терезе"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:355 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
 msgid "Close Window"
 msgstr "Терезені жабу"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:363
+#: src/apprt/gtk/ui/1.2/surface.blp:365
 msgid "Config"
 msgstr "Конфигурация"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:366 src/apprt/gtk/ui/1.5/window.blp:295
+#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
 msgid "Open Configuration"
 msgstr "Конфигурацияны ашу"
 
@@ -244,7 +244,7 @@ msgstr "Командалар палитрасы"
 msgid "Terminal Inspector"
 msgstr "Терминал инспекторы"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1772
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
 msgid "About Ghostty"
 msgstr "Ghostty туралы"
 
@@ -255,6 +255,18 @@ msgstr "Шығу"
 #: src/apprt/gtk/ui/1.5/command-palette.blp:17
 msgid "Execute a command…"
 msgstr "Команданы орындау…"
+
+#: src/apprt/gtk/class/application.zig:1708
+msgid "The keybind was revoked by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1710
+msgid "The keybind was denied by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1721
+msgid "Global keybind unavailable"
+msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
 msgid ""
@@ -316,15 +328,15 @@ msgstr "Осы терезедегі барлық терминал сессиял
 msgid "The currently running process in this split will be terminated."
 msgstr "Осы бөлудегі ағымдағы орындалып жатқан процесс тоқтатылады."
 
-#: src/apprt/gtk/class/surface.zig:1141
+#: src/apprt/gtk/class/surface.zig:1170
 msgid "Command Finished"
 msgstr "Команда аяқталды"
 
-#: src/apprt/gtk/class/surface.zig:1142
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Succeeded"
 msgstr "Команда сәтті орындалды"
 
-#: src/apprt/gtk/class/surface.zig:1143
+#: src/apprt/gtk/class/surface.zig:1172
 msgid "Command Failed"
 msgstr "Команда сәтсіз аяқталды"
 
@@ -344,18 +356,18 @@ msgstr "Терминал атауын өзгерту"
 msgid "Change Tab Title"
 msgstr "Бет атауын өзгерту"
 
-#: src/apprt/gtk/class/window.zig:1067
+#: src/apprt/gtk/class/window.zig:1102
 msgid "Reloaded the configuration"
 msgstr "Конфигурация қайта жүктелді"
 
-#: src/apprt/gtk/class/window.zig:1611
+#: src/apprt/gtk/class/window.zig:1705
 msgid "Copied to clipboard"
 msgstr "Алмасу буферіне көшірілді"
 
-#: src/apprt/gtk/class/window.zig:1613
+#: src/apprt/gtk/class/window.zig:1707
 msgid "Cleared clipboard"
 msgstr "Алмасу буфері тазартылды"
 
-#: src/apprt/gtk/class/window.zig:1753
+#: src/apprt/gtk/class/window.zig:1847
 msgid "Ghostty Developers"
 msgstr "Ghostty әзірлеушілері"

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-03-25 16:24-0700\n"
+"POT-Creation-Date: 2026-07-26 04:59+0200\n"
 "PO-Revision-Date: 2026-02-11 12:50+0900\n"
 "Last-Translator: GyuYong Jung <obliviscence@gmail.com>\n"
 "Language-Team: Korean <translation-team-ko@googlegroups.com>\n"
@@ -74,7 +74,7 @@ msgid "Ignore"
 msgstr "무시"
 
 #: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
 msgid "Reload Configuration"
 msgstr "설정 값 다시 불러오기"
 
@@ -108,7 +108,7 @@ msgstr "이런!"
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "렌더링을 위한 OpenGL 컨텍스트를 가져올 수 없습니다."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:97
+#: src/apprt/gtk/ui/1.2/surface.blp:99
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -117,97 +117,97 @@ msgstr ""
 "이 터미널은 읽기 전용 모드입니다. 콘텐츠를 보고 선택하고 스크롤할 수는 있지"
 "만 실행 중인 애플리케이션으로 입력 이벤트가 전송되지 않습니다."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:107
+#: src/apprt/gtk/ui/1.2/surface.blp:109
 msgid "Read-only"
 msgstr "읽기 전용"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:260 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
 msgid "Copy"
 msgstr "복사"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:265 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
 msgid "Paste"
 msgstr "붙여넣기"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:270
+#: src/apprt/gtk/ui/1.2/surface.blp:272
 msgid "Notify on Next Command Finish"
 msgstr "다음 명령 완료 시 알림"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:277 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
 msgid "Clear"
 msgstr "지우기"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:282 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
 msgid "Reset"
 msgstr "초기화"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:289 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
 msgid "Split"
 msgstr "나누기"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:292 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Change Title…"
 msgstr "제목 변경…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:297 src/apprt/gtk/ui/1.5/window.blp:177
+#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
 #: src/apprt/gtk/ui/1.5/window.blp:250
 msgid "Split Up"
 msgstr "위로 창 나누기"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:303 src/apprt/gtk/ui/1.5/window.blp:182
+#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
 #: src/apprt/gtk/ui/1.5/window.blp:255
 msgid "Split Down"
 msgstr "아래로 창 나누기"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:309 src/apprt/gtk/ui/1.5/window.blp:187
+#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
 #: src/apprt/gtk/ui/1.5/window.blp:260
 msgid "Split Left"
 msgstr "왼쪽으로 창 나누기"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:315 src/apprt/gtk/ui/1.5/window.blp:192
+#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
 #: src/apprt/gtk/ui/1.5/window.blp:265
 msgid "Split Right"
 msgstr "오른쪽으로 창 나누기"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:321
+#: src/apprt/gtk/ui/1.2/surface.blp:323
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:327
+#: src/apprt/gtk/ui/1.2/surface.blp:329
 msgid "Tab"
 msgstr "탭"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:330 src/apprt/gtk/ui/1.5/window.blp:224
+#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
 #: src/apprt/gtk/ui/1.5/window.blp:320
 msgid "Change Tab Title…"
 msgstr "탭 제목 변경…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:335 src/apprt/gtk/ui/1.5/window.blp:57
+#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
 msgid "New Tab"
 msgstr "새 탭"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:340 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
 msgid "Close Tab"
 msgstr "탭 닫기"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:347
+#: src/apprt/gtk/ui/1.2/surface.blp:349
 msgid "Window"
 msgstr "창"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:350 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
 msgid "New Window"
 msgstr "새 창"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:355 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
 msgid "Close Window"
 msgstr "창 닫기"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:363
+#: src/apprt/gtk/ui/1.2/surface.blp:365
 msgid "Config"
 msgstr "설정"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:366 src/apprt/gtk/ui/1.5/window.blp:295
+#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
 msgid "Open Configuration"
 msgstr "설정 열기"
 
@@ -239,7 +239,7 @@ msgstr "명령 팔레트"
 msgid "Terminal Inspector"
 msgstr "터미널 인스펙터"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1772
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
 msgid "About Ghostty"
 msgstr "Ghostty 정보"
 
@@ -250,6 +250,18 @@ msgstr "종료"
 #: src/apprt/gtk/ui/1.5/command-palette.blp:17
 msgid "Execute a command…"
 msgstr "명령을 실행하세요…"
+
+#: src/apprt/gtk/class/application.zig:1708
+msgid "The keybind was revoked by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1710
+msgid "The keybind was denied by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1721
+msgid "Global keybind unavailable"
+msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
 msgid ""
@@ -311,15 +323,15 @@ msgstr "이 창의 모든 터미널 세션이 종료됩니다."
 msgid "The currently running process in this split will be terminated."
 msgstr "이 분할에서 현재 실행 중인 프로세스가 종료됩니다."
 
-#: src/apprt/gtk/class/surface.zig:1141
+#: src/apprt/gtk/class/surface.zig:1170
 msgid "Command Finished"
 msgstr "명령 완료"
 
-#: src/apprt/gtk/class/surface.zig:1142
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Succeeded"
 msgstr "명령 성공"
 
-#: src/apprt/gtk/class/surface.zig:1143
+#: src/apprt/gtk/class/surface.zig:1172
 msgid "Command Failed"
 msgstr "명령 실패"
 
@@ -339,18 +351,18 @@ msgstr "터미널 제목 변경"
 msgid "Change Tab Title"
 msgstr "탭 제목 변경"
 
-#: src/apprt/gtk/class/window.zig:1067
+#: src/apprt/gtk/class/window.zig:1102
 msgid "Reloaded the configuration"
 msgstr "설정값을 다시 불러왔습니다"
 
-#: src/apprt/gtk/class/window.zig:1611
+#: src/apprt/gtk/class/window.zig:1705
 msgid "Copied to clipboard"
 msgstr "클립보드에 복사됨"
 
-#: src/apprt/gtk/class/window.zig:1613
+#: src/apprt/gtk/class/window.zig:1707
 msgid "Cleared clipboard"
 msgstr "클립보드 지워짐"
 
-#: src/apprt/gtk/class/window.zig:1753
+#: src/apprt/gtk/class/window.zig:1847
 msgid "Ghostty Developers"
 msgstr "Ghostty 개발자들"

--- a/po/lt.po
+++ b/po/lt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-03-25 16:24-0700\n"
+"POT-Creation-Date: 2026-07-26 04:59+0200\n"
 "PO-Revision-Date: 2026-02-20 12:13+0100\n"
 "Last-Translator: Tadas Lotuzas <tdslot@gmail.com>\n"
 "Language-Team: Language LT\n"
@@ -76,7 +76,7 @@ msgid "Ignore"
 msgstr "Ignoruoti"
 
 #: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
 msgid "Reload Configuration"
 msgstr "Iš naujo įkelti konfigūraciją"
 
@@ -110,7 +110,7 @@ msgstr "Oi, ne."
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "Nepavyko gauti OpenGL konteksto vaizdavimui."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:97
+#: src/apprt/gtk/ui/1.2/surface.blp:99
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -120,97 +120,97 @@ msgstr ""
 "slinkti per turinį, tačiau jokie įvesties įvykiai nebus siunčiami "
 "veikiančiai programai."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:107
+#: src/apprt/gtk/ui/1.2/surface.blp:109
 msgid "Read-only"
 msgstr "Tik skaitymui"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:260 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
 msgid "Copy"
 msgstr "Kopijuoti"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:265 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
 msgid "Paste"
 msgstr "Įklijuoti"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:270
+#: src/apprt/gtk/ui/1.2/surface.blp:272
 msgid "Notify on Next Command Finish"
 msgstr "Pranešti apie sekančios komandos užbaigimą"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:277 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
 msgid "Clear"
 msgstr "Išvalyti"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:282 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
 msgid "Reset"
 msgstr "Atstatyti"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:289 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
 msgid "Split"
 msgstr "Padalinti"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:292 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Change Title…"
 msgstr "Keisti pavadinimą…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:297 src/apprt/gtk/ui/1.5/window.blp:177
+#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
 #: src/apprt/gtk/ui/1.5/window.blp:250
 msgid "Split Up"
 msgstr "Padalinti aukštyn"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:303 src/apprt/gtk/ui/1.5/window.blp:182
+#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
 #: src/apprt/gtk/ui/1.5/window.blp:255
 msgid "Split Down"
 msgstr "Padalinti žemyn"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:309 src/apprt/gtk/ui/1.5/window.blp:187
+#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
 #: src/apprt/gtk/ui/1.5/window.blp:260
 msgid "Split Left"
 msgstr "Padalinti kairėn"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:315 src/apprt/gtk/ui/1.5/window.blp:192
+#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
 #: src/apprt/gtk/ui/1.5/window.blp:265
 msgid "Split Right"
 msgstr "Padalinti dešinėn"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:321
+#: src/apprt/gtk/ui/1.2/surface.blp:323
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:327
+#: src/apprt/gtk/ui/1.2/surface.blp:329
 msgid "Tab"
 msgstr "Kortelė"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:330 src/apprt/gtk/ui/1.5/window.blp:224
+#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
 #: src/apprt/gtk/ui/1.5/window.blp:320
 msgid "Change Tab Title…"
 msgstr "Keisti kortelės pavadinimą…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:335 src/apprt/gtk/ui/1.5/window.blp:57
+#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
 msgid "New Tab"
 msgstr "Nauja kortelė"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:340 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
 msgid "Close Tab"
 msgstr "Uždaryti kortelę"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:347
+#: src/apprt/gtk/ui/1.2/surface.blp:349
 msgid "Window"
 msgstr "Langas"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:350 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
 msgid "New Window"
 msgstr "Naujas langas"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:355 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
 msgid "Close Window"
 msgstr "Uždaryti langą"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:363
+#: src/apprt/gtk/ui/1.2/surface.blp:365
 msgid "Config"
 msgstr "Konfigūracija"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:366 src/apprt/gtk/ui/1.5/window.blp:295
+#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
 msgid "Open Configuration"
 msgstr "Atidaryti konfigūraciją"
 
@@ -242,7 +242,7 @@ msgstr "Komandų paletė"
 msgid "Terminal Inspector"
 msgstr "Terminalo inspektorius"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1772
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
 msgid "About Ghostty"
 msgstr "Apie Ghostty"
 
@@ -253,6 +253,18 @@ msgstr "Išeiti"
 #: src/apprt/gtk/ui/1.5/command-palette.blp:17
 msgid "Execute a command…"
 msgstr "Vykdyti komandą…"
+
+#: src/apprt/gtk/class/application.zig:1708
+msgid "The keybind was revoked by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1710
+msgid "The keybind was denied by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1721
+msgid "Global keybind unavailable"
+msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
 msgid ""
@@ -314,15 +326,15 @@ msgstr "Visos terminalo sesijos šiame lange bus nutrauktos."
 msgid "The currently running process in this split will be terminated."
 msgstr "Šiuo metu vykdomas procesas šiame padalijime bus nutrauktas."
 
-#: src/apprt/gtk/class/surface.zig:1141
+#: src/apprt/gtk/class/surface.zig:1170
 msgid "Command Finished"
 msgstr "Komanda užbaigta"
 
-#: src/apprt/gtk/class/surface.zig:1142
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Succeeded"
 msgstr "Komanda sėkminga"
 
-#: src/apprt/gtk/class/surface.zig:1143
+#: src/apprt/gtk/class/surface.zig:1172
 msgid "Command Failed"
 msgstr "Komanda nepavyko"
 
@@ -342,18 +354,18 @@ msgstr "Keisti terminalo pavadinimą"
 msgid "Change Tab Title"
 msgstr "Keisti kortelės pavadinimą"
 
-#: src/apprt/gtk/class/window.zig:1067
+#: src/apprt/gtk/class/window.zig:1102
 msgid "Reloaded the configuration"
 msgstr "Konfigūracija įkelta iš naujo"
 
-#: src/apprt/gtk/class/window.zig:1611
+#: src/apprt/gtk/class/window.zig:1705
 msgid "Copied to clipboard"
 msgstr "Nukopijuota į iškarpinę"
 
-#: src/apprt/gtk/class/window.zig:1613
+#: src/apprt/gtk/class/window.zig:1707
 msgid "Cleared clipboard"
 msgstr "Iškarpinė išvalyta"
 
-#: src/apprt/gtk/class/window.zig:1753
+#: src/apprt/gtk/class/window.zig:1847
 msgid "Ghostty Developers"
 msgstr "Ghostty kūrėjai"

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-03-25 16:24-0700\n"
+"POT-Creation-Date: 2026-07-26 04:59+0200\n"
 "PO-Revision-Date: 2026-02-09 03:24+0200\n"
 "Last-Translator: Ēriks Remess <eriks@remess.lv>\n"
 "Language-Team: Latvian\n"
@@ -74,7 +74,7 @@ msgid "Ignore"
 msgstr "Ignorēt"
 
 #: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
 msgid "Reload Configuration"
 msgstr "Pārlādēt konfigurāciju"
 
@@ -108,7 +108,7 @@ msgstr "Ak, nē."
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "Neizdevās iegūt OpenGL kontekstu attēlošanai."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:97
+#: src/apprt/gtk/ui/1.2/surface.blp:99
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -117,97 +117,97 @@ msgstr ""
 "Šis terminālis ir tikai lasīšanas režīmā. Jūs joprojām varat skatīt, atlasīt "
 "un ritināt saturu, taču ievade netiks sūtīta palaistajai lietotnei."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:107
+#: src/apprt/gtk/ui/1.2/surface.blp:109
 msgid "Read-only"
 msgstr "Tikai lasīšanai"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:260 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
 msgid "Copy"
 msgstr "Kopēt"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:265 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
 msgid "Paste"
 msgstr "Ielīmēt"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:270
+#: src/apprt/gtk/ui/1.2/surface.blp:272
 msgid "Notify on Next Command Finish"
 msgstr "Paziņot, kad nākamā komanda būs izpildīta"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:277 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
 msgid "Clear"
 msgstr "Notīrīt"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:282 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
 msgid "Reset"
 msgstr "Atiestatīt"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:289 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
 msgid "Split"
 msgstr "Sadalīt"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:292 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Change Title…"
 msgstr "Mainīt virsrakstu…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:297 src/apprt/gtk/ui/1.5/window.blp:177
+#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
 #: src/apprt/gtk/ui/1.5/window.blp:250
 msgid "Split Up"
 msgstr "Sadalīt uz augšu"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:303 src/apprt/gtk/ui/1.5/window.blp:182
+#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
 #: src/apprt/gtk/ui/1.5/window.blp:255
 msgid "Split Down"
 msgstr "Sadalīt uz leju"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:309 src/apprt/gtk/ui/1.5/window.blp:187
+#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
 #: src/apprt/gtk/ui/1.5/window.blp:260
 msgid "Split Left"
 msgstr "Sadalīt pa kreisi"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:315 src/apprt/gtk/ui/1.5/window.blp:192
+#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
 #: src/apprt/gtk/ui/1.5/window.blp:265
 msgid "Split Right"
 msgstr "Sadalīt pa labi"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:321
+#: src/apprt/gtk/ui/1.2/surface.blp:323
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:327
+#: src/apprt/gtk/ui/1.2/surface.blp:329
 msgid "Tab"
 msgstr "Cilne"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:330 src/apprt/gtk/ui/1.5/window.blp:224
+#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
 #: src/apprt/gtk/ui/1.5/window.blp:320
 msgid "Change Tab Title…"
 msgstr "Mainīt cilnes virsrakstu…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:335 src/apprt/gtk/ui/1.5/window.blp:57
+#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
 msgid "New Tab"
 msgstr "Jauna cilne"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:340 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
 msgid "Close Tab"
 msgstr "Aizvērt cilni"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:347
+#: src/apprt/gtk/ui/1.2/surface.blp:349
 msgid "Window"
 msgstr "Logs"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:350 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
 msgid "New Window"
 msgstr "Jauns logs"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:355 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
 msgid "Close Window"
 msgstr "Aizvērt logu"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:363
+#: src/apprt/gtk/ui/1.2/surface.blp:365
 msgid "Config"
 msgstr "Konfigurācija"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:366 src/apprt/gtk/ui/1.5/window.blp:295
+#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
 msgid "Open Configuration"
 msgstr "Atvērt konfigurāciju"
 
@@ -239,7 +239,7 @@ msgstr "Komandu palete"
 msgid "Terminal Inspector"
 msgstr "Termināļa inspektors"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1772
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
 msgid "About Ghostty"
 msgstr "Par Ghostty"
 
@@ -250,6 +250,18 @@ msgstr "Iziet"
 #: src/apprt/gtk/ui/1.5/command-palette.blp:17
 msgid "Execute a command…"
 msgstr "Izpildīt komandu…"
+
+#: src/apprt/gtk/class/application.zig:1708
+msgid "The keybind was revoked by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1710
+msgid "The keybind was denied by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1721
+msgid "Global keybind unavailable"
+msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
 msgid ""
@@ -311,15 +323,15 @@ msgstr "Visas termināļa sesijas šajā logā tiks pārtrauktas."
 msgid "The currently running process in this split will be terminated."
 msgstr "Pašlaik palaistais process šajā sadalījumā tiks pārtraukts."
 
-#: src/apprt/gtk/class/surface.zig:1141
+#: src/apprt/gtk/class/surface.zig:1170
 msgid "Command Finished"
 msgstr "Komanda izpildīta"
 
-#: src/apprt/gtk/class/surface.zig:1142
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Succeeded"
 msgstr "Komanda izdevās"
 
-#: src/apprt/gtk/class/surface.zig:1143
+#: src/apprt/gtk/class/surface.zig:1172
 msgid "Command Failed"
 msgstr "Komanda neizdevās"
 
@@ -339,18 +351,18 @@ msgstr "Mainīt termināļa virsrakstu"
 msgid "Change Tab Title"
 msgstr "Mainīt cilnes virsrakstu"
 
-#: src/apprt/gtk/class/window.zig:1067
+#: src/apprt/gtk/class/window.zig:1102
 msgid "Reloaded the configuration"
 msgstr "Konfigurācija pārlādēta"
 
-#: src/apprt/gtk/class/window.zig:1611
+#: src/apprt/gtk/class/window.zig:1705
 msgid "Copied to clipboard"
 msgstr "Nokopēts starpliktuvē"
 
-#: src/apprt/gtk/class/window.zig:1613
+#: src/apprt/gtk/class/window.zig:1707
 msgid "Cleared clipboard"
 msgstr "Starpliktuve notīrīta"
 
-#: src/apprt/gtk/class/window.zig:1753
+#: src/apprt/gtk/class/window.zig:1847
 msgid "Ghostty Developers"
 msgstr "Ghostty izstrādātāji"

--- a/po/mk.po
+++ b/po/mk.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-03-25 16:24-0700\n"
+"POT-Creation-Date: 2026-07-26 04:59+0200\n"
 "PO-Revision-Date: 2026-02-12 17:00+0100\n"
 "Last-Translator: Andrej Daskalov <andrej.daskalov@gmail.com>\n"
 "Language-Team: Macedonian\n"
@@ -75,7 +75,7 @@ msgid "Ignore"
 msgstr "Игнорирај"
 
 #: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
 msgid "Reload Configuration"
 msgstr "Одново вчитај конфигурација"
 
@@ -110,7 +110,7 @@ msgstr "Упс."
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "Не може да се добие OpenGL контекст за рендерирање."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:97
+#: src/apprt/gtk/ui/1.2/surface.blp:99
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -120,97 +120,97 @@ msgstr ""
 "се движите низ содржината, но влезните настани нема да бидат испратени до "
 "апликацијата."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:107
+#: src/apprt/gtk/ui/1.2/surface.blp:109
 msgid "Read-only"
 msgstr "Само читање"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:260 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
 msgid "Copy"
 msgstr "Копирај"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:265 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
 msgid "Paste"
 msgstr "Вметни"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:270
+#: src/apprt/gtk/ui/1.2/surface.blp:272
 msgid "Notify on Next Command Finish"
 msgstr "Извести по завршување на следната команда"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:277 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
 msgid "Clear"
 msgstr "Исчисти"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:282 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
 msgid "Reset"
 msgstr "Ресетирај"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:289 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
 msgid "Split"
 msgstr "Подели"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:292 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Change Title…"
 msgstr "Промени наслов…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:297 src/apprt/gtk/ui/1.5/window.blp:177
+#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
 #: src/apprt/gtk/ui/1.5/window.blp:250
 msgid "Split Up"
 msgstr "Подели нагоре"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:303 src/apprt/gtk/ui/1.5/window.blp:182
+#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
 #: src/apprt/gtk/ui/1.5/window.blp:255
 msgid "Split Down"
 msgstr "Подели надолу"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:309 src/apprt/gtk/ui/1.5/window.blp:187
+#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
 #: src/apprt/gtk/ui/1.5/window.blp:260
 msgid "Split Left"
 msgstr "Подели налево"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:315 src/apprt/gtk/ui/1.5/window.blp:192
+#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
 #: src/apprt/gtk/ui/1.5/window.blp:265
 msgid "Split Right"
 msgstr "Подели надесно"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:321
+#: src/apprt/gtk/ui/1.2/surface.blp:323
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:327
+#: src/apprt/gtk/ui/1.2/surface.blp:329
 msgid "Tab"
 msgstr "Јазиче"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:330 src/apprt/gtk/ui/1.5/window.blp:224
+#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
 #: src/apprt/gtk/ui/1.5/window.blp:320
 msgid "Change Tab Title…"
 msgstr "Промени наслов на јазиче…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:335 src/apprt/gtk/ui/1.5/window.blp:57
+#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
 msgid "New Tab"
 msgstr "Ново јазиче"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:340 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
 msgid "Close Tab"
 msgstr "Затвори јазиче"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:347
+#: src/apprt/gtk/ui/1.2/surface.blp:349
 msgid "Window"
 msgstr "Прозор"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:350 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
 msgid "New Window"
 msgstr "Нов прозор"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:355 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
 msgid "Close Window"
 msgstr "Затвори прозор"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:363
+#: src/apprt/gtk/ui/1.2/surface.blp:365
 msgid "Config"
 msgstr "Конфигурација"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:366 src/apprt/gtk/ui/1.5/window.blp:295
+#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
 msgid "Open Configuration"
 msgstr "Отвори конфигурација"
 
@@ -242,7 +242,7 @@ msgstr "Командна палета"
 msgid "Terminal Inspector"
 msgstr "Инспектор на терминал"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1772
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
 msgid "About Ghostty"
 msgstr "За Ghostty"
 
@@ -253,6 +253,18 @@ msgstr "Излез"
 #: src/apprt/gtk/ui/1.5/command-palette.blp:17
 msgid "Execute a command…"
 msgstr "Изврши команда…"
+
+#: src/apprt/gtk/class/application.zig:1708
+msgid "The keybind was revoked by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1710
+msgid "The keybind was denied by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1721
+msgid "Global keybind unavailable"
+msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
 msgid ""
@@ -314,15 +326,15 @@ msgstr "Сите сесии во овој прозорец ќе бидат пр�
 msgid "The currently running process in this split will be terminated."
 msgstr "Процесот кој моментално се извршува во оваа поделба ќе биде прекинат."
 
-#: src/apprt/gtk/class/surface.zig:1141
+#: src/apprt/gtk/class/surface.zig:1170
 msgid "Command Finished"
 msgstr "Командата заврши"
 
-#: src/apprt/gtk/class/surface.zig:1142
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Succeeded"
 msgstr "Командата успеа"
 
-#: src/apprt/gtk/class/surface.zig:1143
+#: src/apprt/gtk/class/surface.zig:1172
 msgid "Command Failed"
 msgstr "Командата не успеа"
 
@@ -342,18 +354,18 @@ msgstr "Промени наслов на терминал"
 msgid "Change Tab Title"
 msgstr "Промени наслов на јазиче"
 
-#: src/apprt/gtk/class/window.zig:1067
+#: src/apprt/gtk/class/window.zig:1102
 msgid "Reloaded the configuration"
 msgstr "Конфигурацијата е одново вчитана"
 
-#: src/apprt/gtk/class/window.zig:1611
+#: src/apprt/gtk/class/window.zig:1705
 msgid "Copied to clipboard"
 msgstr "Копирано во привремена меморија"
 
-#: src/apprt/gtk/class/window.zig:1613
+#: src/apprt/gtk/class/window.zig:1707
 msgid "Cleared clipboard"
 msgstr "Исчистена привремена меморија"
 
-#: src/apprt/gtk/class/window.zig:1753
+#: src/apprt/gtk/class/window.zig:1847
 msgid "Ghostty Developers"
 msgstr "Развивачи на Ghostty"

--- a/po/nb.po
+++ b/po/nb.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-03-25 16:24-0700\n"
+"POT-Creation-Date: 2026-07-26 04:59+0200\n"
 "PO-Revision-Date: 2026-02-12 15:50+0000\n"
 "Last-Translator: Hanna Rose <me@hanna.lol>\n"
 "Language-Team: Norwegian Bokmal <l10n-no@lister.huftis.org>\n"
@@ -77,7 +77,7 @@ msgid "Ignore"
 msgstr "Ignorer"
 
 #: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
 msgid "Reload Configuration"
 msgstr "Last konfigurasjon på nytt"
 
@@ -111,7 +111,7 @@ msgstr "Å, nei."
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "Kan ikke hente en OpenGL-kontekst for rendering."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:97
+#: src/apprt/gtk/ui/1.2/surface.blp:99
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -121,97 +121,97 @@ msgstr ""
 "bla gjennom innholdet, men ingen inndatahendelser vil bli sendt til den "
 "kjørende applikasjonen."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:107
+#: src/apprt/gtk/ui/1.2/surface.blp:109
 msgid "Read-only"
 msgstr "Skrivebeskyttet"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:260 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
 msgid "Copy"
 msgstr "Kopier"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:265 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
 msgid "Paste"
 msgstr "Lim inn"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:270
+#: src/apprt/gtk/ui/1.2/surface.blp:272
 msgid "Notify on Next Command Finish"
 msgstr "Varsle når neste kommandoen fullføres"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:277 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
 msgid "Clear"
 msgstr "Fjern"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:282 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
 msgid "Reset"
 msgstr "Nullstill"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:289 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
 msgid "Split"
 msgstr "Del vindu"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:292 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Change Title…"
 msgstr "Endre tittel…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:297 src/apprt/gtk/ui/1.5/window.blp:177
+#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
 #: src/apprt/gtk/ui/1.5/window.blp:250
 msgid "Split Up"
 msgstr "Del oppover"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:303 src/apprt/gtk/ui/1.5/window.blp:182
+#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
 #: src/apprt/gtk/ui/1.5/window.blp:255
 msgid "Split Down"
 msgstr "Del nedover"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:309 src/apprt/gtk/ui/1.5/window.blp:187
+#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
 #: src/apprt/gtk/ui/1.5/window.blp:260
 msgid "Split Left"
 msgstr "Del til venstre"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:315 src/apprt/gtk/ui/1.5/window.blp:192
+#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
 #: src/apprt/gtk/ui/1.5/window.blp:265
 msgid "Split Right"
 msgstr "Del til høyre"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:321
+#: src/apprt/gtk/ui/1.2/surface.blp:323
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:327
+#: src/apprt/gtk/ui/1.2/surface.blp:329
 msgid "Tab"
 msgstr "Fane"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:330 src/apprt/gtk/ui/1.5/window.blp:224
+#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
 #: src/apprt/gtk/ui/1.5/window.blp:320
 msgid "Change Tab Title…"
 msgstr "Endre fanetittel…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:335 src/apprt/gtk/ui/1.5/window.blp:57
+#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
 msgid "New Tab"
 msgstr "Ny fane"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:340 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
 msgid "Close Tab"
 msgstr "Lukk fane"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:347
+#: src/apprt/gtk/ui/1.2/surface.blp:349
 msgid "Window"
 msgstr "Vindu"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:350 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
 msgid "New Window"
 msgstr "Nytt vindu"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:355 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
 msgid "Close Window"
 msgstr "Lukk vindu"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:363
+#: src/apprt/gtk/ui/1.2/surface.blp:365
 msgid "Config"
 msgstr "Konfigurasjon"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:366 src/apprt/gtk/ui/1.5/window.blp:295
+#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
 msgid "Open Configuration"
 msgstr "Åpne konfigurasjon"
 
@@ -243,7 +243,7 @@ msgstr "Kommandopalett"
 msgid "Terminal Inspector"
 msgstr "Terminalinspektør"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1772
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
 msgid "About Ghostty"
 msgstr "Om Ghostty"
 
@@ -254,6 +254,18 @@ msgstr "Avslutt"
 #: src/apprt/gtk/ui/1.5/command-palette.blp:17
 msgid "Execute a command…"
 msgstr "Kjør en kommando…"
+
+#: src/apprt/gtk/class/application.zig:1708
+msgid "The keybind was revoked by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1710
+msgid "The keybind was denied by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1721
+msgid "Global keybind unavailable"
+msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
 msgid ""
@@ -315,15 +327,15 @@ msgstr "Alle terminaløkter i dette vinduet vil bli avsluttet."
 msgid "The currently running process in this split will be terminated."
 msgstr "Den kjørende prosessen for denne splitten vil bli avsluttet."
 
-#: src/apprt/gtk/class/surface.zig:1141
+#: src/apprt/gtk/class/surface.zig:1170
 msgid "Command Finished"
 msgstr "Kommandoen fullført"
 
-#: src/apprt/gtk/class/surface.zig:1142
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Succeeded"
 msgstr "Kommandoen lyktes"
 
-#: src/apprt/gtk/class/surface.zig:1143
+#: src/apprt/gtk/class/surface.zig:1172
 msgid "Command Failed"
 msgstr "Kommandoen mislyktes"
 
@@ -343,18 +355,18 @@ msgstr "Endre terminaltittel"
 msgid "Change Tab Title"
 msgstr "Endre fanetittel"
 
-#: src/apprt/gtk/class/window.zig:1067
+#: src/apprt/gtk/class/window.zig:1102
 msgid "Reloaded the configuration"
 msgstr "Konfigurasjonen ble lastet på nytt"
 
-#: src/apprt/gtk/class/window.zig:1611
+#: src/apprt/gtk/class/window.zig:1705
 msgid "Copied to clipboard"
 msgstr "Kopiert til utklippstavlen"
 
-#: src/apprt/gtk/class/window.zig:1613
+#: src/apprt/gtk/class/window.zig:1707
 msgid "Cleared clipboard"
 msgstr "Utklippstavle tømt"
 
-#: src/apprt/gtk/class/window.zig:1753
+#: src/apprt/gtk/class/window.zig:1847
 msgid "Ghostty Developers"
 msgstr "Ghostty-utviklere"

--- a/po/nl.po
+++ b/po/nl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-03-25 16:24-0700\n"
+"POT-Creation-Date: 2026-07-26 04:59+0200\n"
 "PO-Revision-Date: 2026-02-18 20:59+0100\n"
 "Last-Translator: Nico Geesink <geesinknico@gmail.com>\n"
 "Language-Team: Dutch <vertaling@vrijschrift.org>\n"
@@ -75,7 +75,7 @@ msgid "Ignore"
 msgstr "Negeer"
 
 #: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
 msgid "Reload Configuration"
 msgstr "Herlaad configuratie"
 
@@ -111,7 +111,7 @@ msgstr "Oh, nee."
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "OpenGL-context voor rendering aanmaken mislukt."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:97
+#: src/apprt/gtk/ui/1.2/surface.blp:99
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -121,97 +121,97 @@ msgstr ""
 "bekijken en selecteren, maar er wordt geen invoer naar de applicatie "
 "verzonden."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:107
+#: src/apprt/gtk/ui/1.2/surface.blp:109
 msgid "Read-only"
 msgstr "Alleen-lezen"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:260 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
 msgid "Copy"
 msgstr "Kopiëren"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:265 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
 msgid "Paste"
 msgstr "Plakken"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:270
+#: src/apprt/gtk/ui/1.2/surface.blp:272
 msgid "Notify on Next Command Finish"
 msgstr "Meld wanneer het volgende commando is afgerond"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:277 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
 msgid "Clear"
 msgstr "Leegmaken"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:282 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
 msgid "Reset"
 msgstr "Herstellen"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:289 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
 msgid "Split"
 msgstr "Splitsen"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:292 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Change Title…"
 msgstr "Wijzig titel…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:297 src/apprt/gtk/ui/1.5/window.blp:177
+#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
 #: src/apprt/gtk/ui/1.5/window.blp:250
 msgid "Split Up"
 msgstr "Splits naar boven"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:303 src/apprt/gtk/ui/1.5/window.blp:182
+#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
 #: src/apprt/gtk/ui/1.5/window.blp:255
 msgid "Split Down"
 msgstr "Splits naar beneden"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:309 src/apprt/gtk/ui/1.5/window.blp:187
+#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
 #: src/apprt/gtk/ui/1.5/window.blp:260
 msgid "Split Left"
 msgstr "Splits naar links"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:315 src/apprt/gtk/ui/1.5/window.blp:192
+#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
 #: src/apprt/gtk/ui/1.5/window.blp:265
 msgid "Split Right"
 msgstr "Splits naar rechts"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:321
+#: src/apprt/gtk/ui/1.2/surface.blp:323
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:327
+#: src/apprt/gtk/ui/1.2/surface.blp:329
 msgid "Tab"
 msgstr "Tabblad"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:330 src/apprt/gtk/ui/1.5/window.blp:224
+#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
 #: src/apprt/gtk/ui/1.5/window.blp:320
 msgid "Change Tab Title…"
 msgstr "Wijzig tabbladtitel…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:335 src/apprt/gtk/ui/1.5/window.blp:57
+#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
 msgid "New Tab"
 msgstr "Nieuw tabblad"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:340 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
 msgid "Close Tab"
 msgstr "Sluit tabblad"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:347
+#: src/apprt/gtk/ui/1.2/surface.blp:349
 msgid "Window"
 msgstr "Venster"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:350 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
 msgid "New Window"
 msgstr "Nieuw venster"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:355 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
 msgid "Close Window"
 msgstr "Sluit venster"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:363
+#: src/apprt/gtk/ui/1.2/surface.blp:365
 msgid "Config"
 msgstr "Configuratie"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:366 src/apprt/gtk/ui/1.5/window.blp:295
+#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
 msgid "Open Configuration"
 msgstr "Open configuratie"
 
@@ -243,7 +243,7 @@ msgstr "Opdrachtpalet"
 msgid "Terminal Inspector"
 msgstr "Terminalinspecteur"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1772
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
 msgid "About Ghostty"
 msgstr "Over Ghostty"
 
@@ -254,6 +254,18 @@ msgstr "Afsluiten"
 #: src/apprt/gtk/ui/1.5/command-palette.blp:17
 msgid "Execute a command…"
 msgstr "Voer een commando uit…"
+
+#: src/apprt/gtk/class/application.zig:1708
+msgid "The keybind was revoked by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1710
+msgid "The keybind was denied by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1721
+msgid "Global keybind unavailable"
+msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
 msgid ""
@@ -315,15 +327,15 @@ msgstr "Alle terminalsessies binnen dit venster zullen worden beëindigd."
 msgid "The currently running process in this split will be terminated."
 msgstr "Alle processen in deze splitsing zullen worden beëindigd."
 
-#: src/apprt/gtk/class/surface.zig:1141
+#: src/apprt/gtk/class/surface.zig:1170
 msgid "Command Finished"
 msgstr "Commando afgerond"
 
-#: src/apprt/gtk/class/surface.zig:1142
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Succeeded"
 msgstr "Commando succesvol afgerond"
 
-#: src/apprt/gtk/class/surface.zig:1143
+#: src/apprt/gtk/class/surface.zig:1172
 msgid "Command Failed"
 msgstr "Commando onsuccesvol afgerond"
 
@@ -343,18 +355,18 @@ msgstr "Titel van de terminal wijzigen"
 msgid "Change Tab Title"
 msgstr "Wijzig tabbladtitel"
 
-#: src/apprt/gtk/class/window.zig:1067
+#: src/apprt/gtk/class/window.zig:1102
 msgid "Reloaded the configuration"
 msgstr "De configuratie is herladen"
 
-#: src/apprt/gtk/class/window.zig:1611
+#: src/apprt/gtk/class/window.zig:1705
 msgid "Copied to clipboard"
 msgstr "Gekopieerd naar klembord"
 
-#: src/apprt/gtk/class/window.zig:1613
+#: src/apprt/gtk/class/window.zig:1707
 msgid "Cleared clipboard"
 msgstr "Klembord geleegd"
 
-#: src/apprt/gtk/class/window.zig:1753
+#: src/apprt/gtk/class/window.zig:1847
 msgid "Ghostty Developers"
 msgstr "Ghostty-ontwikkelaars"

--- a/po/pl.po
+++ b/po/pl.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-03-25 16:24-0700\n"
+"POT-Creation-Date: 2026-07-26 04:59+0200\n"
 "PO-Revision-Date: 2026-02-11 14:12+0100\n"
 "Last-Translator: trag1c <dev@jakubr.me>\n"
 "Language-Team: Polish <translation-team-pl@lists.sourceforge.net>\n"
@@ -77,7 +77,7 @@ msgid "Ignore"
 msgstr "Zignoruj"
 
 #: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
 msgid "Reload Configuration"
 msgstr "Przeładuj konfigurację"
 
@@ -111,7 +111,7 @@ msgstr "O nie!"
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "Nie można uzyskać kontekstu OpenGL do renderowania."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:97
+#: src/apprt/gtk/ui/1.2/surface.blp:99
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -121,97 +121,97 @@ msgstr ""
 "przeglądać, zaznaczać i przewijać zawartość, ale wprowadzane dane nie będą "
 "przesyłane do wykonywanej aplikacji."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:107
+#: src/apprt/gtk/ui/1.2/surface.blp:109
 msgid "Read-only"
 msgstr "Tylko do odczytu"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:260 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
 msgid "Copy"
 msgstr "Kopiuj"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:265 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
 msgid "Paste"
 msgstr "Wklej"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:270
+#: src/apprt/gtk/ui/1.2/surface.blp:272
 msgid "Notify on Next Command Finish"
 msgstr "Powiadom o ukończeniu następnej komendy"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:277 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
 msgid "Clear"
 msgstr "Wyczyść"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:282 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
 msgid "Reset"
 msgstr "Zresetuj"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:289 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
 msgid "Split"
 msgstr "Podział"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:292 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Change Title…"
 msgstr "Zmień tytuł…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:297 src/apprt/gtk/ui/1.5/window.blp:177
+#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
 #: src/apprt/gtk/ui/1.5/window.blp:250
 msgid "Split Up"
 msgstr "Podziel w górę"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:303 src/apprt/gtk/ui/1.5/window.blp:182
+#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
 #: src/apprt/gtk/ui/1.5/window.blp:255
 msgid "Split Down"
 msgstr "Podziel w dół"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:309 src/apprt/gtk/ui/1.5/window.blp:187
+#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
 #: src/apprt/gtk/ui/1.5/window.blp:260
 msgid "Split Left"
 msgstr "Podziel w lewo"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:315 src/apprt/gtk/ui/1.5/window.blp:192
+#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
 #: src/apprt/gtk/ui/1.5/window.blp:265
 msgid "Split Right"
 msgstr "Podziel w prawo"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:321
+#: src/apprt/gtk/ui/1.2/surface.blp:323
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:327
+#: src/apprt/gtk/ui/1.2/surface.blp:329
 msgid "Tab"
 msgstr "Karta"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:330 src/apprt/gtk/ui/1.5/window.blp:224
+#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
 #: src/apprt/gtk/ui/1.5/window.blp:320
 msgid "Change Tab Title…"
 msgstr "Zmień tytuł karty…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:335 src/apprt/gtk/ui/1.5/window.blp:57
+#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
 msgid "New Tab"
 msgstr "Nowa karta"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:340 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
 msgid "Close Tab"
 msgstr "Zamknij kartę"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:347
+#: src/apprt/gtk/ui/1.2/surface.blp:349
 msgid "Window"
 msgstr "Okno"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:350 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
 msgid "New Window"
 msgstr "Nowe okno"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:355 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
 msgid "Close Window"
 msgstr "Zamknij okno"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:363
+#: src/apprt/gtk/ui/1.2/surface.blp:365
 msgid "Config"
 msgstr "Konfiguracja"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:366 src/apprt/gtk/ui/1.5/window.blp:295
+#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
 msgid "Open Configuration"
 msgstr "Otwórz konfigurację"
 
@@ -243,7 +243,7 @@ msgstr "Paleta komend"
 msgid "Terminal Inspector"
 msgstr "Inspektor terminala"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1772
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
 msgid "About Ghostty"
 msgstr "O Ghostty"
 
@@ -254,6 +254,18 @@ msgstr "Zamknij"
 #: src/apprt/gtk/ui/1.5/command-palette.blp:17
 msgid "Execute a command…"
 msgstr "Wykonaj komendę…"
+
+#: src/apprt/gtk/class/application.zig:1708
+msgid "The keybind was revoked by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1710
+msgid "The keybind was denied by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1721
+msgid "Global keybind unavailable"
+msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
 msgid ""
@@ -315,15 +327,15 @@ msgstr "Wszystkie sesje terminala w obecnym oknie zostaną zakończone."
 msgid "The currently running process in this split will be terminated."
 msgstr "Wszyskie trwające procesy w obecnym podziale zostaną zakończone."
 
-#: src/apprt/gtk/class/surface.zig:1141
+#: src/apprt/gtk/class/surface.zig:1170
 msgid "Command Finished"
 msgstr "Komenda zakończona"
 
-#: src/apprt/gtk/class/surface.zig:1142
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Succeeded"
 msgstr "Komenda wykonana pomyślnie"
 
-#: src/apprt/gtk/class/surface.zig:1143
+#: src/apprt/gtk/class/surface.zig:1172
 msgid "Command Failed"
 msgstr "Komenda nie powiodła się"
 
@@ -343,18 +355,18 @@ msgstr "Zmień tytuł terminala"
 msgid "Change Tab Title"
 msgstr "Zmień tytuł karty"
 
-#: src/apprt/gtk/class/window.zig:1067
+#: src/apprt/gtk/class/window.zig:1102
 msgid "Reloaded the configuration"
 msgstr "Przeładowano konfigurację"
 
-#: src/apprt/gtk/class/window.zig:1611
+#: src/apprt/gtk/class/window.zig:1705
 msgid "Copied to clipboard"
 msgstr "Skopiowano do schowka"
 
-#: src/apprt/gtk/class/window.zig:1613
+#: src/apprt/gtk/class/window.zig:1707
 msgid "Cleared clipboard"
 msgstr "Wyczyszczono schowek"
 
-#: src/apprt/gtk/class/window.zig:1753
+#: src/apprt/gtk/class/window.zig:1847
 msgid "Ghostty Developers"
 msgstr "Twórcy Ghostty"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-03-25 16:24-0700\n"
+"POT-Creation-Date: 2026-07-26 04:59+0200\n"
 "PO-Revision-Date: 2026-02-18 10:50-0300\n"
 "Last-Translator: Guilherme Tiscoski <github@guilhermetiscoski.com>\n"
 "Language-Team: Brazilian Portuguese <ldpbr-"
@@ -78,7 +78,7 @@ msgid "Ignore"
 msgstr "Ignorar"
 
 #: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
 msgid "Reload Configuration"
 msgstr "Recarregar configuração"
 
@@ -113,7 +113,7 @@ msgstr "Ah, não."
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "Não foi possível obter um contexto OpenGL para renderização."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:97
+#: src/apprt/gtk/ui/1.2/surface.blp:99
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -123,97 +123,97 @@ msgstr ""
 "selecionar e rolar o conteúdo, mas nenhum evento de entrada será enviado "
 "para a aplicação em execução."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:107
+#: src/apprt/gtk/ui/1.2/surface.blp:109
 msgid "Read-only"
 msgstr "Somente leitura"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:260 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
 msgid "Copy"
 msgstr "Copiar"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:265 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
 msgid "Paste"
 msgstr "Colar"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:270
+#: src/apprt/gtk/ui/1.2/surface.blp:272
 msgid "Notify on Next Command Finish"
 msgstr "Notificar ao finalizar o próximo comando"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:277 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
 msgid "Clear"
 msgstr "Limpar"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:282 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
 msgid "Reset"
 msgstr "Reiniciar"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:289 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
 msgid "Split"
 msgstr "Dividir"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:292 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Change Title…"
 msgstr "Mudar título…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:297 src/apprt/gtk/ui/1.5/window.blp:177
+#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
 #: src/apprt/gtk/ui/1.5/window.blp:250
 msgid "Split Up"
 msgstr "Dividir para cima"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:303 src/apprt/gtk/ui/1.5/window.blp:182
+#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
 #: src/apprt/gtk/ui/1.5/window.blp:255
 msgid "Split Down"
 msgstr "Dividir para baixo"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:309 src/apprt/gtk/ui/1.5/window.blp:187
+#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
 #: src/apprt/gtk/ui/1.5/window.blp:260
 msgid "Split Left"
 msgstr "Dividir à esquerda"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:315 src/apprt/gtk/ui/1.5/window.blp:192
+#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
 #: src/apprt/gtk/ui/1.5/window.blp:265
 msgid "Split Right"
 msgstr "Dividir à direita"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:321
+#: src/apprt/gtk/ui/1.2/surface.blp:323
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:327
+#: src/apprt/gtk/ui/1.2/surface.blp:329
 msgid "Tab"
 msgstr "Aba"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:330 src/apprt/gtk/ui/1.5/window.blp:224
+#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
 #: src/apprt/gtk/ui/1.5/window.blp:320
 msgid "Change Tab Title…"
 msgstr "Mudar título da aba…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:335 src/apprt/gtk/ui/1.5/window.blp:57
+#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
 msgid "New Tab"
 msgstr "Nova aba"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:340 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
 msgid "Close Tab"
 msgstr "Fechar aba"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:347
+#: src/apprt/gtk/ui/1.2/surface.blp:349
 msgid "Window"
 msgstr "Janela"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:350 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
 msgid "New Window"
 msgstr "Nova janela"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:355 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
 msgid "Close Window"
 msgstr "Fechar janela"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:363
+#: src/apprt/gtk/ui/1.2/surface.blp:365
 msgid "Config"
 msgstr "Configurar"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:366 src/apprt/gtk/ui/1.5/window.blp:295
+#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
 msgid "Open Configuration"
 msgstr "Abrir configuração"
 
@@ -245,7 +245,7 @@ msgstr "Paleta de comandos"
 msgid "Terminal Inspector"
 msgstr "Inspetor de terminal"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1772
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
 msgid "About Ghostty"
 msgstr "Sobre o Ghostty"
 
@@ -256,6 +256,18 @@ msgstr "Sair"
 #: src/apprt/gtk/ui/1.5/command-palette.blp:17
 msgid "Execute a command…"
 msgstr "Executar um comando…"
+
+#: src/apprt/gtk/class/application.zig:1708
+msgid "The keybind was revoked by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1710
+msgid "The keybind was denied by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1721
+msgid "Global keybind unavailable"
+msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
 msgid ""
@@ -317,15 +329,15 @@ msgstr "Todas as sessões de terminal nessa janela serão finalizadas."
 msgid "The currently running process in this split will be terminated."
 msgstr "O processo atual rodando nessa divisão será finalizado."
 
-#: src/apprt/gtk/class/surface.zig:1141
+#: src/apprt/gtk/class/surface.zig:1170
 msgid "Command Finished"
 msgstr "Comando finalizado"
 
-#: src/apprt/gtk/class/surface.zig:1142
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Succeeded"
 msgstr "Comando bem-sucedido"
 
-#: src/apprt/gtk/class/surface.zig:1143
+#: src/apprt/gtk/class/surface.zig:1172
 msgid "Command Failed"
 msgstr "Comando falhou"
 
@@ -345,18 +357,18 @@ msgstr "Mudar título do Terminal"
 msgid "Change Tab Title"
 msgstr "Mudar título da aba"
 
-#: src/apprt/gtk/class/window.zig:1067
+#: src/apprt/gtk/class/window.zig:1102
 msgid "Reloaded the configuration"
 msgstr "Configuração recarregada"
 
-#: src/apprt/gtk/class/window.zig:1611
+#: src/apprt/gtk/class/window.zig:1705
 msgid "Copied to clipboard"
 msgstr "Copiado para a área de transferência"
 
-#: src/apprt/gtk/class/window.zig:1613
+#: src/apprt/gtk/class/window.zig:1707
 msgid "Cleared clipboard"
 msgstr "Área de transferência limpa"
 
-#: src/apprt/gtk/class/window.zig:1753
+#: src/apprt/gtk/class/window.zig:1847
 msgid "Ghostty Developers"
 msgstr "Desenvolvedores do Ghostty"

--- a/po/ru.po
+++ b/po/ru.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-03-25 16:24-0700\n"
+"POT-Creation-Date: 2026-07-26 04:59+0200\n"
 "PO-Revision-Date: 2025-02-18 10:20+0100\n"
 "Last-Translator: Ivan Bastrakov <bastaynav@proton.me>\n"
 "Language-Team: Russian <gnu@d07.ru>\n"
@@ -76,7 +76,7 @@ msgid "Ignore"
 msgstr "Игнорировать"
 
 #: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
 msgid "Reload Configuration"
 msgstr "Перезагрузить конфигурацию"
 
@@ -112,7 +112,7 @@ msgstr "Ой!"
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "Не удалось получить доступ к контексту OpenGL для отрисовки."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:97
+#: src/apprt/gtk/ui/1.2/surface.blp:99
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -122,97 +122,97 @@ msgstr ""
 "прокручивать и выделять, но запущенное приложение не будет получать события "
 "ввода."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:107
+#: src/apprt/gtk/ui/1.2/surface.blp:109
 msgid "Read-only"
 msgstr "Режим только для чтения"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:260 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
 msgid "Copy"
 msgstr "Копировать"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:265 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
 msgid "Paste"
 msgstr "Вставить"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:270
+#: src/apprt/gtk/ui/1.2/surface.blp:272
 msgid "Notify on Next Command Finish"
 msgstr "Сообщить о завершении следующей команды"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:277 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
 msgid "Clear"
 msgstr "Очистить"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:282 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
 msgid "Reset"
 msgstr "Сброс"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:289 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
 msgid "Split"
 msgstr "Сплит"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:292 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Change Title…"
 msgstr "Переименовать…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:297 src/apprt/gtk/ui/1.5/window.blp:177
+#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
 #: src/apprt/gtk/ui/1.5/window.blp:250
 msgid "Split Up"
 msgstr "Сплит вверх"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:303 src/apprt/gtk/ui/1.5/window.blp:182
+#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
 #: src/apprt/gtk/ui/1.5/window.blp:255
 msgid "Split Down"
 msgstr "Сплит вниз"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:309 src/apprt/gtk/ui/1.5/window.blp:187
+#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
 #: src/apprt/gtk/ui/1.5/window.blp:260
 msgid "Split Left"
 msgstr "Сплит влево"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:315 src/apprt/gtk/ui/1.5/window.blp:192
+#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
 #: src/apprt/gtk/ui/1.5/window.blp:265
 msgid "Split Right"
 msgstr "Сплит вправо"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:321
+#: src/apprt/gtk/ui/1.2/surface.blp:323
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:327
+#: src/apprt/gtk/ui/1.2/surface.blp:329
 msgid "Tab"
 msgstr "Вкладка"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:330 src/apprt/gtk/ui/1.5/window.blp:224
+#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
 #: src/apprt/gtk/ui/1.5/window.blp:320
 msgid "Change Tab Title…"
 msgstr "Переименовать вкладку…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:335 src/apprt/gtk/ui/1.5/window.blp:57
+#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
 msgid "New Tab"
 msgstr "Новая вкладка"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:340 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
 msgid "Close Tab"
 msgstr "Закрыть вкладку"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:347
+#: src/apprt/gtk/ui/1.2/surface.blp:349
 msgid "Window"
 msgstr "Окно"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:350 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
 msgid "New Window"
 msgstr "Новое окно"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:355 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
 msgid "Close Window"
 msgstr "Закрыть окно"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:363
+#: src/apprt/gtk/ui/1.2/surface.blp:365
 msgid "Config"
 msgstr "Конфигурация"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:366 src/apprt/gtk/ui/1.5/window.blp:295
+#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
 msgid "Open Configuration"
 msgstr "Открыть конфигурационный файл"
 
@@ -244,7 +244,7 @@ msgstr "Палитра команд"
 msgid "Terminal Inspector"
 msgstr "Инспектор терминала"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1772
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
 msgid "About Ghostty"
 msgstr "О Ghostty"
 
@@ -255,6 +255,18 @@ msgstr "Выход"
 #: src/apprt/gtk/ui/1.5/command-palette.blp:17
 msgid "Execute a command…"
 msgstr "Выполнить команду…"
+
+#: src/apprt/gtk/class/application.zig:1708
+msgid "The keybind was revoked by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1710
+msgid "The keybind was denied by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1721
+msgid "Global keybind unavailable"
+msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
 msgid ""
@@ -316,15 +328,15 @@ msgstr "Все сессии терминала в этом окне будут �
 msgid "The currently running process in this split will be terminated."
 msgstr "Процесс, работающий в этой сплит-области, будет остановлен."
 
-#: src/apprt/gtk/class/surface.zig:1141
+#: src/apprt/gtk/class/surface.zig:1170
 msgid "Command Finished"
 msgstr "Команда завершилась"
 
-#: src/apprt/gtk/class/surface.zig:1142
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Succeeded"
 msgstr "Команда выполнена успешно"
 
-#: src/apprt/gtk/class/surface.zig:1143
+#: src/apprt/gtk/class/surface.zig:1172
 msgid "Command Failed"
 msgstr "Команда завершилась с ошибкой"
 
@@ -344,18 +356,18 @@ msgstr "Переименовать терминал"
 msgid "Change Tab Title"
 msgstr "Переименовать вкладку"
 
-#: src/apprt/gtk/class/window.zig:1067
+#: src/apprt/gtk/class/window.zig:1102
 msgid "Reloaded the configuration"
 msgstr "Конфигурация перезагружена"
 
-#: src/apprt/gtk/class/window.zig:1611
+#: src/apprt/gtk/class/window.zig:1705
 msgid "Copied to clipboard"
 msgstr "Скопировано в буфер обмена"
 
-#: src/apprt/gtk/class/window.zig:1613
+#: src/apprt/gtk/class/window.zig:1707
 msgid "Cleared clipboard"
 msgstr "Буфер обмена очищен"
 
-#: src/apprt/gtk/class/window.zig:1753
+#: src/apprt/gtk/class/window.zig:1847
 msgid "Ghostty Developers"
 msgstr "Разработчики Ghostty"

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-03-25 16:24-0700\n"
+"POT-Creation-Date: 2026-07-26 04:59+0200\n"
 "PO-Revision-Date: 2026-02-09 22:18+0300\n"
 "Last-Translator: Emir SARI <emir_sari@icloud.com>\n"
 "Language-Team: Turkish\n"
@@ -75,7 +75,7 @@ msgid "Ignore"
 msgstr "Yok Say"
 
 #: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
 msgid "Reload Configuration"
 msgstr "Yapılandırmayı Yeniden Yükle"
 
@@ -111,7 +111,7 @@ msgstr "Hayır, olamaz."
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "Görüntü oluşturma işlemi için OpenGL bağlamı elde edilemiyor."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:97
+#: src/apprt/gtk/ui/1.2/surface.blp:99
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -121,97 +121,97 @@ msgstr ""
 "kaydırabilirsiniz; ancak çalışan uygulamaya hiçbir giriş olayı "
 "gönderilmeyecektir."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:107
+#: src/apprt/gtk/ui/1.2/surface.blp:109
 msgid "Read-only"
 msgstr "Salt Okunur"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:260 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
 msgid "Copy"
 msgstr "Kopyala"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:265 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
 msgid "Paste"
 msgstr "Yapıştır"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:270
+#: src/apprt/gtk/ui/1.2/surface.blp:272
 msgid "Notify on Next Command Finish"
 msgstr "Sonraki Komut Bittiğinde Bildir"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:277 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
 msgid "Clear"
 msgstr "Temizle"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:282 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
 msgid "Reset"
 msgstr "Sıfırla"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:289 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
 msgid "Split"
 msgstr "Böl"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:292 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Change Title…"
 msgstr "Başlığı Değiştir…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:297 src/apprt/gtk/ui/1.5/window.blp:177
+#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
 #: src/apprt/gtk/ui/1.5/window.blp:250
 msgid "Split Up"
 msgstr "Yukarı Doğru Böl"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:303 src/apprt/gtk/ui/1.5/window.blp:182
+#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
 #: src/apprt/gtk/ui/1.5/window.blp:255
 msgid "Split Down"
 msgstr "Aşağı Doğru Böl"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:309 src/apprt/gtk/ui/1.5/window.blp:187
+#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
 #: src/apprt/gtk/ui/1.5/window.blp:260
 msgid "Split Left"
 msgstr "Sola Doğru Böl"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:315 src/apprt/gtk/ui/1.5/window.blp:192
+#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
 #: src/apprt/gtk/ui/1.5/window.blp:265
 msgid "Split Right"
 msgstr "Sağa Doğru Böl"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:321
+#: src/apprt/gtk/ui/1.2/surface.blp:323
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:327
+#: src/apprt/gtk/ui/1.2/surface.blp:329
 msgid "Tab"
 msgstr "Sekme"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:330 src/apprt/gtk/ui/1.5/window.blp:224
+#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
 #: src/apprt/gtk/ui/1.5/window.blp:320
 msgid "Change Tab Title…"
 msgstr "Sekme Başlığını Değiştir…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:335 src/apprt/gtk/ui/1.5/window.blp:57
+#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
 msgid "New Tab"
 msgstr "Yeni Sekme"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:340 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
 msgid "Close Tab"
 msgstr "Sekmeyi Kapat"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:347
+#: src/apprt/gtk/ui/1.2/surface.blp:349
 msgid "Window"
 msgstr "Pencere"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:350 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
 msgid "New Window"
 msgstr "Yeni Pencere"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:355 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
 msgid "Close Window"
 msgstr "Pencereyi Kapat"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:363
+#: src/apprt/gtk/ui/1.2/surface.blp:365
 msgid "Config"
 msgstr "Yapılandırma"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:366 src/apprt/gtk/ui/1.5/window.blp:295
+#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
 msgid "Open Configuration"
 msgstr "Yapılandırmayı Aç"
 
@@ -243,7 +243,7 @@ msgstr "Komut Paleti"
 msgid "Terminal Inspector"
 msgstr "Uçbirim Denetçisi"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1772
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
 msgid "About Ghostty"
 msgstr "Ghostty Hakkında"
 
@@ -254,6 +254,18 @@ msgstr "Çık"
 #: src/apprt/gtk/ui/1.5/command-palette.blp:17
 msgid "Execute a command…"
 msgstr "Bir komut çalıştır…"
+
+#: src/apprt/gtk/class/application.zig:1708
+msgid "The keybind was revoked by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1710
+msgid "The keybind was denied by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1721
+msgid "Global keybind unavailable"
+msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
 msgid ""
@@ -315,15 +327,15 @@ msgstr "Bu penceredeki tüm uçbirim oturumları sonlandırılacaktır."
 msgid "The currently running process in this split will be terminated."
 msgstr "Bu bölmedeki şu anda çalışan süreç sonlandırılacaktır."
 
-#: src/apprt/gtk/class/surface.zig:1141
+#: src/apprt/gtk/class/surface.zig:1170
 msgid "Command Finished"
 msgstr "Komut Bitti"
 
-#: src/apprt/gtk/class/surface.zig:1142
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Succeeded"
 msgstr "Komut Başarılı"
 
-#: src/apprt/gtk/class/surface.zig:1143
+#: src/apprt/gtk/class/surface.zig:1172
 msgid "Command Failed"
 msgstr "Komut Başarısız"
 
@@ -343,18 +355,18 @@ msgstr "Uçbirim Başlığını Değiştir"
 msgid "Change Tab Title"
 msgstr "Sekme Başlığını Değiştir"
 
-#: src/apprt/gtk/class/window.zig:1067
+#: src/apprt/gtk/class/window.zig:1102
 msgid "Reloaded the configuration"
 msgstr "Yapılandırma yeniden yüklendi"
 
-#: src/apprt/gtk/class/window.zig:1611
+#: src/apprt/gtk/class/window.zig:1705
 msgid "Copied to clipboard"
 msgstr "Panoya kopyalandı"
 
-#: src/apprt/gtk/class/window.zig:1613
+#: src/apprt/gtk/class/window.zig:1707
 msgid "Cleared clipboard"
 msgstr "Pano temizlendi"
 
-#: src/apprt/gtk/class/window.zig:1753
+#: src/apprt/gtk/class/window.zig:1847
 msgid "Ghostty Developers"
 msgstr "Ghostty Geliştiricileri"

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-03-25 16:24-0700\n"
+"POT-Creation-Date: 2026-07-26 04:59+0200\n"
 "PO-Revision-Date: 2026-02-18 13:14+0100\n"
 "Last-Translator: Volodymyr Chernetskyi "
 "<19735328+chernetskyi@users.noreply.github.com>\n"
@@ -76,7 +76,7 @@ msgid "Ignore"
 msgstr "Ігнорувати"
 
 #: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
 msgid "Reload Configuration"
 msgstr "Перезавантажити налаштування"
 
@@ -111,7 +111,7 @@ msgstr "Халепа."
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "Не вдалося отримати контекст OpenGL для відображення."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:97
+#: src/apprt/gtk/ui/1.2/surface.blp:99
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -120,97 +120,97 @@ msgstr ""
 "Цей термінал працює в режимі читання. Можна переглядати, виділяти і гортати "
 "вміст, але ввід не буде передано до запущеної програми."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:107
+#: src/apprt/gtk/ui/1.2/surface.blp:109
 msgid "Read-only"
 msgstr "Тільки для читання"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:260 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
 msgid "Copy"
 msgstr "Скопіювати"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:265 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
 msgid "Paste"
 msgstr "Вставити"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:270
+#: src/apprt/gtk/ui/1.2/surface.blp:272
 msgid "Notify on Next Command Finish"
 msgstr "Сповістити про завершення наступної команди"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:277 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
 msgid "Clear"
 msgstr "Очистити"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:282 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
 msgid "Reset"
 msgstr "Скинути"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:289 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
 msgid "Split"
 msgstr "Панель"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:292 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Change Title…"
 msgstr "Змінити заголовок…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:297 src/apprt/gtk/ui/1.5/window.blp:177
+#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
 #: src/apprt/gtk/ui/1.5/window.blp:250
 msgid "Split Up"
 msgstr "Нова панель зверху"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:303 src/apprt/gtk/ui/1.5/window.blp:182
+#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
 #: src/apprt/gtk/ui/1.5/window.blp:255
 msgid "Split Down"
 msgstr "Нова панель знизу"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:309 src/apprt/gtk/ui/1.5/window.blp:187
+#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
 #: src/apprt/gtk/ui/1.5/window.blp:260
 msgid "Split Left"
 msgstr "Нова панель ліворуч"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:315 src/apprt/gtk/ui/1.5/window.blp:192
+#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
 #: src/apprt/gtk/ui/1.5/window.blp:265
 msgid "Split Right"
 msgstr "Нова панель праворуч"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:321
+#: src/apprt/gtk/ui/1.2/surface.blp:323
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:327
+#: src/apprt/gtk/ui/1.2/surface.blp:329
 msgid "Tab"
 msgstr "Вкладка"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:330 src/apprt/gtk/ui/1.5/window.blp:224
+#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
 #: src/apprt/gtk/ui/1.5/window.blp:320
 msgid "Change Tab Title…"
 msgstr "Змінити заголовок вкладки…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:335 src/apprt/gtk/ui/1.5/window.blp:57
+#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
 msgid "New Tab"
 msgstr "Нова вкладка"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:340 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
 msgid "Close Tab"
 msgstr "Закрити вкладку"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:347
+#: src/apprt/gtk/ui/1.2/surface.blp:349
 msgid "Window"
 msgstr "Вікно"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:350 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
 msgid "New Window"
 msgstr "Нове вікно"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:355 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
 msgid "Close Window"
 msgstr "Закрити вікно"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:363
+#: src/apprt/gtk/ui/1.2/surface.blp:365
 msgid "Config"
 msgstr "Налаштування"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:366 src/apprt/gtk/ui/1.5/window.blp:295
+#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
 msgid "Open Configuration"
 msgstr "Відкрити налаштування"
 
@@ -242,7 +242,7 @@ msgstr "Палітра команд"
 msgid "Terminal Inspector"
 msgstr "Інспектор терміналу"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1772
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
 msgid "About Ghostty"
 msgstr "Про Ghostty"
 
@@ -253,6 +253,18 @@ msgstr "Завершити"
 #: src/apprt/gtk/ui/1.5/command-palette.blp:17
 msgid "Execute a command…"
 msgstr "Виконати команду…"
+
+#: src/apprt/gtk/class/application.zig:1708
+msgid "The keybind was revoked by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1710
+msgid "The keybind was denied by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1721
+msgid "Global keybind unavailable"
+msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
 msgid ""
@@ -314,15 +326,15 @@ msgstr "Всі сесії терміналу в цьому вікні будут
 msgid "The currently running process in this split will be terminated."
 msgstr "Процес, що виконується в цій панелі, буде завершено."
 
-#: src/apprt/gtk/class/surface.zig:1141
+#: src/apprt/gtk/class/surface.zig:1170
 msgid "Command Finished"
 msgstr "Команда завершилась"
 
-#: src/apprt/gtk/class/surface.zig:1142
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Succeeded"
 msgstr "Команда завершилась успішно"
 
-#: src/apprt/gtk/class/surface.zig:1143
+#: src/apprt/gtk/class/surface.zig:1172
 msgid "Command Failed"
 msgstr "Команда завершилась з помилкою"
 
@@ -342,18 +354,18 @@ msgstr "Змінити заголовок терміналу"
 msgid "Change Tab Title"
 msgstr "Змінити заголовок вкладки"
 
-#: src/apprt/gtk/class/window.zig:1067
+#: src/apprt/gtk/class/window.zig:1102
 msgid "Reloaded the configuration"
 msgstr "Налаштування перезавантажено"
 
-#: src/apprt/gtk/class/window.zig:1611
+#: src/apprt/gtk/class/window.zig:1705
 msgid "Copied to clipboard"
 msgstr "Скопійовано до буферa обміну"
 
-#: src/apprt/gtk/class/window.zig:1613
+#: src/apprt/gtk/class/window.zig:1707
 msgid "Cleared clipboard"
 msgstr "Буфер обміну очищено"
 
-#: src/apprt/gtk/class/window.zig:1753
+#: src/apprt/gtk/class/window.zig:1847
 msgid "Ghostty Developers"
 msgstr "Розробники Ghostty"

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-03-25 16:24-0700\n"
+"POT-Creation-Date: 2026-07-26 04:59+0200\n"
 "PO-Revision-Date: 2026-03-04 09:32+0700\n"
 "Last-Translator: Anh Thang <buianhthang89@gmail.com>\n"
 "Language-Team: Vietnamese <translation-team-vi@lists.sourceforge.net>\n"
@@ -74,7 +74,7 @@ msgid "Ignore"
 msgstr "Bỏ qua"
 
 #: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
 msgid "Reload Configuration"
 msgstr "Tải lại cấu hình"
 
@@ -110,7 +110,7 @@ msgstr "Ôi hỏng rồi."
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "Không thể lấy ngữ cảnh OpenGL để kết xuất đồ họa."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:97
+#: src/apprt/gtk/ui/1.2/surface.blp:99
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -119,97 +119,97 @@ msgstr ""
 "Terminal này đang ở chế độ chỉ đọc. Bạn vẫn có thể xem, chọn và cuộn nội "
 "dung, nhưng các sự kiện nhập liệu sẽ không được gửi đến ứng dụng."
 
-#: src/apprt/gtk/ui/1.2/surface.blp:107
+#: src/apprt/gtk/ui/1.2/surface.blp:109
 msgid "Read-only"
 msgstr "Chỉ đọc"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:260 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
 msgid "Copy"
 msgstr "Sao chép"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:265 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
 msgid "Paste"
 msgstr "Dán"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:270
+#: src/apprt/gtk/ui/1.2/surface.blp:272
 msgid "Notify on Next Command Finish"
 msgstr "Thông báo khi lệnh tiếp theo kết thúc"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:277 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
 msgid "Clear"
 msgstr "Xóa"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:282 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
 msgid "Reset"
 msgstr "Đặt lại"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:289 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
 msgid "Split"
 msgstr "Chia màn hình"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:292 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Change Title…"
 msgstr "Đổi tiêu đề…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:297 src/apprt/gtk/ui/1.5/window.blp:177
+#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
 #: src/apprt/gtk/ui/1.5/window.blp:250
 msgid "Split Up"
 msgstr "Chia lên trên"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:303 src/apprt/gtk/ui/1.5/window.blp:182
+#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
 #: src/apprt/gtk/ui/1.5/window.blp:255
 msgid "Split Down"
 msgstr "Chia xuống dưới"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:309 src/apprt/gtk/ui/1.5/window.blp:187
+#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
 #: src/apprt/gtk/ui/1.5/window.blp:260
 msgid "Split Left"
 msgstr "Chia sang trái"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:315 src/apprt/gtk/ui/1.5/window.blp:192
+#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
 #: src/apprt/gtk/ui/1.5/window.blp:265
 msgid "Split Right"
 msgstr "Chia sang phải"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:321
+#: src/apprt/gtk/ui/1.2/surface.blp:323
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:327
+#: src/apprt/gtk/ui/1.2/surface.blp:329
 msgid "Tab"
 msgstr "Tab"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:330 src/apprt/gtk/ui/1.5/window.blp:224
+#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
 #: src/apprt/gtk/ui/1.5/window.blp:320
 msgid "Change Tab Title…"
 msgstr "Đổi tiêu đề Tab…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:335 src/apprt/gtk/ui/1.5/window.blp:57
+#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
 msgid "New Tab"
 msgstr "Tab mới"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:340 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
 msgid "Close Tab"
 msgstr "Đóng Tab"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:347
+#: src/apprt/gtk/ui/1.2/surface.blp:349
 msgid "Window"
 msgstr "Cửa sổ"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:350 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
 msgid "New Window"
 msgstr "Cửa sổ mới"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:355 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
 msgid "Close Window"
 msgstr "Đóng cửa sổ"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:363
+#: src/apprt/gtk/ui/1.2/surface.blp:365
 msgid "Config"
 msgstr "Cấu hình"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:366 src/apprt/gtk/ui/1.5/window.blp:295
+#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
 msgid "Open Configuration"
 msgstr "Mở tệp cấu hình"
 
@@ -241,7 +241,7 @@ msgstr "Bảng lệnh"
 msgid "Terminal Inspector"
 msgstr "Bộ kiểm tra Terminal"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1772
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
 msgid "About Ghostty"
 msgstr "Về Ghostty"
 
@@ -252,6 +252,18 @@ msgstr "Thoát"
 #: src/apprt/gtk/ui/1.5/command-palette.blp:17
 msgid "Execute a command…"
 msgstr "Chạy một lệnh…"
+
+#: src/apprt/gtk/class/application.zig:1708
+msgid "The keybind was revoked by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1710
+msgid "The keybind was denied by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1721
+msgid "Global keybind unavailable"
+msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
 msgid ""
@@ -313,15 +325,15 @@ msgstr "Tất cả các phiên làm việc terminal trong cửa sổ này sẽ b
 msgid "The currently running process in this split will be terminated."
 msgstr "Tiến trình đang chạy trong phần chia này sẽ bị chấm dứt."
 
-#: src/apprt/gtk/class/surface.zig:1141
+#: src/apprt/gtk/class/surface.zig:1170
 msgid "Command Finished"
 msgstr "Lệnh đã kết thúc"
 
-#: src/apprt/gtk/class/surface.zig:1142
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Succeeded"
 msgstr "Lệnh thành công"
 
-#: src/apprt/gtk/class/surface.zig:1143
+#: src/apprt/gtk/class/surface.zig:1172
 msgid "Command Failed"
 msgstr "Lệnh thất bại"
 
@@ -341,18 +353,18 @@ msgstr "Đổi tiêu đề Terminal"
 msgid "Change Tab Title"
 msgstr "Đổi tiêu đề Tab"
 
-#: src/apprt/gtk/class/window.zig:1067
+#: src/apprt/gtk/class/window.zig:1102
 msgid "Reloaded the configuration"
 msgstr "Đã tải lại cấu hình"
 
-#: src/apprt/gtk/class/window.zig:1611
+#: src/apprt/gtk/class/window.zig:1705
 msgid "Copied to clipboard"
 msgstr "Đã sao chép vào bảng tạm"
 
-#: src/apprt/gtk/class/window.zig:1613
+#: src/apprt/gtk/class/window.zig:1707
 msgid "Cleared clipboard"
 msgstr "Đã xóa sạch bảng tạm"
 
-#: src/apprt/gtk/class/window.zig:1753
+#: src/apprt/gtk/class/window.zig:1847
 msgid "Ghostty Developers"
 msgstr "Các nhà phát triển Ghostty"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-03-25 16:24-0700\n"
+"POT-Creation-Date: 2026-07-26 04:59+0200\n"
 "PO-Revision-Date: 2026-02-12 01:56+0800\n"
 "Last-Translator: Leah <hi@pluie.me>\n"
 "Language-Team: Chinese (simplified) <i18n-zh@googlegroups.com>\n"
@@ -74,7 +74,7 @@ msgid "Ignore"
 msgstr "忽略"
 
 #: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
 msgid "Reload Configuration"
 msgstr "重新加载配置"
 
@@ -108,7 +108,7 @@ msgstr "糟糕。"
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "未能获取可用于渲染的 OpenGL 环境。"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:97
+#: src/apprt/gtk/ui/1.2/surface.blp:99
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -117,97 +117,97 @@ msgstr ""
 "本终端当前处于只读模式。你仍可浏览、选择、并滚动其中内容，但任何用户输入都不"
 "会传给运行中的程序。"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:107
+#: src/apprt/gtk/ui/1.2/surface.blp:109
 msgid "Read-only"
 msgstr "只读"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:260 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
 msgid "Copy"
 msgstr "复制"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:265 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
 msgid "Paste"
 msgstr "粘贴"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:270
+#: src/apprt/gtk/ui/1.2/surface.blp:272
 msgid "Notify on Next Command Finish"
 msgstr "下条命令完成时发出提醒"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:277 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
 msgid "Clear"
 msgstr "清除屏幕"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:282 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
 msgid "Reset"
 msgstr "重置终端"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:289 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
 msgid "Split"
 msgstr "分屏"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:292 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Change Title…"
 msgstr "更改标题…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:297 src/apprt/gtk/ui/1.5/window.blp:177
+#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
 #: src/apprt/gtk/ui/1.5/window.blp:250
 msgid "Split Up"
 msgstr "向上分屏"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:303 src/apprt/gtk/ui/1.5/window.blp:182
+#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
 #: src/apprt/gtk/ui/1.5/window.blp:255
 msgid "Split Down"
 msgstr "向下分屏"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:309 src/apprt/gtk/ui/1.5/window.blp:187
+#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
 #: src/apprt/gtk/ui/1.5/window.blp:260
 msgid "Split Left"
 msgstr "向左分屏"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:315 src/apprt/gtk/ui/1.5/window.blp:192
+#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
 #: src/apprt/gtk/ui/1.5/window.blp:265
 msgid "Split Right"
 msgstr "向右分屏"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:321
+#: src/apprt/gtk/ui/1.2/surface.blp:323
 msgid "Close Split"
 msgstr "关闭分屏"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:327
+#: src/apprt/gtk/ui/1.2/surface.blp:329
 msgid "Tab"
 msgstr "标签页"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:330 src/apprt/gtk/ui/1.5/window.blp:224
+#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
 #: src/apprt/gtk/ui/1.5/window.blp:320
 msgid "Change Tab Title…"
 msgstr "更改标签页标题…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:335 src/apprt/gtk/ui/1.5/window.blp:57
+#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
 msgid "New Tab"
 msgstr "新建标签页"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:340 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
 msgid "Close Tab"
 msgstr "关闭标签页"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:347
+#: src/apprt/gtk/ui/1.2/surface.blp:349
 msgid "Window"
 msgstr "窗口"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:350 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
 msgid "New Window"
 msgstr "新建窗口"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:355 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
 msgid "Close Window"
 msgstr "关闭窗口"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:363
+#: src/apprt/gtk/ui/1.2/surface.blp:365
 msgid "Config"
 msgstr "配置"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:366 src/apprt/gtk/ui/1.5/window.blp:295
+#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
 msgid "Open Configuration"
 msgstr "打开配置文件"
 
@@ -239,7 +239,7 @@ msgstr "命令面板"
 msgid "Terminal Inspector"
 msgstr "终端调试器"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1772
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
 msgid "About Ghostty"
 msgstr "关于 Ghostty"
 
@@ -250,6 +250,18 @@ msgstr "退出"
 #: src/apprt/gtk/ui/1.5/command-palette.blp:17
 msgid "Execute a command…"
 msgstr "选择要执行的命令…"
+
+#: src/apprt/gtk/class/application.zig:1708
+msgid "The keybind was revoked by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1710
+msgid "The keybind was denied by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1721
+msgid "Global keybind unavailable"
+msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
 msgid ""
@@ -305,15 +317,15 @@ msgstr "窗口内所有运行中的进程将被终止。"
 msgid "The currently running process in this split will be terminated."
 msgstr "分屏内正在运行中的进程将被终止。"
 
-#: src/apprt/gtk/class/surface.zig:1141
+#: src/apprt/gtk/class/surface.zig:1170
 msgid "Command Finished"
 msgstr "命令已完成"
 
-#: src/apprt/gtk/class/surface.zig:1142
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Succeeded"
 msgstr "命令执行成功"
 
-#: src/apprt/gtk/class/surface.zig:1143
+#: src/apprt/gtk/class/surface.zig:1172
 msgid "Command Failed"
 msgstr "命令执行失败"
 
@@ -333,18 +345,18 @@ msgstr "更改终端标题"
 msgid "Change Tab Title"
 msgstr "更改标签页标题"
 
-#: src/apprt/gtk/class/window.zig:1067
+#: src/apprt/gtk/class/window.zig:1102
 msgid "Reloaded the configuration"
 msgstr "已重新加载配置"
 
-#: src/apprt/gtk/class/window.zig:1611
+#: src/apprt/gtk/class/window.zig:1705
 msgid "Copied to clipboard"
 msgstr "已复制至剪贴板"
 
-#: src/apprt/gtk/class/window.zig:1613
+#: src/apprt/gtk/class/window.zig:1707
 msgid "Cleared clipboard"
 msgstr "已清空剪贴板"
 
-#: src/apprt/gtk/class/window.zig:1753
+#: src/apprt/gtk/class/window.zig:1847
 msgid "Ghostty Developers"
 msgstr "Ghostty 开发团队"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-03-25 16:24-0700\n"
+"POT-Creation-Date: 2026-07-26 04:59+0200\n"
 "PO-Revision-Date: 2026-02-18 13:58+0800\n"
 "Last-Translator: Yi-Jyun Pan <me@pan93.com>\n"
 "Language-Team: Chinese (traditional)\n"
@@ -72,7 +72,7 @@ msgid "Ignore"
 msgstr "忽略"
 
 #: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:11
-#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:300
+#: src/apprt/gtk/ui/1.2/surface.blp:373 src/apprt/gtk/ui/1.5/window.blp:300
 msgid "Reload Configuration"
 msgstr "重新載入設定"
 
@@ -106,7 +106,7 @@ msgstr "噢不。"
 msgid "Unable to acquire an OpenGL context for rendering."
 msgstr "無法取得用於算繪的 OpenGL 上下文。"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:97
+#: src/apprt/gtk/ui/1.2/surface.blp:99
 msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll "
 "through the content, but no input events will be sent to the running "
@@ -115,97 +115,97 @@ msgstr ""
 "本終端機目前處於唯讀模式。您仍可查看、選取及捲動內容，但不會傳送任何輸入事件"
 "至執行中的應用程式。"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:107
+#: src/apprt/gtk/ui/1.2/surface.blp:109
 msgid "Read-only"
 msgstr "唯讀"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:260 src/apprt/gtk/ui/1.5/window.blp:200
+#: src/apprt/gtk/ui/1.2/surface.blp:262 src/apprt/gtk/ui/1.5/window.blp:200
 msgid "Copy"
 msgstr "複製"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:265 src/apprt/gtk/ui/1.5/window.blp:205
+#: src/apprt/gtk/ui/1.2/surface.blp:267 src/apprt/gtk/ui/1.5/window.blp:205
 msgid "Paste"
 msgstr "貼上"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:270
+#: src/apprt/gtk/ui/1.2/surface.blp:272
 msgid "Notify on Next Command Finish"
 msgstr "下個命令完成時通知"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:277 src/apprt/gtk/ui/1.5/window.blp:273
+#: src/apprt/gtk/ui/1.2/surface.blp:279 src/apprt/gtk/ui/1.5/window.blp:273
 msgid "Clear"
 msgstr "清除"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:282 src/apprt/gtk/ui/1.5/window.blp:278
+#: src/apprt/gtk/ui/1.2/surface.blp:284 src/apprt/gtk/ui/1.5/window.blp:278
 msgid "Reset"
 msgstr "重設"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:289 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/apprt/gtk/ui/1.2/surface.blp:291 src/apprt/gtk/ui/1.5/window.blp:242
 msgid "Split"
 msgstr "分割"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:292 src/apprt/gtk/ui/1.5/window.blp:245
+#: src/apprt/gtk/ui/1.2/surface.blp:294 src/apprt/gtk/ui/1.5/window.blp:245
 msgid "Change Title…"
 msgstr "變更標題…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:297 src/apprt/gtk/ui/1.5/window.blp:177
+#: src/apprt/gtk/ui/1.2/surface.blp:299 src/apprt/gtk/ui/1.5/window.blp:177
 #: src/apprt/gtk/ui/1.5/window.blp:250
 msgid "Split Up"
 msgstr "向上分割"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:303 src/apprt/gtk/ui/1.5/window.blp:182
+#: src/apprt/gtk/ui/1.2/surface.blp:305 src/apprt/gtk/ui/1.5/window.blp:182
 #: src/apprt/gtk/ui/1.5/window.blp:255
 msgid "Split Down"
 msgstr "向下分割"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:309 src/apprt/gtk/ui/1.5/window.blp:187
+#: src/apprt/gtk/ui/1.2/surface.blp:311 src/apprt/gtk/ui/1.5/window.blp:187
 #: src/apprt/gtk/ui/1.5/window.blp:260
 msgid "Split Left"
 msgstr "向左分割"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:315 src/apprt/gtk/ui/1.5/window.blp:192
+#: src/apprt/gtk/ui/1.2/surface.blp:317 src/apprt/gtk/ui/1.5/window.blp:192
 #: src/apprt/gtk/ui/1.5/window.blp:265
 msgid "Split Right"
 msgstr "向右分割"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:321
+#: src/apprt/gtk/ui/1.2/surface.blp:323
 msgid "Close Split"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.2/surface.blp:327
+#: src/apprt/gtk/ui/1.2/surface.blp:329
 msgid "Tab"
 msgstr "分頁"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:330 src/apprt/gtk/ui/1.5/window.blp:224
+#: src/apprt/gtk/ui/1.2/surface.blp:332 src/apprt/gtk/ui/1.5/window.blp:224
 #: src/apprt/gtk/ui/1.5/window.blp:320
 msgid "Change Tab Title…"
 msgstr "變更分頁標題…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:335 src/apprt/gtk/ui/1.5/window.blp:57
+#: src/apprt/gtk/ui/1.2/surface.blp:337 src/apprt/gtk/ui/1.5/window.blp:57
 #: src/apprt/gtk/ui/1.5/window.blp:107 src/apprt/gtk/ui/1.5/window.blp:229
 msgid "New Tab"
 msgstr "開新分頁"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:340 src/apprt/gtk/ui/1.5/window.blp:234
+#: src/apprt/gtk/ui/1.2/surface.blp:342 src/apprt/gtk/ui/1.5/window.blp:234
 msgid "Close Tab"
 msgstr "關閉分頁"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:347
+#: src/apprt/gtk/ui/1.2/surface.blp:349
 msgid "Window"
 msgstr "視窗"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:350 src/apprt/gtk/ui/1.5/window.blp:212
+#: src/apprt/gtk/ui/1.2/surface.blp:352 src/apprt/gtk/ui/1.5/window.blp:212
 msgid "New Window"
 msgstr "開新視窗"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:355 src/apprt/gtk/ui/1.5/window.blp:217
+#: src/apprt/gtk/ui/1.2/surface.blp:357 src/apprt/gtk/ui/1.5/window.blp:217
 msgid "Close Window"
 msgstr "關閉視窗"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:363
+#: src/apprt/gtk/ui/1.2/surface.blp:365
 msgid "Config"
 msgstr "設定"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:366 src/apprt/gtk/ui/1.5/window.blp:295
+#: src/apprt/gtk/ui/1.2/surface.blp:368 src/apprt/gtk/ui/1.5/window.blp:295
 msgid "Open Configuration"
 msgstr "開啟設定"
 
@@ -237,7 +237,7 @@ msgstr "命令面板"
 msgid "Terminal Inspector"
 msgstr "終端機檢查工具"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1772
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
 msgid "About Ghostty"
 msgstr "關於 Ghostty"
 
@@ -248,6 +248,18 @@ msgstr "結束"
 #: src/apprt/gtk/ui/1.5/command-palette.blp:17
 msgid "Execute a command…"
 msgstr "執行命令…"
+
+#: src/apprt/gtk/class/application.zig:1708
+msgid "The keybind was revoked by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1710
+msgid "The keybind was denied by the system."
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:1721
+msgid "Global keybind unavailable"
+msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
 msgid ""
@@ -303,15 +315,15 @@ msgstr "此視窗中的所有終端機工作階段都將被終止。"
 msgid "The currently running process in this split will be terminated."
 msgstr "此窗格中目前執行的處理程序將被終止。"
 
-#: src/apprt/gtk/class/surface.zig:1141
+#: src/apprt/gtk/class/surface.zig:1170
 msgid "Command Finished"
 msgstr "命令執行完成"
 
-#: src/apprt/gtk/class/surface.zig:1142
+#: src/apprt/gtk/class/surface.zig:1171
 msgid "Command Succeeded"
 msgstr "命令執行成功"
 
-#: src/apprt/gtk/class/surface.zig:1143
+#: src/apprt/gtk/class/surface.zig:1172
 msgid "Command Failed"
 msgstr "命令執行失敗"
 
@@ -331,18 +343,18 @@ msgstr "變更終端機標題"
 msgid "Change Tab Title"
 msgstr "變更分頁標題"
 
-#: src/apprt/gtk/class/window.zig:1067
+#: src/apprt/gtk/class/window.zig:1102
 msgid "Reloaded the configuration"
 msgstr "已重新載入設定"
 
-#: src/apprt/gtk/class/window.zig:1611
+#: src/apprt/gtk/class/window.zig:1705
 msgid "Copied to clipboard"
 msgstr "已複製到剪貼簿"
 
-#: src/apprt/gtk/class/window.zig:1613
+#: src/apprt/gtk/class/window.zig:1707
 msgid "Cleared clipboard"
 msgstr "已清除剪貼簿"
 
-#: src/apprt/gtk/class/window.zig:1753
+#: src/apprt/gtk/class/window.zig:1847
 msgid "Ghostty Developers"
 msgstr "Ghostty 開發者"

--- a/src/apprt/gtk/class/application.zig
+++ b/src/apprt/gtk/class/application.zig
@@ -1471,6 +1471,14 @@ pub const Application = extern struct {
             self,
             .{},
         );
+
+        _ = GlobalShortcuts.signals.@"bind-failed".connect(
+            priv.global_shortcuts,
+            *Application,
+            globalShortcutBindFailed,
+            self,
+            .{},
+        );
     }
 
     fn activate(self: *Self) callconv(.c) void {
@@ -1677,6 +1685,41 @@ pub const Application = extern struct {
         self.core().performAllAction(self.rt(), action.*) catch |err| {
             log.warn("failed to perform action={}", .{err});
         };
+    }
+
+    /// May fire before any window exists, hence a desktop notification
+    /// rather than a toast.
+    fn globalShortcutBindFailed(
+        _: *GlobalShortcuts,
+        failure: *const GlobalShortcuts.BindFailed,
+        self: *Self,
+    ) callconv(.c) void {
+        var label_buf: [128]u8 = undefined;
+        var writer: std.Io.Writer = .fixed(&label_buf);
+        const label: []const u8 = label: {
+            const ok = key.labelFromTrigger(&writer, failure.trigger) catch false;
+            break :label if (ok) writer.buffered() else "?";
+        };
+
+        const detail: [*:0]const u8 = detail: {
+            if (failure.message[0] != 0) break :detail failure.message;
+            break :detail if (failure.revoked)
+                i18n._("The keybind was revoked by the system.")
+            else
+                i18n._("The keybind was denied by the system.");
+        };
+
+        var body_buf: [512]u8 = undefined;
+        const body = std.fmt.bufPrintZ(
+            &body_buf,
+            "{s}: {s}",
+            .{ label, detail },
+        ) catch return;
+
+        Action.desktopNotification(self, .app, .{
+            .title = std.mem.span(i18n._("Global keybind unavailable")),
+            .body = body,
+        });
     }
 
     fn actionReloadConfig(

--- a/src/apprt/gtk/class/global_shortcuts.zig
+++ b/src/apprt/gtk/class/global_shortcuts.zig
@@ -83,6 +83,24 @@ pub const GlobalShortcuts = extern struct {
         pub var offset: c_int = 0;
     };
 
+    /// A global shortcut that failed to bind or was revoked.
+    /// Only valid for the duration of the signal emission.
+    pub const BindFailed = struct {
+        trigger: Binding.Trigger,
+        action: Binding.Action,
+
+        /// May be empty.
+        message: [*:0]const u8,
+
+        /// Revoked after binding rather than denied up front.
+        revoked: bool,
+
+        pub const getGObjectType = gobject.ext.defineBoxed(
+            BindFailed,
+            .{ .name = "GhosttyGlobalShortcutsBindFailed" },
+        );
+    };
+
     pub const signals = struct {
         /// Emitted whenever a global shortcut is triggered.
         pub const trigger = struct {
@@ -92,6 +110,18 @@ pub const GlobalShortcuts = extern struct {
                 name,
                 Self,
                 &.{*const Binding.Action},
+                void,
+            );
+        };
+
+        /// Emitted when a global shortcut fails to bind or is revoked.
+        pub const @"bind-failed" = struct {
+            pub const name = "bind-failed";
+            pub const connect = impl.connect;
+            const impl = gobject.ext.defineSignal(
+                name,
+                Self,
+                &.{*const BindFailed},
                 void,
             );
         };
@@ -109,6 +139,10 @@ pub const GlobalShortcuts = extern struct {
 
     fn close(self: *Self) void {
         const priv = self.private();
+
+        // This is safe to call even if the winproto was already
+        // deinitialized, which happens during application teardown.
+        Application.default().winproto().clearGlobalShortcuts();
 
         if (priv.dbus_connection) |dbus| {
             if (priv.response_subscription != 0) {
@@ -153,9 +187,18 @@ pub const GlobalShortcuts = extern struct {
 
         const priv = self.private();
 
-        // We need a dbus connection and configuration to proceed.
-        if (priv.dbus_connection == null) return;
+        // We need a configuration to proceed.
         const config = if (priv.config) |v| v.get() else return;
+
+        // Prefer a windowing protocol native mechanism over the
+        // XDG desktop portal when available.
+        if (Application.default().winproto().bindGlobalShortcuts(self, config)) {
+            log.debug("global shortcuts bound via winproto", .{});
+            return;
+        }
+
+        // The portal fallback requires a dbus connection.
+        if (priv.dbus_connection == null) return;
 
         // Setup our new arena that we'll use for memory allocations.
         assert(priv.arena == null);
@@ -559,10 +602,25 @@ pub const GlobalShortcuts = extern struct {
         log.debug("activated={s}", .{shortcut_id});
 
         const action = self.private().map.get(std.mem.span(shortcut_id)) orelse return;
+        self.emitTrigger(&action);
+    }
+
+    /// Emit the trigger signal. Public for winproto shortcut backends.
+    pub fn emitTrigger(self: *Self, action: *const Binding.Action) void {
         signals.trigger.impl.emit(
             self,
             null,
-            .{&action},
+            .{action},
+            null,
+        );
+    }
+
+    /// Emit the bind-failed signal. Public for winproto shortcut backends.
+    pub fn emitBindFailed(self: *Self, failure: *const BindFailed) void {
+        signals.@"bind-failed".impl.emit(
+            self,
+            null,
+            .{failure},
             null,
         );
     }
@@ -612,6 +670,7 @@ pub const GlobalShortcuts = extern struct {
 
             // Signals
             signals.trigger.impl.register(.{});
+            signals.@"bind-failed".impl.register(.{});
 
             // Virtual methods
             gobject.Object.virtual_methods.dispose.implement(class, &dispose);

--- a/src/apprt/gtk/key.zig
+++ b/src/apprt/gtk/key.zig
@@ -57,6 +57,16 @@ pub fn xdgShortcutFromTrigger(
     return slice[0 .. slice.len - 1 :0];
 }
 
+/// Returns the keysym (identical to a GDK keyval) for a trigger key,
+/// or null if the trigger has no keysym representation.
+pub fn keysymFromTrigger(trigger: input.Binding.Trigger) ?c_uint {
+    return switch (trigger.key) {
+        .physical => |k| keyvalFromKey(k),
+        .unicode => |cp| gdk.unicodeToKeyval(cp),
+        .catch_all => null,
+    };
+}
+
 fn writeTriggerKey(
     writer: *std.Io.Writer,
     trigger: input.Binding.Trigger,
@@ -325,6 +335,28 @@ test "xdgShortcutFromTrigger" {
         .mods = .{ .ctrl = true, .alt = true, .super = true, .shift = true },
         .key = .{ .unicode = 92 },
     })).?);
+}
+
+test "keysymFromTrigger" {
+    const testing = std.testing;
+
+    // Unicode keys use the keysym numbering (latin-1 maps directly).
+    try testing.expectEqual(@as(?c_uint, 'q'), keysymFromTrigger(.{
+        .mods = .{ .super = true },
+        .key = .{ .unicode = 'q' },
+    }));
+
+    // Physical keys map through our keymap.
+    try testing.expectEqual(@as(?c_uint, gdk.KEY_a), keysymFromTrigger(.{
+        .mods = .{},
+        .key = .{ .physical = .key_a },
+    }));
+
+    // catch_all has no keysym representation.
+    try testing.expectEqual(@as(?c_uint, null), keysymFromTrigger(.{
+        .mods = .{},
+        .key = .catch_all,
+    }));
 }
 
 test "labelFromTrigger" {

--- a/src/apprt/gtk/winproto.zig
+++ b/src/apprt/gtk/winproto.zig
@@ -8,6 +8,7 @@ const Config = @import("../../config.zig").Config;
 const input = @import("../../input.zig");
 const key = @import("key.zig");
 const ApprtWindow = @import("class/window.zig").Window;
+const GlobalShortcuts = @import("class/global_shortcuts.zig").GlobalShortcuts;
 
 pub const noop = @import("winproto/noop.zig");
 pub const x11 = @import("winproto/x11.zig");
@@ -76,6 +77,26 @@ pub const App = union(Protocol) {
     pub fn initQuickTerminal(self: *App, apprt_window: *ApprtWindow) !void {
         switch (self.*) {
             inline else => |*v| try v.initQuickTerminal(apprt_window),
+        }
+    }
+
+    /// Bind all global keybinds through a mechanism native to the
+    /// windowing protocol. Returns false if there is none; the caller
+    /// should then fall back to the XDG desktop portal.
+    pub fn bindGlobalShortcuts(
+        self: *App,
+        shortcuts: *GlobalShortcuts,
+        config: *const Config,
+    ) bool {
+        return switch (self.*) {
+            inline else => |*v| v.bindGlobalShortcuts(shortcuts, config),
+        };
+    }
+
+    /// Unbind all global keybinds bound via bindGlobalShortcuts.
+    pub fn clearGlobalShortcuts(self: *App) void {
+        switch (self.*) {
+            inline else => |*v| v.clearGlobalShortcuts(),
         }
     }
 };

--- a/src/apprt/gtk/winproto/noop.zig
+++ b/src/apprt/gtk/winproto/noop.zig
@@ -6,6 +6,7 @@ const gdk = @import("gdk");
 const Config = @import("../../../config.zig").Config;
 const input = @import("../../../input.zig");
 const ApprtWindow = @import("../class/window.zig").Window;
+const GlobalShortcuts = @import("../class/global_shortcuts.zig").GlobalShortcuts;
 
 const log = std.log.scoped(.winproto_noop);
 
@@ -35,6 +36,16 @@ pub const App = struct {
         return false;
     }
     pub fn initQuickTerminal(_: *App, _: *ApprtWindow) !void {}
+
+    pub fn bindGlobalShortcuts(
+        _: *App,
+        _: *GlobalShortcuts,
+        _: *const Config,
+    ) bool {
+        return false;
+    }
+
+    pub fn clearGlobalShortcuts(_: *App) void {}
 };
 
 pub const Window = struct {

--- a/src/apprt/gtk/winproto/wayland.zig
+++ b/src/apprt/gtk/winproto/wayland.zig
@@ -17,8 +17,10 @@ const xdg = wayland.client.xdg;
 
 const Config = @import("../../../config.zig").Config;
 const Globals = @import("wayland/Globals.zig");
+const Hotkeys = @import("wayland/Hotkeys.zig");
 const input = @import("../../../input.zig");
 const ApprtWindow = @import("../class/window.zig").Window;
+const GlobalShortcuts = @import("../class/global_shortcuts.zig").GlobalShortcuts;
 const BlurRegion = @import("BlurRegion.zig");
 
 const log = std.log.scoped(.winproto_wayland);
@@ -27,6 +29,7 @@ const log = std.log.scoped(.winproto_wayland);
 pub const App = struct {
     display: *wl.Display,
     globals: *Globals,
+    hotkeys: Hotkeys,
 
     pub fn init(
         alloc: Allocator,
@@ -35,7 +38,6 @@ pub const App = struct {
         config: *const Config,
     ) !?App {
         _ = config;
-        _ = app_id;
 
         const gdk_wayland_display = gobject.ext.cast(
             gdk_wayland.WaylandDisplay,
@@ -49,14 +51,33 @@ pub const App = struct {
         const globals: *Globals = try .init(alloc, display);
         errdefer globals.deinit();
 
+        var hotkeys: Hotkeys = try .init(alloc, app_id);
+        errdefer hotkeys.deinit();
+
         return .{
             .display = display,
             .globals = globals,
+            .hotkeys = hotkeys,
         };
     }
 
     pub fn deinit(self: *App) void {
+        self.hotkeys.deinit();
         self.globals.deinit();
+    }
+
+    pub fn bindGlobalShortcuts(
+        self: *App,
+        shortcuts: *GlobalShortcuts,
+        config: *const Config,
+    ) bool {
+        const manager = self.globals.get(.vicinae_hotkey_manager) orelse return false;
+        self.hotkeys.bind(manager, shortcuts, config);
+        return true;
+    }
+
+    pub fn clearGlobalShortcuts(self: *App) void {
+        self.hotkeys.clear();
     }
 
     pub fn eventMods(

--- a/src/apprt/gtk/winproto/wayland/Globals.zig
+++ b/src/apprt/gtk/winproto/wayland/Globals.zig
@@ -8,6 +8,7 @@ const wl = wayland.client.wl;
 const ext = wayland.client.ext;
 const kde = wayland.client.kde;
 const org = wayland.client.org;
+const vicinae = wayland.client.vicinae;
 const xdg = wayland.client.xdg;
 
 const log = std.log.scoped(.winproto_wayland_globals);
@@ -32,6 +33,7 @@ pub const Tag = enum {
     kde_decoration_manager,
     kde_slide_manager,
     kde_output_order,
+    vicinae_hotkey_manager,
     xdg_activation,
 
     fn Type(comptime self: Tag) type {
@@ -41,6 +43,7 @@ pub const Tag = enum {
             .kde_decoration_manager => org.KdeKwinServerDecorationManager,
             .kde_slide_manager => org.KdeKwinSlideManager,
             .kde_output_order => kde.OutputOrderV1,
+            .vicinae_hotkey_manager => vicinae.HotkeyManagerV1,
             .xdg_activation => xdg.ActivationV1,
         };
     }

--- a/src/apprt/gtk/winproto/wayland/Hotkeys.zig
+++ b/src/apprt/gtk/winproto/wayland/Hotkeys.zig
@@ -106,7 +106,6 @@ fn bindOne(
 
     const entry = try self.alloc.create(Entry);
     errdefer self.alloc.destroy(entry);
-    try self.entries.ensureUnusedCapacity(self.alloc, 1);
 
     const hotkey = try manager.bind(
         keysym,
@@ -120,6 +119,7 @@ fn bindOne(
         self.app_id.ptr,
         description.ptr,
     );
+    errdefer hotkey.destroy();
 
     entry.* = .{
         .hotkey = hotkey,
@@ -128,7 +128,7 @@ fn bindOne(
         .shortcuts = shortcuts,
     };
     hotkey.setListener(*Entry, hotkeyListener, entry);
-    self.entries.appendAssumeCapacity(entry);
+    try self.entries.append(self.alloc, entry);
 }
 
 fn hotkeyListener(

--- a/src/apprt/gtk/winproto/wayland/Hotkeys.zig
+++ b/src/apprt/gtk/winproto/wayland/Hotkeys.zig
@@ -16,7 +16,7 @@ const log = std.log.scoped(.winproto_wayland_hotkeys);
 
 alloc: Allocator,
 app_id: [:0]const u8,
-entries: std.ArrayListUnmanaged(*Entry) = .empty,
+entries: std.ArrayList(*Entry) = .empty,
 
 const Entry = struct {
     /// Null once the binding was denied or revoked.
@@ -142,7 +142,7 @@ fn hotkeyListener(
         .denied => |v| {
             log.warn("hotkey denied action={f} reason={} message={s}", .{
                 entry.action,
-                @intFromEnum(v.reason),
+                v.reason,
                 v.message,
             });
             entry.fail(v.message, false);
@@ -151,7 +151,7 @@ fn hotkeyListener(
         .revoked => |v| {
             log.warn("hotkey revoked action={f} reason={} message={s}", .{
                 entry.action,
-                @intFromEnum(v.reason),
+                v.reason,
                 v.message,
             });
             entry.fail(v.message, true);

--- a/src/apprt/gtk/winproto/wayland/Hotkeys.zig
+++ b/src/apprt/gtk/winproto/wayland/Hotkeys.zig
@@ -16,6 +16,9 @@ const log = std.log.scoped(.winproto_wayland_hotkeys);
 
 alloc: Allocator,
 app_id: [:0]const u8,
+
+/// Entries must have stable addresses: the hotkey listeners point to them.
+arena: std.heap.ArenaAllocator,
 entries: std.ArrayList(*Entry) = .empty,
 
 const Entry = struct {
@@ -42,6 +45,7 @@ pub fn init(alloc: Allocator, app_id: [:0]const u8) Allocator.Error!Hotkeys {
     return .{
         .alloc = alloc,
         .app_id = try alloc.dupeZ(u8, app_id),
+        .arena = .init(alloc),
     };
 }
 
@@ -49,17 +53,17 @@ pub fn init(alloc: Allocator, app_id: [:0]const u8) Allocator.Error!Hotkeys {
 /// called after deinit during application teardown.
 pub fn deinit(self: *Hotkeys) void {
     self.clear();
-    self.entries.deinit(self.alloc);
-    self.entries = .empty;
+    self.arena.deinit();
+    self.arena = .init(self.alloc);
     self.alloc.free(self.app_id);
 }
 
 pub fn clear(self: *Hotkeys) void {
     for (self.entries.items) |entry| {
         if (entry.hotkey) |hotkey| hotkey.destroy();
-        self.alloc.destroy(entry);
     }
-    self.entries.clearRetainingCapacity();
+    _ = self.arena.reset(.retain_capacity);
+    self.entries = .empty;
 }
 
 pub fn bind(
@@ -104,8 +108,8 @@ fn bindOne(
     var desc_buf: [256]u8 = undefined;
     const description = std.fmt.bufPrintZ(&desc_buf, "{f}", .{action}) catch "";
 
-    const entry = try self.alloc.create(Entry);
-    errdefer self.alloc.destroy(entry);
+    const alloc = self.arena.allocator();
+    const entry = try alloc.create(Entry);
 
     const hotkey = try manager.bind(
         keysym,
@@ -128,7 +132,7 @@ fn bindOne(
         .shortcuts = shortcuts,
     };
     hotkey.setListener(*Entry, hotkeyListener, entry);
-    try self.entries.append(self.alloc, entry);
+    try self.entries.append(alloc, entry);
 }
 
 fn hotkeyListener(

--- a/src/apprt/gtk/winproto/wayland/Hotkeys.zig
+++ b/src/apprt/gtk/winproto/wayland/Hotkeys.zig
@@ -1,0 +1,163 @@
+//! Global shortcuts backed by the vicinae-hotkey Wayland protocol.
+const Hotkeys = @This();
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+const wayland = @import("wayland");
+const vicinae = wayland.client.vicinae;
+
+const Config = @import("../../../../config.zig").Config;
+const Binding = @import("../../../../input.zig").Binding;
+const key = @import("../../key.zig");
+const GlobalShortcuts = @import("../../class/global_shortcuts.zig").GlobalShortcuts;
+
+const log = std.log.scoped(.winproto_wayland_hotkeys);
+
+alloc: Allocator,
+app_id: [:0]const u8,
+entries: std.ArrayListUnmanaged(*Entry) = .empty,
+
+const Entry = struct {
+    /// Null once the binding was denied or revoked.
+    hotkey: ?*vicinae.HotkeyV1,
+    trigger: Binding.Trigger,
+    action: Binding.Action,
+    shortcuts: *GlobalShortcuts,
+
+    fn fail(entry: *Entry, message: [*:0]const u8, revoked: bool) void {
+        entry.hotkey.?.destroy();
+        entry.hotkey = null;
+
+        entry.shortcuts.emitBindFailed(&.{
+            .trigger = entry.trigger,
+            .action = entry.action,
+            .message = message,
+            .revoked = revoked,
+        });
+    }
+};
+
+pub fn init(alloc: Allocator, app_id: [:0]const u8) Allocator.Error!Hotkeys {
+    return .{
+        .alloc = alloc,
+        .app_id = try alloc.dupeZ(u8, app_id),
+    };
+}
+
+/// Must leave the entries in a valid empty state: clear may still be
+/// called after deinit during application teardown.
+pub fn deinit(self: *Hotkeys) void {
+    self.clear();
+    self.entries.deinit(self.alloc);
+    self.entries = .empty;
+    self.alloc.free(self.app_id);
+}
+
+pub fn clear(self: *Hotkeys) void {
+    for (self.entries.items) |entry| {
+        if (entry.hotkey) |hotkey| hotkey.destroy();
+        self.alloc.destroy(entry);
+    }
+    self.entries.clearRetainingCapacity();
+}
+
+pub fn bind(
+    self: *Hotkeys,
+    manager: *vicinae.HotkeyManagerV1,
+    shortcuts: *GlobalShortcuts,
+    config: *const Config,
+) void {
+    self.clear();
+
+    var it = config.keybind.set.bindings.iterator();
+    while (it.next()) |entry| {
+        const leaf: Binding.Set.GenericLeaf = switch (entry.value_ptr.*) {
+            .leader => continue,
+            inline .leaf, .leaf_chained => |leaf| leaf.generic(),
+        };
+        if (!leaf.flags.global) continue;
+
+        // Only single-action global keybinds are supported, as in the
+        // portal implementation.
+        const actions = leaf.actionsSlice();
+        if (actions.len != 1) continue;
+
+        self.bindOne(manager, shortcuts, entry.key_ptr.*, actions[0]) catch |err| {
+            log.warn("failed to request hotkey trigger={f} err={}", .{
+                entry.key_ptr.*,
+                err,
+            });
+        };
+    }
+}
+
+fn bindOne(
+    self: *Hotkeys,
+    manager: *vicinae.HotkeyManagerV1,
+    shortcuts: *GlobalShortcuts,
+    trigger: Binding.Trigger,
+    action: Binding.Action,
+) !void {
+    const keysym = key.keysymFromTrigger(trigger) orelse return error.NoKeysym;
+
+    var desc_buf: [256]u8 = undefined;
+    const description = std.fmt.bufPrintZ(&desc_buf, "{f}", .{action}) catch "";
+
+    const entry = try self.alloc.create(Entry);
+    errdefer self.alloc.destroy(entry);
+    try self.entries.ensureUnusedCapacity(self.alloc, 1);
+
+    const hotkey = try manager.bind(
+        keysym,
+        .{
+            .shift = trigger.mods.shift,
+            .ctrl = trigger.mods.ctrl,
+            .alt = trigger.mods.alt,
+            .super = trigger.mods.super,
+        },
+        null,
+        self.app_id.ptr,
+        description.ptr,
+    );
+
+    entry.* = .{
+        .hotkey = hotkey,
+        .trigger = trigger,
+        .action = action,
+        .shortcuts = shortcuts,
+    };
+    hotkey.setListener(*Entry, hotkeyListener, entry);
+    self.entries.appendAssumeCapacity(entry);
+}
+
+fn hotkeyListener(
+    _: *vicinae.HotkeyV1,
+    event: vicinae.HotkeyV1.Event,
+    entry: *Entry,
+) void {
+    switch (event) {
+        .bound => log.debug("hotkey bound action={f}", .{entry.action}),
+
+        .denied => |v| {
+            log.warn("hotkey denied action={f} reason={} message={s}", .{
+                entry.action,
+                @intFromEnum(v.reason),
+                v.message,
+            });
+            entry.fail(v.message, false);
+        },
+
+        .revoked => |v| {
+            log.warn("hotkey revoked action={f} reason={} message={s}", .{
+                entry.action,
+                @intFromEnum(v.reason),
+                v.message,
+            });
+            entry.fail(v.message, true);
+        },
+
+        .pressed => entry.shortcuts.emitTrigger(&entry.action),
+        .released => {},
+    }
+}

--- a/src/apprt/gtk/winproto/wayland/protocols/vicinae-hotkey-v1.xml
+++ b/src/apprt/gtk/winproto/wayland/protocols/vicinae-hotkey-v1.xml
@@ -1,0 +1,305 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="vicinae_hotkey_v1">
+  <copyright>
+    Copyright © 2026 Aurelien Brabant
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <description summary="client-managed global hotkeys">
+    This protocol lets a client choose, and freely reconfigure, its own
+    global hotkeys: it requests a specific key combination and the compositor
+    accepts it or rejects it with a reason. The compositor remains the eventual
+    arbiter (it may deny a request, revoke a binding at any time, or apply
+    whatever policy it likes), but within that the application manages its own
+    bindings, including changing them at runtime, with no out-of-band user
+    configuration and no persisted compositor state.
+
+    A hotkey is a key combination that fires regardless of which surface holds
+    keyboard focus. This is unrelated to keyboard-shortcuts-inhibit, which lets a
+    focused client suppress the compositor's own shortcuts.
+
+    Whether a combination is exclusive is compositor policy. A compositor MAY
+    treat combinations as exclusive and reject a clashing request with
+    "already_bound", or MAY grant the same combination to more than one binding
+    (each bound hotkey then receives the events), as some platforms do. Clients
+    must cope with either.
+
+    It is intentionally a thin mechanism. It does NOT define which combinations
+    are acceptable: that is policy and belongs to the compositor, expressed
+    through the accept/deny channel. It does NOT persist hotkeys: a binding lives
+    only as long as its vicinae_hotkey_v1 object and the client connection; there is
+    no configure or storage step, a binding never outlives the client that created
+    it, and reconfiguring is simply destroying a hotkey and binding the new
+    combination.
+
+    Warning! The protocol described in this file is currently in the testing
+    phase. Backward incompatible changes may be added together with the
+    corresponding interface version bump. Backward compatible changes are added
+    by bumping the interface version.
+
+    Security considerations:
+
+    A global hotkey lets an unfocused client observe that a specific key
+    combination was pressed. Compositors are the security boundary and SHOULD
+    apply policy when deciding whether to accept a request. In particular,
+    implementations SHOULD reject combinations that do not include at least one
+    non-latching modifier among Ctrl, Alt or Super, unless the trigger is a
+    function key, because unmodified (and Shift-only) keys carry ordinary text
+    entry and grabbing them turns this protocol into a keylogger.
+
+    The protocol's one hard guarantee is containment: a compositor MUST NOT
+    deliver events for a combination the client did not successfully bind, and
+    never forwards the raw key stream, so a client learns nothing about input it
+    did not explicitly, and successfully, bind. Beyond that, a compositor MAY
+    apply any further policy it sees fit (for example prompting the user,
+    restricting which clients may bind, or limiting how many bindings a client may
+    hold) and MAY revoke a binding at any time via the "revoked" event, including
+    under user control.
+
+    These are recommendations, not wire requirements: a combination the
+    compositor disallows is simply reported through the "denied" event with the
+    "not_permitted" reason, so applications can rely on a uniform rejection path
+    regardless of each compositor's policy.
+  </description>
+
+  <interface name="vicinae_hotkey_manager_v1" version="1">
+    <description summary="global hotkey factory">
+      This interface is the entry point of the protocol. It is used to request
+      global hotkeys.
+    </description>
+
+    <enum name="modifiers" bitfield="true">
+      <description summary="modifier keys required by a hotkey">
+        A bitmask of the modifiers that must be held for the hotkey to fire.
+
+        These are fixed, keymap-independent semantic bits naming the standard
+        modifiers, suitable for expressing a binding, unlike wl_keyboard.modifiers,
+        which carries opaque, keymap-derived masks for runtime state. A compositor
+        matches each bit against the corresponding modifier in its keyboard state
+        as the keymap defines it; for the xkb_v1 keymap format that is shift ->
+        XKB_MOD_NAME_SHIFT, ctrl -> XKB_MOD_NAME_CTRL, alt -> XKB_MOD_NAME_ALT
+        ("Mod1"), super -> XKB_MOD_NAME_LOGO ("Mod4").
+
+        Lock modifiers (Caps Lock, Num Lock) are never part of a binding and are
+        ignored when matching.
+      </description>
+      <entry name="shift" value="1" summary="the Shift modifier"/>
+      <entry name="ctrl" value="2" summary="the Control modifier"/>
+      <entry name="alt" value="4" summary="the Alt modifier"/>
+      <entry name="super" value="8" summary="the Super/Logo modifier"/>
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the manager">
+        Destroy the manager object. Hotkey objects created through this manager
+        are unaffected and remain valid; their bindings persist until they are
+        themselves destroyed or the client disconnects.
+      </description>
+    </request>
+
+    <request name="bind">
+      <description summary="request a global hotkey">
+        Request that the given key combination be bound as a global hotkey.
+
+        The keysym identifies the trigger key using the keysym numbering shared
+        with the keymap delivered over wl_keyboard (for the xkb_v1 keymap format,
+        an XKB_KEY_* value), taken in its unshifted form (XKB_KEY_b not XKB_KEY_B). A compositor SHOULD match
+        it against any of the user's layout groups, so a binding keeps firing after
+        the user switches layout group. This is one deliberately specified rule,
+        not a universal one: other platforms differ (macOS matches a physical
+        keycode, X11 re-grabs per layout, Windows tracks the active layout's key),
+        and no rule serves a layout that never produces the keysym; the single
+        documented rule is chosen for predictability across compositors.
+
+        The request creates an vicinae_hotkey_v1 object immediately, but the binding
+        is not active yet. The compositor replies asynchronously with either the
+        "bound" event (the hotkey is now active) or the "denied" event (the
+        request was rejected, with a reason).
+
+        seat is the wl_seat whose keyboard should trigger the hotkey, or null to
+        request it on all of the client's seats. Most clients pass null; seat is
+        provided for completeness on multi-seat systems.
+
+        app_id identifies the requesting application, for use in the compositor's
+        policy and any user-facing audit UI. Where the application has a desktop
+        entry, app_id SHOULD be its desktop file ID as defined by the
+        freedesktop.org Desktop Entry specification, that is the .desktop file
+        name with the .desktop suffix removed (for example "org.example.Launcher"),
+        matching the convention used by xdg_toplevel.set_app_id so a compositor
+        can correlate the two. It is advisory and may be spoofed; a compositor
+        that needs a trustworthy identity SHOULD obtain it through the
+        security-context mechanism rather than relying on this string.
+
+        description is a human-readable, localized description of what the hotkey
+		  does (e.g. "Toggle the launcher"), for display in compositor UI or even in this protocol error messages.
+      </description>
+      <arg name="id" type="new_id" interface="vicinae_hotkey_v1"
+           summary="the new hotkey object"/>
+      <arg name="keysym" type="uint" summary="keysym of the trigger key (see description)"/>
+      <arg name="modifiers" type="uint" enum="modifiers"
+           summary="bitmask of required modifiers"/>
+      <arg name="seat" type="object" interface="wl_seat" allow-null="true"
+           summary="target seat, or null for all of the client's seats"/>
+      <arg name="app_id" type="string"
+           summary="advisory application identifier (SHOULD be the desktop file ID)"/>
+      <arg name="description" type="string"
+           summary="human-readable action description"/>
+    </request>
+  </interface>
+
+  <interface name="vicinae_hotkey_v1" version="1">
+    <description summary="a single global hotkey">
+      Represents one requested global hotkey. Its binding is ephemeral: it is
+      released when this object is destroyed or when the client disconnects, and
+      it is never written to any persistent store.
+
+      After bind, exactly one of "bound" or "denied" is sent. While the hotkey is
+      bound, "pressed" and "released" are sent as the combination is activated.
+      The compositor may send "revoked" at any time after "bound" to indicate the
+      binding is no longer active (for example because the user removed it, or a
+      higher-priority binding took the combination).
+    </description>
+
+    <enum name="deny_reason">
+      <description summary="why a bind request was denied">
+        Carried by the "denied" event. This is a reason code, not a fatal
+        protocol error: the object remains valid and the client should destroy
+        it (or try a different combination).
+      </description>
+      <entry name="already_bound" value="0"
+             summary="already held by another hotkey the compositor treats as exclusive. The compositor is not obligated to give this level of detail and can just give not_permitted as the general 'deny' reason."/>
+      <entry name="not_permitted" value="1"
+             summary="the combination is disallowed by compositor policy"/>
+      <entry name="invalid" value="2"
+             summary="the keysym or combination is not a valid trigger"/>
+    </enum>
+
+    <enum name="revoke_reason">
+      <description summary="why a previously bound hotkey was withdrawn">
+        Carried by the "revoked" event. This is a reason code, not a fatal
+        protocol error: the object remains valid and the client should destroy
+        it.
+
+        The distinction is actionable: on "superseded" the combination may
+        become available again, so a client may reasonably re-request it later;
+        on "removed" the withdrawal is a deliberate user or compositor decision,
+        so a client MUST NOT silently re-request the same combination. A client
+        that receives a value it does not recognise (a future addition) MUST
+        treat it conservatively as "removed" and not auto-rebind.
+      </description>
+      <entry name="removed" value="0"
+             summary="withdrawn by the user or compositor; do not auto-rebind"/>
+      <entry name="superseded" value="1"
+             summary="a higher-priority binding took the combination; it may become available again"/>
+      <entry name="not_permitted" value="2"
+             summary="the combination is no longer allowed by compositor policy"/>
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="release the hotkey">
+        Release the binding and destroy the object. The combination becomes
+        available again immediately. It is valid to destroy the object before
+        receiving "bound" or "denied", which cancels the pending request.
+      </description>
+    </request>
+
+    <event name="bound">
+      <description summary="the hotkey is now active">
+        The requested combination was accepted and is now active. "pressed" and
+        "released" events may follow.
+      </description>
+    </event>
+
+    <event name="denied">
+      <description summary="the request was rejected">
+        The requested combination was not bound. No input events will be sent.
+        The client should destroy this object; it may then create a new request
+        with a different combination.
+
+        message is an optional, advisory, human-readable explanation in the
+        compositor's locale, intended for verbatim display in client UI (for
+        example a "change shortcut" settings screen). It may be empty, and a
+        compositor is never required to provide it. Clients MUST NOT parse it or
+        rely on its contents in any way; all programmatic behavior keys off
+        reason. A client with nowhere to show it simply ignores it.
+      </description>
+      <arg name="reason" type="uint" enum="deny_reason" summary="why it was rejected"/>
+      <arg name="message" type="string"
+           summary="optional human-readable detail for display (may be empty)"/>
+    </event>
+
+    <event name="revoked">
+      <description summary="a previously active hotkey was withdrawn">
+        A binding that was previously "bound" is no longer active. No further
+        input events will be sent for it. The client should destroy this object;
+        it may request the combination again later.
+
+        message is an optional, advisory, human-readable explanation in the
+        compositor's locale, intended for verbatim display in client UI. It may
+        be empty, and a compositor is never required to provide it. Clients MUST
+        NOT parse it or rely on its contents in any way; all programmatic
+        behavior keys off reason. A client with nowhere to show it simply
+        ignores it.
+      </description>
+      <arg name="reason" type="uint" enum="revoke_reason" summary="why it was withdrawn"/>
+      <arg name="message" type="string"
+           summary="optional human-readable detail for display (may be empty)"/>
+    </event>
+
+    <event name="pressed">
+      <description summary="the hotkey combination was pressed">
+        The bound combination was activated.
+
+        This event is sent once per activation. While the combination is held
+        down no further "pressed" events are sent, and a single "released"
+        follows when the trigger key is released: the compositor does not
+        auto-repeat the hotkey.
+
+        serial is a compositor-issued input serial that counts as a recent user
+        interaction, so the client can act on the hotkey even though the
+        triggering key press is not otherwise delivered to it (the compositor
+        consumes it). In particular, a client may pass this serial to
+        xdg_activation_token_v1.set_serial in order to raise or focus a surface in
+        response to the hotkey; a compositor SHOULD honor activation carried by
+        this serial, since the hotkey is itself a deliberate user action. The
+        serial is drawn from the same space as other input event serials.
+
+        time is the event timestamp, with the same millisecond clock as wl_pointer
+        and wl_keyboard input events; it is useful for ordering and for measuring
+        press-to-release duration.
+      </description>
+      <arg name="serial" type="uint" summary="input serial for the activation (e.g. xdg-activation)"/>
+      <arg name="time" type="uint" summary="timestamp in milliseconds"/>
+    </event>
+
+    <event name="released">
+      <description summary="the hotkey combination was released">
+        The trigger key of a previously pressed combination was released. This
+        enables press-and-hold uses (e.g. push-to-talk); clients that only act
+        on activation may ignore it.
+
+        serial and time have the same meaning as in the "pressed" event.
+      </description>
+      <arg name="serial" type="uint" summary="input serial for the activation (e.g. xdg-activation)"/>
+      <arg name="time" type="uint" summary="timestamp in milliseconds"/>
+    </event>
+  </interface>
+</protocol>

--- a/src/apprt/gtk/winproto/x11.zig
+++ b/src/apprt/gtk/winproto/x11.zig
@@ -19,6 +19,7 @@ pub const c = @cImport({
 const input = @import("../../../input.zig");
 const Config = @import("../../../config.zig").Config;
 const ApprtWindow = @import("../class/window.zig").Window;
+const GlobalShortcuts = @import("../class/global_shortcuts.zig").GlobalShortcuts;
 const BlurRegion = @import("BlurRegion.zig");
 
 const log = std.log.scoped(.gtk_x11);
@@ -157,6 +158,16 @@ pub const App = struct {
 
         return mods;
     }
+
+    pub fn bindGlobalShortcuts(
+        _: *App,
+        _: *GlobalShortcuts,
+        _: *const Config,
+    ) bool {
+        return false;
+    }
+
+    pub fn clearGlobalShortcuts(_: *App) void {}
 
     pub fn supportsQuickTerminal(_: App) bool {
         log.warn("quick terminal is not yet supported on X11", .{});

--- a/src/build/SharedDeps.zig
+++ b/src/build/SharedDeps.zig
@@ -816,13 +816,19 @@ fn addGtkNg(
         );
         scanner.addSystemProtocol("staging/xdg-activation/xdg-activation-v1.xml");
         scanner.addSystemProtocol("staging/ext-background-effect/ext-background-effect-v1.xml");
+        scanner.addCustomProtocol(
+            b.path("src/apprt/gtk/winproto/wayland/protocols/vicinae-hotkey-v1.xml"),
+        );
 
         scanner.generate("wl_compositor", 1);
+        // Only referenced by vicinae_hotkey_manager_v1.bind (nullable arg).
+        scanner.generate("wl_seat", 1);
         scanner.generate("org_kde_kwin_server_decoration_manager", 1);
         scanner.generate("org_kde_kwin_slide_manager", 1);
         scanner.generate("kde_output_order_v1", 1);
         scanner.generate("xdg_activation_v1", 1);
         scanner.generate("ext_background_effect_manager_v1", 1);
+        scanner.generate("vicinae_hotkey_manager_v1", 1);
 
         step.root_module.addImport("wayland", b.createModule(.{
             .root_source_file = scanner.result,


### PR DESCRIPTION
This PR provides an implementation for the [vicinae-hotkey-v1](https://github.com/vicinaehq/vicinae-wayland-protocols/tree/main/staging/vicinae-hotkey) protocol, as discussed [here](https://github.com/ghostty-org/ghostty/discussions/13453).

This is a wayland protocol that allows the client to dynamically negotiate global shortcuts with the compositor. Unlike the portal, the clients are free to bind, rebind, and unbind global shortcuts they reserve.

Here are a few advantages of using this over the global shortcut portal for ghostty specifically:

- `vicinae-hotkey-v1` lets the client know the state of its bindings at all time, if a global bind is not granted by the compositor the cllient is notified with a descriptive error message which is designed to help the user understand what the problem might be. In my implementation, I decided I would show a desktop notification to the user in case a global shortcut reservation fails.

- Global binds set in the config cannot drift from what is actually registered, cannot be unilaterally changed by the user in compositor settings, and do not pollute the global shortcut namespace permanently. Reservations are only active while ghostty is running.

- The protocol provides the client with an input serial that can be used to generate an `xdg_activation` token, allowing ghostty to steal focus when one of its global shortcut is used. Currently ghostty doesn't have an input serial to pass to `xdg_activation`. I didn't wire it for now, in order keep things simple. But I guess it will be a nice to have.

---

AI disclosure: most of the code was written by Fable 5 (Claude Code), as zig is not my primary language.

From an implementation perspective: I made it so that `vicinae-hotkey-v1` is used to manage global shortcuts over the portal when the global is advertised by the compositor. If it's not available, we fallback on the portal like before.

At this time the protocol is implemented by Hyprland (since [v0.56.0](https://github.com/hyprwm/Hyprland/pull/15010)) and there is an open PR for [niri](https://github.com/niri-wm/niri/pull/4145). There is also an official [wayland-protocols proposal](https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/525).

As for the clients, for now the only implementer (that I know of) is [vicinae](https://github.com/vicinaehq/vicinae).

The idea would be to merge this `vicinae-hotkey-v1` implementation and then have it be superseded by the upstream version later, assuming it is turned into an official extension protocol following the wayland-protocols process.

PS: sorry for the diff noise about all the .po changes, I'm not sure whether this is intended or not, but I did regenerate the translations as asked