### PR TITLE
docs: clarify macOS dependencies

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -40,14 +40,14 @@ here:
 
 ## Extra Dependencies
 
+### Linux
+
 Building Ghostty from a Git checkout on Linux requires some additional
 dependencies:
 
 - `blueprint-compiler` (version 0.16.0 or newer)
 
-macOS users don't require any additional dependencies.
-
-## Xcode Version and SDKs
+### macOS
 
 Building the Ghostty macOS app requires that Xcode, the macOS SDK,
 the iOS SDK, and Metal Toolchain are all installed.


### PR DESCRIPTION
reword: The doc said "macOS doesn't need any dependencies" and then immediately listed things you needed to install for macOS 😁.  This is just rewording the doc to be more consistent.