### PR TITLE
url: exclude trailing spaces from path matches

### DIFF
--- a/src/config/url.zig
+++ b/src/config/url.zig
@@ -52,10 +52,6 @@ const no_trailing_colon =
     \\(?<!:)
 ;
 
-const trailing_spaces_at_eol =
-    \\(?: +(?= *$))?
-;
-
 const dotted_path_lookahead =
     \\(?=[\w\-.~:\/?#@!$&*+;=%]*\.)
 ;
@@ -92,13 +88,11 @@ const rooted_or_relative_path_branch =
     path_chars ++ "+" ++
     dotted_path_space_segments ++
     no_trailing_colon ++
-    trailing_spaces_at_eol ++
     "|" ++
     non_dotted_path_lookahead ++
     path_chars ++ "+" ++
     any_path_space_segments ++
     no_trailing_colon ++
-    trailing_spaces_at_eol ++
     ")";
 
 // Branch 3: Bare relative paths such as src/config/url.zig.
@@ -110,8 +104,7 @@ const bare_relative_path_branch =
     dotted_path_lookahead ++
     bare_relative_path_prefix ++
     path_chars ++ "+" ++
-    no_trailing_colon ++
-    trailing_spaces_at_eol;
+    no_trailing_colon;
 
 pub const regex =
     scheme_url_branch ++
@@ -282,7 +275,7 @@ test "url regex" {
         },
         .{
             .input = "../example.py ",
-            .expect = "../example.py ",
+            .expect = "../example.py",
         },
         .{
             .input = "first time ../example.py contributor ",
@@ -341,11 +334,12 @@ test "url regex" {
             .input = "IPv6 in markdown [link](http://[2001:db8::1]/docs)",
             .expect = "http://[2001:db8::1]/docs",
         },
-        // File paths with spaces
+        // Trailing whitespace isn't part of a detected file path.
         .{
             .input = "./spaces-end.   ",
-            .expect = "./spaces-end.   ",
+            .expect = "./spaces-end.",
         },
+        // File paths with internal spaces
         .{
             .input = "./space middle",
             .expect = "./space middle",


### PR DESCRIPTION
This change improves the user experience for Pi TUI users on macOS.

As a user of Ghostty 1.3.1, Pi 0.80.7, and macOS 26.5, I noticed that
Command-click was not working.

With Pi's help (GPT-5.6 Terra High), I narrowed the cause down to Pi's redraw
behavior and `src/config/url.zig`'s regular expression. More details are in
[Vouch Request #13491](https://github.com/ghostty-org/ghostty/discussions/13491).

The `trailing_spaces_at_eol` behavior in `src/config/url.zig` was introduced in
[PR #9921](https://github.com/ghostty-org/ghostty/pull/9921) while improving
Command-click handling for relative and local paths. The concern about matching
trailing whitespace was also noted in [a review comment](https://github.com/ghostty-org/ghostty/pull/9921#issuecomment-3661107609).

However, supporting file paths with trailing spaces does not seem like a good
trade-off because it blocks Command-click for file paths displayed by Pi TUI.

This PR removes that behavior.

I tested this on my Mac with a patched Ghostty build, and Command-click worked
correctly for file paths in Pi TUI.

AI disclosure: I used Pi with GPT-5.6 Terra High to investigate and implement this change. 
I reviewed the code and tested the result myself.
