### PR TITLE
macOS: rename `download` to `install` for `auto-update`

### DIFF
--- a/macos/Sources/App/AppDelegate.swift
+++ b/macos/Sources/App/AppDelegate.swift
@@ -785,14 +785,14 @@ class AppDelegate: NSObject,
             updateController.updater.automaticallyDownloadsUpdates = false
         } else if let autoUpdate = config.autoUpdate {
             updateController.updater.automaticallyChecksForUpdates =
-                autoUpdate == .check || autoUpdate == .download
+                autoUpdate == .check || autoUpdate == .install
             updateController.updater.automaticallyDownloadsUpdates =
-                autoUpdate == .download
+                autoUpdate == .install
             /*
              To test `auto-update` easily, uncomment the line below and
              delete `SUEnableAutomaticChecks` in Ghostty-Info.plist.
 
-             Note: When `auto-update = download`, you may need to
+             Note: When `auto-update = install`, you may need to
              `Clean Build Folder` if a background install has already begun.
              */
             // updateController.updater.checkForUpdatesInBackground()

--- a/macos/Sources/Features/Update/UpdateDelegate.swift
+++ b/macos/Sources/Features/Update/UpdateDelegate.swift
@@ -17,7 +17,7 @@ extension UpdateDriver: SPUUpdaterDelegate {
     }
 
     /// Called when an update is scheduled to install silently,
-    /// which occurs when `auto-update = download`.
+    /// which occurs when `auto-update = install`.
     ///
     /// When `auto-update = check`, Sparkle will call the corresponding
     /// delegate method on the responsible driver instead.

--- a/macos/Sources/Ghostty/Ghostty.Config.swift
+++ b/macos/Sources/Ghostty/Ghostty.Config.swift
@@ -737,7 +737,7 @@ extension Ghostty.Config {
     enum AutoUpdate: String {
         case off
         case check
-        case download
+        case install
     }
 
     /// Background blur configuration that maps from the C API values.

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -106,6 +106,11 @@ pub const compatibility = std.StaticStringMap(
     // both. The semantics also changed but this is the correct mapping.
     // See: https://github.com/ghostty-org/ghostty/pull/12604
     .{ "copy-on-select", compatCopyOnSelect },
+
+    // Ghostty 1.4 rename the `download` to `install` for `auto-update`.
+    // Sparkle doesn't actually support downloading only.
+    // See: https://sparkle-project.org/documentation/customization/
+    .{ "auto-update", compatAutoUpdate },
 });
 
 /// Set Ghostty's graphical user interface language to a language other than the
@@ -3909,8 +3914,8 @@ term: []const u8 = "xterm-ghostty",
 ///  * `off` - Disable auto-updates.
 ///  * `check` - Check for updates and notify the user if an update is
 ///    available, but do not automatically download or install the update.
-///  * `download` - Check for updates, automatically download the update,
-///    notify the user, but do not automatically install the update.
+///  * `install` - Check for updates, automatically download and install
+///    the update, but do not automatically relaunch Ghostty.
 ///
 /// If unset, we defer to Sparkle's default behavior, which respects the
 /// preference stored in the standard user defaults (`defaults(1)`).
@@ -5076,6 +5081,23 @@ fn compatCopyOnSelect(
 
     if (std.mem.eql(u8, value orelse "", "false")) {
         self.@"copy-on-select" = .none;
+        return true;
+    }
+
+    return false;
+}
+
+fn compatAutoUpdate(
+    self: *Config,
+    alloc: Allocator,
+    key: []const u8,
+    value: ?[]const u8,
+) bool {
+    _ = alloc;
+    assert(std.mem.eql(u8, key, "auto-update"));
+
+    if (std.mem.eql(u8, value orelse "", "download")) {
+        self.@"auto-update" = .install;
         return true;
     }
 
@@ -9833,7 +9855,7 @@ pub const AsyncBackend = enum {
 pub const AutoUpdate = enum {
     off,
     check,
-    download,
+    install,
 };
 
 /// See background-blur
@@ -11266,6 +11288,25 @@ test "compatibility: window new-window" {
         try testing.expectEqual(
             MacOSDockDropBehavior.@"new-window",
             cfg.@"macos-dock-drop-behavior",
+        );
+    }
+}
+
+test "compatibility: download install" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    {
+        var cfg = try Config.default(alloc);
+        defer cfg.deinit();
+        var it: TestIterator = .{ .data = &.{
+            "--auto-update=download",
+        } };
+        try cfg.loadIter(alloc, &it);
+        try cfg.finalize();
+        try testing.expectEqual(
+            AutoUpdate.install,
+            cfg.@"auto-update",
         );
     }
 }


### PR DESCRIPTION
[automaticallyDownloadsUpdates](https://sparkle-project.org/documentation/api-reference/Classes/SPUUpdater.html#/c:objc(cs)SPUUpdater(py)automaticallyDownloadsUpdates) will actually install the update as well. `download` could be misleading.

There will be following prs to update current behaviour of when to show `installing` pill as well.

### AI Disclosure

Looks trivial but no AI involved, just a quick find and replace in VSCode 