### PR TITLE
inspector: add copy and export for terminal IO events

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -645,6 +645,12 @@ typedef enum {
   GHOSTTY_INSPECTOR_HIDE,
 } ghostty_action_inspector_e;
 
+// apprt.action.ExportTerminalIO.C
+typedef struct {
+  const char* contents;
+  size_t len;
+} ghostty_action_export_terminal_io_s;
+
 // apprt.action.QuitTimer
 typedef enum {
   GHOSTTY_QUIT_TIMER_START,
@@ -914,6 +920,7 @@ typedef enum {
   GHOSTTY_ACTION_INSPECTOR,
   GHOSTTY_ACTION_SHOW_GTK_INSPECTOR,
   GHOSTTY_ACTION_RENDER_INSPECTOR,
+  GHOSTTY_ACTION_EXPORT_TERMINAL_IO,
   GHOSTTY_ACTION_DESKTOP_NOTIFICATION,
   GHOSTTY_ACTION_SET_TITLE,
   GHOSTTY_ACTION_SET_TAB_TITLE,
@@ -964,6 +971,7 @@ typedef union {
   ghostty_action_cell_size_s cell_size;
   ghostty_action_scrollbar_s scrollbar;
   ghostty_action_inspector_e inspector;
+  ghostty_action_export_terminal_io_s export_terminal_io;
   ghostty_action_desktop_notification_s desktop_notification;
   ghostty_action_set_title_s set_title;
   ghostty_action_set_title_s set_tab_title;

--- a/macos/Sources/Ghostty/Ghostty.App.swift
+++ b/macos/Sources/Ghostty/Ghostty.App.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UniformTypeIdentifiers
 import UserNotifications
 import GhosttyKit
 
@@ -538,6 +539,9 @@ extension Ghostty {
 
             case GHOSTTY_ACTION_RENDER_INSPECTOR:
                 renderInspector(app, target: target)
+
+            case GHOSTTY_ACTION_EXPORT_TERMINAL_IO:
+                return exportTerminalIO(app, target: target, v: action.action.export_terminal_io)
 
             case GHOSTTY_ACTION_DESKTOP_NOTIFICATION:
                 showDesktopNotification(app, target: target, n: action.action.desktop_notification)
@@ -1392,6 +1396,41 @@ extension Ghostty {
             default:
                 assertionFailure()
             }
+        }
+
+        private static func exportTerminalIO(
+            _ app: ghostty_app_t,
+            target: ghostty_target_s,
+            v: ghostty_action_export_terminal_io_s
+        ) -> Bool {
+            guard target.tag == GHOSTTY_TARGET_SURFACE,
+                  let surface = target.target.surface,
+                  let surfaceView = self.surfaceView(from: surface),
+                  let window = surfaceView.window,
+                  let contents = v.contents
+            else { return false }
+
+            // The action data is borrowed for the duration of this callback,
+            // so copy it before presenting the asynchronous save panel.
+            let data = Data(bytes: contents, count: v.len)
+            DispatchQueue.main.async {
+                let panel = NSSavePanel()
+                panel.allowedContentTypes = [.plainText]
+                panel.canCreateDirectories = true
+                panel.nameFieldStringValue = "ghostty-terminal-io.txt"
+                panel.beginSheetModal(for: window) { response in
+                    guard response == .OK, let url = panel.url else { return }
+                    do {
+                        try data.write(to: url, options: .atomic)
+                    } catch {
+                        Ghostty.logger.error(
+                            "Failed to export terminal IO events: \(error, privacy: .public)"
+                        )
+                    }
+                }
+            }
+
+            return true
         }
 
         private static func showDesktopNotification(

--- a/po/be.po
+++ b/po/be.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-07-26 04:59+0200\n"
+"POT-Creation-Date: 2026-07-30 18:07+0200\n"
 "PO-Revision-Date: 2026-04-14 00:00+0000\n"
 "Last-Translator: Illia Krauchanka <illiakrauchanka@gmail.com>\n"
 "Language-Team: Belarusian\n"
@@ -49,6 +49,7 @@ msgstr "Перазагрузіць канфігурацыю, каб паказа
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
+#: src/apprt/gtk/class/application.zig:2031
 msgid "Cancel"
 msgstr "Скасаваць"
 
@@ -242,7 +243,7 @@ msgstr "Палітра каманд"
 msgid "Terminal Inspector"
 msgstr "Інспектар тэрмінала"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1888
 msgid "About Ghostty"
 msgstr "Пра Ghostty"
 
@@ -254,16 +255,24 @@ msgstr "Выйсці"
 msgid "Execute a command…"
 msgstr "Выканаць каманду…"
 
-#: src/apprt/gtk/class/application.zig:1708
+#: src/apprt/gtk/class/application.zig:1713
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1710
+#: src/apprt/gtk/class/application.zig:1715
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1721
+#: src/apprt/gtk/class/application.zig:1726
 msgid "Global keybind unavailable"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2027
+msgid "Export Terminal IO Events"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2030
+msgid "Export"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -358,14 +367,14 @@ msgstr "Змяніць назву ўкладкі"
 msgid "Reloaded the configuration"
 msgstr "Канфігурацыя перазагружана"
 
-#: src/apprt/gtk/class/window.zig:1705
+#: src/apprt/gtk/class/window.zig:1727
 msgid "Copied to clipboard"
 msgstr "Скапіявана ў буфер абмену"
 
-#: src/apprt/gtk/class/window.zig:1707
+#: src/apprt/gtk/class/window.zig:1729
 msgid "Cleared clipboard"
 msgstr "Буфер абмену ачышчаны"
 
-#: src/apprt/gtk/class/window.zig:1847
+#: src/apprt/gtk/class/window.zig:1869
 msgid "Ghostty Developers"
 msgstr "Распрацоўшчыкі Ghostty"

--- a/po/bg.po
+++ b/po/bg.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-07-26 04:59+0200\n"
+"POT-Creation-Date: 2026-07-30 18:07+0200\n"
 "PO-Revision-Date: 2026-02-09 22:07+0200\n"
 "Last-Translator: reo101 <pavel.atanasov2001@gmail.com>\n"
 "Language-Team: Bulgarian <dict@ludost.net>\n"
@@ -49,6 +49,7 @@ msgstr "За да покажеш това съобщение отново, пр�
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
+#: src/apprt/gtk/class/application.zig:2031
 msgid "Cancel"
 msgstr "Отказ"
 
@@ -242,7 +243,7 @@ msgstr "Командна палитра"
 msgid "Terminal Inspector"
 msgstr "Инспектор на терминала"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1888
 msgid "About Ghostty"
 msgstr "За Ghostty"
 
@@ -254,16 +255,24 @@ msgstr "Изход"
 msgid "Execute a command…"
 msgstr "Изпълни команда…"
 
-#: src/apprt/gtk/class/application.zig:1708
+#: src/apprt/gtk/class/application.zig:1713
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1710
+#: src/apprt/gtk/class/application.zig:1715
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1721
+#: src/apprt/gtk/class/application.zig:1726
 msgid "Global keybind unavailable"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2027
+msgid "Export Terminal IO Events"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2030
+msgid "Export"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -358,14 +367,14 @@ msgstr "Смени името на таба"
 msgid "Reloaded the configuration"
 msgstr "Конфигурацията е презаредена"
 
-#: src/apprt/gtk/class/window.zig:1705
+#: src/apprt/gtk/class/window.zig:1727
 msgid "Copied to clipboard"
 msgstr "Копирано в клипборда"
 
-#: src/apprt/gtk/class/window.zig:1707
+#: src/apprt/gtk/class/window.zig:1729
 msgid "Cleared clipboard"
 msgstr "Клипбордът е изчистен"
 
-#: src/apprt/gtk/class/window.zig:1847
+#: src/apprt/gtk/class/window.zig:1869
 msgid "Ghostty Developers"
 msgstr "Разработчици на Ghostty"

--- a/po/ca.po
+++ b/po/ca.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-07-26 04:59+0200\n"
+"POT-Creation-Date: 2026-07-30 18:07+0200\n"
 "PO-Revision-Date: 2025-08-24 19:22+0200\n"
 "Last-Translator: Kristofer Soler "
 "<31729650+KristoferSoler@users.noreply.github.com>\n"
@@ -50,6 +50,7 @@ msgstr "Recarrega la configuració per tornar a mostrar aquest missatge"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
+#: src/apprt/gtk/class/application.zig:2031
 msgid "Cancel"
 msgstr "Cancel·la"
 
@@ -244,7 +245,7 @@ msgstr "Paleta de comandes"
 msgid "Terminal Inspector"
 msgstr "Inspector de terminal"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1888
 msgid "About Ghostty"
 msgstr "Sobre Ghostty"
 
@@ -256,16 +257,24 @@ msgstr "Surt"
 msgid "Execute a command…"
 msgstr "Executa una ordre…"
 
-#: src/apprt/gtk/class/application.zig:1708
+#: src/apprt/gtk/class/application.zig:1713
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1710
+#: src/apprt/gtk/class/application.zig:1715
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1721
+#: src/apprt/gtk/class/application.zig:1726
 msgid "Global keybind unavailable"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2027
+msgid "Export Terminal IO Events"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2030
+msgid "Export"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -360,14 +369,14 @@ msgstr "Canvia el títol de la pestanya"
 msgid "Reloaded the configuration"
 msgstr "S'ha tornat a carregar la configuració"
 
-#: src/apprt/gtk/class/window.zig:1705
+#: src/apprt/gtk/class/window.zig:1727
 msgid "Copied to clipboard"
 msgstr "Copiat al porta-retalls"
 
-#: src/apprt/gtk/class/window.zig:1707
+#: src/apprt/gtk/class/window.zig:1729
 msgid "Cleared clipboard"
 msgstr "Porta-retalls netejat"
 
-#: src/apprt/gtk/class/window.zig:1847
+#: src/apprt/gtk/class/window.zig:1869
 msgid "Ghostty Developers"
 msgstr "Desenvolupadors de Ghostty"

--- a/po/com.mitchellh.ghostty.pot
+++ b/po/com.mitchellh.ghostty.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-07-26 04:59+0200\n"
+"POT-Creation-Date: 2026-07-30 18:07+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -48,6 +48,7 @@ msgstr ""
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
+#: src/apprt/gtk/class/application.zig:2031
 msgid "Cancel"
 msgstr ""
 
@@ -235,7 +236,7 @@ msgstr ""
 msgid "Terminal Inspector"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1888
 msgid "About Ghostty"
 msgstr ""
 
@@ -247,16 +248,24 @@ msgstr ""
 msgid "Execute a command…"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1708
+#: src/apprt/gtk/class/application.zig:1713
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1710
+#: src/apprt/gtk/class/application.zig:1715
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1721
+#: src/apprt/gtk/class/application.zig:1726
 msgid "Global keybind unavailable"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2027
+msgid "Export Terminal IO Events"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2030
+msgid "Export"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -345,14 +354,14 @@ msgstr ""
 msgid "Reloaded the configuration"
 msgstr ""
 
-#: src/apprt/gtk/class/window.zig:1705
+#: src/apprt/gtk/class/window.zig:1727
 msgid "Copied to clipboard"
 msgstr ""
 
-#: src/apprt/gtk/class/window.zig:1707
+#: src/apprt/gtk/class/window.zig:1729
 msgid "Cleared clipboard"
 msgstr ""
 
-#: src/apprt/gtk/class/window.zig:1847
+#: src/apprt/gtk/class/window.zig:1869
 msgid "Ghostty Developers"
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-07-26 04:59+0200\n"
+"POT-Creation-Date: 2026-07-30 18:07+0200\n"
 "PO-Revision-Date: 2026-02-13 08:05+0100\n"
 "Last-Translator: Klaus Hipp <khipp@users.noreply.github.com>\n"
 "Language-Team: German <translation-team-de@lists.sourceforge.net>\n"
@@ -52,6 +52,7 @@ msgstr ""
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
+#: src/apprt/gtk/class/application.zig:2031
 msgid "Cancel"
 msgstr "Abbrechen"
 
@@ -247,7 +248,7 @@ msgstr "Befehlspalette"
 msgid "Terminal Inspector"
 msgstr "Terminalinspektor"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1888
 msgid "About Ghostty"
 msgstr "Über Ghostty"
 
@@ -259,16 +260,24 @@ msgstr "Beenden"
 msgid "Execute a command…"
 msgstr "Einen Befehl ausführen…"
 
-#: src/apprt/gtk/class/application.zig:1708
+#: src/apprt/gtk/class/application.zig:1713
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1710
+#: src/apprt/gtk/class/application.zig:1715
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1721
+#: src/apprt/gtk/class/application.zig:1726
 msgid "Global keybind unavailable"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2027
+msgid "Export Terminal IO Events"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2030
+msgid "Export"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -363,14 +372,14 @@ msgstr "Tab-Titel ändern"
 msgid "Reloaded the configuration"
 msgstr "Konfiguration wurde neu geladen"
 
-#: src/apprt/gtk/class/window.zig:1705
+#: src/apprt/gtk/class/window.zig:1727
 msgid "Copied to clipboard"
 msgstr "In die Zwischenablage kopiert"
 
-#: src/apprt/gtk/class/window.zig:1707
+#: src/apprt/gtk/class/window.zig:1729
 msgid "Cleared clipboard"
 msgstr "Zwischenablage geleert"
 
-#: src/apprt/gtk/class/window.zig:1847
+#: src/apprt/gtk/class/window.zig:1869
 msgid "Ghostty Developers"
 msgstr "Ghostty-Entwickler"

--- a/po/es_AR.po
+++ b/po/es_AR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-07-26 04:59+0200\n"
+"POT-Creation-Date: 2026-07-30 18:07+0200\n"
 "PO-Revision-Date: 2026-02-19 13:34-0300\n"
 "Last-Translator: Alan Moyano <alanmoyano203@gmail.com>\n"
 "Language-Team: Argentinian <es@tp.org.es>\n"
@@ -48,6 +48,7 @@ msgstr "Recargar la configuración para volver a mostrar este mensaje"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
+#: src/apprt/gtk/class/application.zig:2031
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -242,7 +243,7 @@ msgstr "Paleta de comandos"
 msgid "Terminal Inspector"
 msgstr "Inspector de la terminal"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1888
 msgid "About Ghostty"
 msgstr "Acerca de Ghostty"
 
@@ -254,16 +255,24 @@ msgstr "Salir"
 msgid "Execute a command…"
 msgstr "Ejecutar un comando…"
 
-#: src/apprt/gtk/class/application.zig:1708
+#: src/apprt/gtk/class/application.zig:1713
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1710
+#: src/apprt/gtk/class/application.zig:1715
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1721
+#: src/apprt/gtk/class/application.zig:1726
 msgid "Global keybind unavailable"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2027
+msgid "Export Terminal IO Events"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2030
+msgid "Export"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -358,14 +367,14 @@ msgstr "Cambiar título de la pestaña"
 msgid "Reloaded the configuration"
 msgstr "Configuración recargada"
 
-#: src/apprt/gtk/class/window.zig:1705
+#: src/apprt/gtk/class/window.zig:1727
 msgid "Copied to clipboard"
 msgstr "Copiado al portapapeles"
 
-#: src/apprt/gtk/class/window.zig:1707
+#: src/apprt/gtk/class/window.zig:1729
 msgid "Cleared clipboard"
 msgstr "Portapapeles limpiado"
 
-#: src/apprt/gtk/class/window.zig:1847
+#: src/apprt/gtk/class/window.zig:1869
 msgid "Ghostty Developers"
 msgstr "Desarrolladores de Ghostty"

--- a/po/es_BO.po
+++ b/po/es_BO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-07-26 04:59+0200\n"
+"POT-Creation-Date: 2026-07-30 18:07+0200\n"
 "PO-Revision-Date: 2026-02-12 17:46+0200\n"
 "Last-Translator: Miguel Peredo <miguelp@quientienemail.com>\n"
 "Language-Team: Spanish <es@tp.org.es>\n"
@@ -48,6 +48,7 @@ msgstr "Recargar configuración para mostrar este aviso nuevamente"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
+#: src/apprt/gtk/class/application.zig:2031
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -242,7 +243,7 @@ msgstr "Paleta de comandos"
 msgid "Terminal Inspector"
 msgstr "Inspector de la terminal"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1888
 msgid "About Ghostty"
 msgstr "Acerca de Ghostty"
 
@@ -254,16 +255,24 @@ msgstr "Salir"
 msgid "Execute a command…"
 msgstr "Ejecutar comando…"
 
-#: src/apprt/gtk/class/application.zig:1708
+#: src/apprt/gtk/class/application.zig:1713
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1710
+#: src/apprt/gtk/class/application.zig:1715
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1721
+#: src/apprt/gtk/class/application.zig:1726
 msgid "Global keybind unavailable"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2027
+msgid "Export Terminal IO Events"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2030
+msgid "Export"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -358,14 +367,14 @@ msgstr "Cambiar el título de la pestaña"
 msgid "Reloaded the configuration"
 msgstr "Configuración recargada"
 
-#: src/apprt/gtk/class/window.zig:1705
+#: src/apprt/gtk/class/window.zig:1727
 msgid "Copied to clipboard"
 msgstr "Copiado al portapapeles"
 
-#: src/apprt/gtk/class/window.zig:1707
+#: src/apprt/gtk/class/window.zig:1729
 msgid "Cleared clipboard"
 msgstr "El portapapeles está limpio"
 
-#: src/apprt/gtk/class/window.zig:1847
+#: src/apprt/gtk/class/window.zig:1869
 msgid "Ghostty Developers"
 msgstr "Desarrolladores de Ghostty"

--- a/po/es_ES.po
+++ b/po/es_ES.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-07-26 04:59+0200\n"
+"POT-Creation-Date: 2026-07-30 18:07+0200\n"
 "PO-Revision-Date: 2026-02-18 10:57+0100\n"
 "Last-Translator: José Miguel Sarasola <alosarjos@gmail.com>\n"
 "Language-Team: \n"
@@ -49,6 +49,7 @@ msgstr "Recargar configuración para volver a mostrar este aviso"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
+#: src/apprt/gtk/class/application.zig:2031
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -243,7 +244,7 @@ msgstr "Paleta de comandos"
 msgid "Terminal Inspector"
 msgstr "Inspector de terminal"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1888
 msgid "About Ghostty"
 msgstr "Acerca de Ghostty"
 
@@ -255,16 +256,24 @@ msgstr "Salir"
 msgid "Execute a command…"
 msgstr "Ejecutar un comando…"
 
-#: src/apprt/gtk/class/application.zig:1708
+#: src/apprt/gtk/class/application.zig:1713
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1710
+#: src/apprt/gtk/class/application.zig:1715
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1721
+#: src/apprt/gtk/class/application.zig:1726
 msgid "Global keybind unavailable"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2027
+msgid "Export Terminal IO Events"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2030
+msgid "Export"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -359,14 +368,14 @@ msgstr "Cambiar el título de la pestaña"
 msgid "Reloaded the configuration"
 msgstr "Configuración recargada"
 
-#: src/apprt/gtk/class/window.zig:1705
+#: src/apprt/gtk/class/window.zig:1727
 msgid "Copied to clipboard"
 msgstr "Copiado al portapapeles"
 
-#: src/apprt/gtk/class/window.zig:1707
+#: src/apprt/gtk/class/window.zig:1729
 msgid "Cleared clipboard"
 msgstr "Portapapeles vaciado"
 
-#: src/apprt/gtk/class/window.zig:1847
+#: src/apprt/gtk/class/window.zig:1869
 msgid "Ghostty Developers"
 msgstr "Desarrolladores de Ghostty"

--- a/po/eu.po
+++ b/po/eu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-07-26 04:59+0200\n"
+"POT-Creation-Date: 2026-07-30 18:07+0200\n"
 "PO-Revision-Date: 2026-05-01 12:56+0200\n"
 "Last-Translator: Mikel Larreategi <mlarreategi@codesyntax.com>\n"
 "Language-Team: Language eu\n"
@@ -47,6 +47,7 @@ msgstr "Birkargatu konfigurazioa eta erakutsi hau berriz"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
+#: src/apprt/gtk/class/application.zig:2031
 msgid "Cancel"
 msgstr "Utzi"
 
@@ -240,7 +241,7 @@ msgstr "Komando paleta"
 msgid "Terminal Inspector"
 msgstr "Terminal ikuskatzailea"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1888
 msgid "About Ghostty"
 msgstr "Ghosttyri buruz"
 
@@ -252,16 +253,24 @@ msgstr "Irten"
 msgid "Execute a command…"
 msgstr "Exekutatu komando bat…"
 
-#: src/apprt/gtk/class/application.zig:1708
+#: src/apprt/gtk/class/application.zig:1713
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1710
+#: src/apprt/gtk/class/application.zig:1715
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1721
+#: src/apprt/gtk/class/application.zig:1726
 msgid "Global keybind unavailable"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2027
+msgid "Export Terminal IO Events"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2030
+msgid "Export"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -355,14 +364,14 @@ msgstr "Aldatu fitxaren izenburua"
 msgid "Reloaded the configuration"
 msgstr "Konfigurazioa berriz kargatu da"
 
-#: src/apprt/gtk/class/window.zig:1705
+#: src/apprt/gtk/class/window.zig:1727
 msgid "Copied to clipboard"
 msgstr "Arbelera kopiatu da"
 
-#: src/apprt/gtk/class/window.zig:1707
+#: src/apprt/gtk/class/window.zig:1729
 msgid "Cleared clipboard"
 msgstr "Arbela garbitu da"
 
-#: src/apprt/gtk/class/window.zig:1847
+#: src/apprt/gtk/class/window.zig:1869
 msgid "Ghostty Developers"
 msgstr "Ghostty garatzaileak"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-07-26 04:59+0200\n"
+"POT-Creation-Date: 2026-07-30 18:07+0200\n"
 "PO-Revision-Date: 2026-02-18 15:03+0200\n"
 "Last-Translator: Pangoraw <naydex.mc+github@gmail.com>\n"
 "Language-Team: French <traduc@traduc.org>\n"
@@ -48,6 +48,7 @@ msgstr "Recharger la configuration pour afficher à nouveau ce message"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
+#: src/apprt/gtk/class/application.zig:2031
 msgid "Cancel"
 msgstr "Annuler"
 
@@ -243,7 +244,7 @@ msgstr "Palette de commandes"
 msgid "Terminal Inspector"
 msgstr "Inspecteur de terminal"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1888
 msgid "About Ghostty"
 msgstr "À propos de Ghostty"
 
@@ -255,16 +256,24 @@ msgstr "Quitter"
 msgid "Execute a command…"
 msgstr "Exécuter une commande…"
 
-#: src/apprt/gtk/class/application.zig:1708
+#: src/apprt/gtk/class/application.zig:1713
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1710
+#: src/apprt/gtk/class/application.zig:1715
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1721
+#: src/apprt/gtk/class/application.zig:1726
 msgid "Global keybind unavailable"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2027
+msgid "Export Terminal IO Events"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2030
+msgid "Export"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -359,14 +368,14 @@ msgstr "Changer le titre de l'onglet"
 msgid "Reloaded the configuration"
 msgstr "Configuration rechargée"
 
-#: src/apprt/gtk/class/window.zig:1705
+#: src/apprt/gtk/class/window.zig:1727
 msgid "Copied to clipboard"
 msgstr "Copié dans le presse-papiers"
 
-#: src/apprt/gtk/class/window.zig:1707
+#: src/apprt/gtk/class/window.zig:1729
 msgid "Cleared clipboard"
 msgstr "Presse-papiers vidé"
 
-#: src/apprt/gtk/class/window.zig:1847
+#: src/apprt/gtk/class/window.zig:1869
 msgid "Ghostty Developers"
 msgstr "Les développeurs de Ghostty"

--- a/po/ga.po
+++ b/po/ga.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-07-26 04:59+0200\n"
+"POT-Creation-Date: 2026-07-30 18:07+0200\n"
 "PO-Revision-Date: 2026-02-18 14:32+0000\n"
 "Last-Translator: Aindriú Mac Giolla Eoin <aindriu80@yahoo.com>\n"
 "Language-Team: Irish <gaeilge-gnulinux@lists.sourceforge.net>\n"
@@ -48,6 +48,7 @@ msgstr "Athlódáil an chumraíocht chun an teachtaireacht seo a thaispeáint ar
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
+#: src/apprt/gtk/class/application.zig:2031
 msgid "Cancel"
 msgstr "Cealaigh"
 
@@ -241,7 +242,7 @@ msgstr "Pailéad ordaithe"
 msgid "Terminal Inspector"
 msgstr "Cigire teirminéil"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1888
 msgid "About Ghostty"
 msgstr "Maidir le Ghostty"
 
@@ -253,16 +254,24 @@ msgstr "Scoir"
 msgid "Execute a command…"
 msgstr "Rith ordú…"
 
-#: src/apprt/gtk/class/application.zig:1708
+#: src/apprt/gtk/class/application.zig:1713
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1710
+#: src/apprt/gtk/class/application.zig:1715
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1721
+#: src/apprt/gtk/class/application.zig:1726
 msgid "Global keybind unavailable"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2027
+msgid "Export Terminal IO Events"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2030
+msgid "Export"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -358,14 +367,14 @@ msgstr "Athraigh teideal an táb"
 msgid "Reloaded the configuration"
 msgstr "Tá an chumraíocht athlódáilte"
 
-#: src/apprt/gtk/class/window.zig:1705
+#: src/apprt/gtk/class/window.zig:1727
 msgid "Copied to clipboard"
 msgstr "Cóipeáilte chuig an ghearrthaisce"
 
-#: src/apprt/gtk/class/window.zig:1707
+#: src/apprt/gtk/class/window.zig:1729
 msgid "Cleared clipboard"
 msgstr "Gearrthaisce glanta"
 
-#: src/apprt/gtk/class/window.zig:1847
+#: src/apprt/gtk/class/window.zig:1869
 msgid "Ghostty Developers"
 msgstr "Forbróirí Ghostty"

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-07-26 04:59+0200\n"
+"POT-Creation-Date: 2026-07-30 18:07+0200\n"
 "PO-Revision-Date: 2026-02-18 18:14+0300\n"
 "Last-Translator: Sl (Shahaf Levi), Sl's Repository Ltd "
 "<ghostty@slsrepo.com>\n"
@@ -51,6 +51,7 @@ msgstr "טען/י את ההגדרות מחדש כדי להציג את הבקשה
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
+#: src/apprt/gtk/class/application.zig:2031
 msgid "Cancel"
 msgstr "ביטול"
 
@@ -242,7 +243,7 @@ msgstr "לוח פקודות"
 msgid "Terminal Inspector"
 msgstr "בודק המסוף"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1888
 msgid "About Ghostty"
 msgstr "אודות Ghostty"
 
@@ -254,16 +255,24 @@ msgstr "יציאה"
 msgid "Execute a command…"
 msgstr "הרץ/י פקודה…"
 
-#: src/apprt/gtk/class/application.zig:1708
+#: src/apprt/gtk/class/application.zig:1713
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1710
+#: src/apprt/gtk/class/application.zig:1715
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1721
+#: src/apprt/gtk/class/application.zig:1726
 msgid "Global keybind unavailable"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2027
+msgid "Export Terminal IO Events"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2030
+msgid "Export"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -355,14 +364,14 @@ msgstr "שינוי כותרת הכרטיסייה"
 msgid "Reloaded the configuration"
 msgstr "ההגדרות הוטענו מחדש"
 
-#: src/apprt/gtk/class/window.zig:1705
+#: src/apprt/gtk/class/window.zig:1727
 msgid "Copied to clipboard"
 msgstr "הועתק ללוח ההעתקה"
 
-#: src/apprt/gtk/class/window.zig:1707
+#: src/apprt/gtk/class/window.zig:1729
 msgid "Cleared clipboard"
 msgstr "לוח ההעתקה רוקן"
 
-#: src/apprt/gtk/class/window.zig:1847
+#: src/apprt/gtk/class/window.zig:1869
 msgid "Ghostty Developers"
 msgstr "המפתחים של Ghostty"

--- a/po/hr.po
+++ b/po/hr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-07-26 04:59+0200\n"
+"POT-Creation-Date: 2026-07-30 18:07+0200\n"
 "PO-Revision-Date: 2026-02-18 21:00+0200\n"
 "Last-Translator: Filip7 <filipm7@protonmail.com>\n"
 "Language-Team: Croatian <lokalizacija@linux.hr>\n"
@@ -50,6 +50,7 @@ msgstr "Ponovno učitaj postavke za prikaz ovog upita"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
+#: src/apprt/gtk/class/application.zig:2031
 msgid "Cancel"
 msgstr "Otkaži"
 
@@ -242,7 +243,7 @@ msgstr "Paleta naredbi"
 msgid "Terminal Inspector"
 msgstr "Inspektor terminala"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1888
 msgid "About Ghostty"
 msgstr "O Ghosttyju"
 
@@ -254,16 +255,24 @@ msgstr "Izađi"
 msgid "Execute a command…"
 msgstr "Izvrši naredbu…"
 
-#: src/apprt/gtk/class/application.zig:1708
+#: src/apprt/gtk/class/application.zig:1713
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1710
+#: src/apprt/gtk/class/application.zig:1715
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1721
+#: src/apprt/gtk/class/application.zig:1726
 msgid "Global keybind unavailable"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2027
+msgid "Export Terminal IO Events"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2030
+msgid "Export"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -358,14 +367,14 @@ msgstr "Promijeni naslov kartice"
 msgid "Reloaded the configuration"
 msgstr "Ponovno učitane postavke"
 
-#: src/apprt/gtk/class/window.zig:1705
+#: src/apprt/gtk/class/window.zig:1727
 msgid "Copied to clipboard"
 msgstr "Kopirano u međuspremnik"
 
-#: src/apprt/gtk/class/window.zig:1707
+#: src/apprt/gtk/class/window.zig:1729
 msgid "Cleared clipboard"
 msgstr "Očišćen međuspremnik"
 
-#: src/apprt/gtk/class/window.zig:1847
+#: src/apprt/gtk/class/window.zig:1869
 msgid "Ghostty Developers"
 msgstr "Razvijatelji Ghosttyja"

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-07-26 04:59+0200\n"
+"POT-Creation-Date: 2026-07-30 18:07+0200\n"
 "PO-Revision-Date: 2026-02-26 21:00+0100\n"
 "Last-Translator: Balázs Szücs <bszucs1209@gmail.com>\n"
 "Language-Team: Hungarian <translation-team-hu@lists.sourceforge.net>\n"
@@ -48,6 +48,7 @@ msgstr "Konfiguráció frissítése a kérdés újbóli megjelenítéséhez"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
+#: src/apprt/gtk/class/application.zig:2031
 msgid "Cancel"
 msgstr "Mégse"
 
@@ -242,7 +243,7 @@ msgstr "Parancspaletta"
 msgid "Terminal Inspector"
 msgstr "Terminálvizsgáló"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1888
 msgid "About Ghostty"
 msgstr "A Ghostty névjegye"
 
@@ -254,16 +255,24 @@ msgstr "Kilépés"
 msgid "Execute a command…"
 msgstr "Parancs végrehajtása…"
 
-#: src/apprt/gtk/class/application.zig:1708
+#: src/apprt/gtk/class/application.zig:1713
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1710
+#: src/apprt/gtk/class/application.zig:1715
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1721
+#: src/apprt/gtk/class/application.zig:1726
 msgid "Global keybind unavailable"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2027
+msgid "Export Terminal IO Events"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2030
+msgid "Export"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -358,14 +367,14 @@ msgstr "Fül címének módosítása"
 msgid "Reloaded the configuration"
 msgstr "Konfiguráció frissítve"
 
-#: src/apprt/gtk/class/window.zig:1705
+#: src/apprt/gtk/class/window.zig:1727
 msgid "Copied to clipboard"
 msgstr "Vágólapra másolva"
 
-#: src/apprt/gtk/class/window.zig:1707
+#: src/apprt/gtk/class/window.zig:1729
 msgid "Cleared clipboard"
 msgstr "Vágólap törölve"
 
-#: src/apprt/gtk/class/window.zig:1847
+#: src/apprt/gtk/class/window.zig:1869
 msgid "Ghostty Developers"
 msgstr "Ghostty fejlesztők"

--- a/po/id.po
+++ b/po/id.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-07-26 04:59+0200\n"
+"POT-Creation-Date: 2026-07-30 18:07+0200\n"
 "PO-Revision-Date: 2026-03-08 20:23+0700\n"
 "Last-Translator: Mikail Muzakki <mikailmmuzakki@gmail.com>\n"
 "Language-Team: Indonesian <translation-team-id@lists.sourceforge.net>\n"
@@ -49,6 +49,7 @@ msgstr "Muat ulang konfigurasi untuk menampilkan pesan ini lagi"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
+#: src/apprt/gtk/class/application.zig:2031
 msgid "Cancel"
 msgstr "Batal"
 
@@ -242,7 +243,7 @@ msgstr "Palet perintah"
 msgid "Terminal Inspector"
 msgstr "Inspektur terminal"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1888
 msgid "About Ghostty"
 msgstr "Tentang Ghostty"
 
@@ -254,16 +255,24 @@ msgstr "Keluar"
 msgid "Execute a command…"
 msgstr "Eksekusi perintah…"
 
-#: src/apprt/gtk/class/application.zig:1708
+#: src/apprt/gtk/class/application.zig:1713
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1710
+#: src/apprt/gtk/class/application.zig:1715
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1721
+#: src/apprt/gtk/class/application.zig:1726
 msgid "Global keybind unavailable"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2027
+msgid "Export Terminal IO Events"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2030
+msgid "Export"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -358,14 +367,14 @@ msgstr "Ubah judul tab"
 msgid "Reloaded the configuration"
 msgstr "Memuat ulang konfigurasi"
 
-#: src/apprt/gtk/class/window.zig:1705
+#: src/apprt/gtk/class/window.zig:1727
 msgid "Copied to clipboard"
 msgstr "Disalin ke papan klip"
 
-#: src/apprt/gtk/class/window.zig:1707
+#: src/apprt/gtk/class/window.zig:1729
 msgid "Cleared clipboard"
 msgstr "Papan klip dibersihkan"
 
-#: src/apprt/gtk/class/window.zig:1847
+#: src/apprt/gtk/class/window.zig:1869
 msgid "Ghostty Developers"
 msgstr "Pengembang Ghostty"

--- a/po/it.po
+++ b/po/it.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-07-26 04:59+0200\n"
+"POT-Creation-Date: 2026-07-30 18:07+0200\n"
 "PO-Revision-Date: 2025-09-06 19:40+0200\n"
 "Last-Translator: Giacomo Bettini <giaco.bettini@gmail.com>\n"
 "Language-Team: Italian <tp@lists.linux.it>\n"
@@ -50,6 +50,7 @@ msgstr ""
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
+#: src/apprt/gtk/class/application.zig:2031
 msgid "Cancel"
 msgstr "Annulla"
 
@@ -243,7 +244,7 @@ msgstr "Riquadro comandi"
 msgid "Terminal Inspector"
 msgstr "Ispettore del terminale"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1888
 msgid "About Ghostty"
 msgstr "Informazioni su Ghostty"
 
@@ -255,16 +256,24 @@ msgstr "Chiudi"
 msgid "Execute a command…"
 msgstr "Esegui un comando…"
 
-#: src/apprt/gtk/class/application.zig:1708
+#: src/apprt/gtk/class/application.zig:1713
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1710
+#: src/apprt/gtk/class/application.zig:1715
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1721
+#: src/apprt/gtk/class/application.zig:1726
 msgid "Global keybind unavailable"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2027
+msgid "Export Terminal IO Events"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2030
+msgid "Export"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -360,14 +369,14 @@ msgstr "Cambia il titolo della scheda"
 msgid "Reloaded the configuration"
 msgstr "Configurazione ricaricata"
 
-#: src/apprt/gtk/class/window.zig:1705
+#: src/apprt/gtk/class/window.zig:1727
 msgid "Copied to clipboard"
 msgstr "Copiato negli Appunti"
 
-#: src/apprt/gtk/class/window.zig:1707
+#: src/apprt/gtk/class/window.zig:1729
 msgid "Cleared clipboard"
 msgstr "Appunti svuotati"
 
-#: src/apprt/gtk/class/window.zig:1847
+#: src/apprt/gtk/class/window.zig:1869
 msgid "Ghostty Developers"
 msgstr "Sviluppatori di Ghostty"

--- a/po/ja.po
+++ b/po/ja.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-07-26 04:59+0200\n"
+"POT-Creation-Date: 2026-07-30 18:07+0200\n"
 "PO-Revision-Date: 2026-02-11 12:02+0900\n"
 "Last-Translator: Takayuki Nagatomi <tnagatomi@okweird.net>\n"
 "Language-Team: Japanese\n"
@@ -49,6 +49,7 @@ msgstr "このプロンプトを再び表示するには設定を再読み込み
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
+#: src/apprt/gtk/class/application.zig:2031
 msgid "Cancel"
 msgstr "キャンセル"
 
@@ -241,7 +242,7 @@ msgstr "コマンドパレット"
 msgid "Terminal Inspector"
 msgstr "端末インスペクター"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1888
 msgid "About Ghostty"
 msgstr "Ghostty について"
 
@@ -253,16 +254,24 @@ msgstr "終了"
 msgid "Execute a command…"
 msgstr "コマンドを実行…"
 
-#: src/apprt/gtk/class/application.zig:1708
+#: src/apprt/gtk/class/application.zig:1713
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1710
+#: src/apprt/gtk/class/application.zig:1715
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1721
+#: src/apprt/gtk/class/application.zig:1726
 msgid "Global keybind unavailable"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2027
+msgid "Export Terminal IO Events"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2030
+msgid "Export"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -357,14 +366,14 @@ msgstr "タブのタイトルを変更する"
 msgid "Reloaded the configuration"
 msgstr "設定を再読み込みしました"
 
-#: src/apprt/gtk/class/window.zig:1705
+#: src/apprt/gtk/class/window.zig:1727
 msgid "Copied to clipboard"
 msgstr "クリップボードにコピーしました"
 
-#: src/apprt/gtk/class/window.zig:1707
+#: src/apprt/gtk/class/window.zig:1729
 msgid "Cleared clipboard"
 msgstr "クリップボードを空にしました"
 
-#: src/apprt/gtk/class/window.zig:1847
+#: src/apprt/gtk/class/window.zig:1869
 msgid "Ghostty Developers"
 msgstr "Ghostty 開発者"

--- a/po/kk.po
+++ b/po/kk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-07-26 04:59+0200\n"
+"POT-Creation-Date: 2026-07-30 18:07+0200\n"
 "PO-Revision-Date: 2026-06-20 17:07+0500\n"
 "Last-Translator: AnmiTaliDev <anmitalidev@nuros.org>\n"
 "Language-Team: Kazakh <kk_KZ@googlegroups.com>\n"
@@ -50,6 +50,7 @@ msgstr "Бұл сұрауды қайта көрсету үшін конфигу�
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
+#: src/apprt/gtk/class/application.zig:2031
 msgid "Cancel"
 msgstr "Бас тарту"
 
@@ -244,7 +245,7 @@ msgstr "Командалар палитрасы"
 msgid "Terminal Inspector"
 msgstr "Терминал инспекторы"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1888
 msgid "About Ghostty"
 msgstr "Ghostty туралы"
 
@@ -256,16 +257,24 @@ msgstr "Шығу"
 msgid "Execute a command…"
 msgstr "Команданы орындау…"
 
-#: src/apprt/gtk/class/application.zig:1708
+#: src/apprt/gtk/class/application.zig:1713
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1710
+#: src/apprt/gtk/class/application.zig:1715
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1721
+#: src/apprt/gtk/class/application.zig:1726
 msgid "Global keybind unavailable"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2027
+msgid "Export Terminal IO Events"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2030
+msgid "Export"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -360,14 +369,14 @@ msgstr "Бет атауын өзгерту"
 msgid "Reloaded the configuration"
 msgstr "Конфигурация қайта жүктелді"
 
-#: src/apprt/gtk/class/window.zig:1705
+#: src/apprt/gtk/class/window.zig:1727
 msgid "Copied to clipboard"
 msgstr "Алмасу буферіне көшірілді"
 
-#: src/apprt/gtk/class/window.zig:1707
+#: src/apprt/gtk/class/window.zig:1729
 msgid "Cleared clipboard"
 msgstr "Алмасу буфері тазартылды"
 
-#: src/apprt/gtk/class/window.zig:1847
+#: src/apprt/gtk/class/window.zig:1869
 msgid "Ghostty Developers"
 msgstr "Ghostty әзірлеушілері"

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-07-26 04:59+0200\n"
+"POT-Creation-Date: 2026-07-30 18:07+0200\n"
 "PO-Revision-Date: 2026-02-11 12:50+0900\n"
 "Last-Translator: GyuYong Jung <obliviscence@gmail.com>\n"
 "Language-Team: Korean <translation-team-ko@googlegroups.com>\n"
@@ -48,6 +48,7 @@ msgstr "이 창을 다시 보려면 설정을 다시 불러오세요"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
+#: src/apprt/gtk/class/application.zig:2031
 msgid "Cancel"
 msgstr "취소"
 
@@ -239,7 +240,7 @@ msgstr "명령 팔레트"
 msgid "Terminal Inspector"
 msgstr "터미널 인스펙터"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1888
 msgid "About Ghostty"
 msgstr "Ghostty 정보"
 
@@ -251,16 +252,24 @@ msgstr "종료"
 msgid "Execute a command…"
 msgstr "명령을 실행하세요…"
 
-#: src/apprt/gtk/class/application.zig:1708
+#: src/apprt/gtk/class/application.zig:1713
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1710
+#: src/apprt/gtk/class/application.zig:1715
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1721
+#: src/apprt/gtk/class/application.zig:1726
 msgid "Global keybind unavailable"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2027
+msgid "Export Terminal IO Events"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2030
+msgid "Export"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -355,14 +364,14 @@ msgstr "탭 제목 변경"
 msgid "Reloaded the configuration"
 msgstr "설정값을 다시 불러왔습니다"
 
-#: src/apprt/gtk/class/window.zig:1705
+#: src/apprt/gtk/class/window.zig:1727
 msgid "Copied to clipboard"
 msgstr "클립보드에 복사됨"
 
-#: src/apprt/gtk/class/window.zig:1707
+#: src/apprt/gtk/class/window.zig:1729
 msgid "Cleared clipboard"
 msgstr "클립보드 지워짐"
 
-#: src/apprt/gtk/class/window.zig:1847
+#: src/apprt/gtk/class/window.zig:1869
 msgid "Ghostty Developers"
 msgstr "Ghostty 개발자들"

--- a/po/lt.po
+++ b/po/lt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-07-26 04:59+0200\n"
+"POT-Creation-Date: 2026-07-30 18:07+0200\n"
 "PO-Revision-Date: 2026-02-20 12:13+0100\n"
 "Last-Translator: Tadas Lotuzas <tdslot@gmail.com>\n"
 "Language-Team: Language LT\n"
@@ -49,6 +49,7 @@ msgstr "Iš naujo įkelkite konfigūraciją, kad vėl būtų rodoma ši užuomin
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
+#: src/apprt/gtk/class/application.zig:2031
 msgid "Cancel"
 msgstr "Atšaukti"
 
@@ -242,7 +243,7 @@ msgstr "Komandų paletė"
 msgid "Terminal Inspector"
 msgstr "Terminalo inspektorius"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1888
 msgid "About Ghostty"
 msgstr "Apie Ghostty"
 
@@ -254,16 +255,24 @@ msgstr "Išeiti"
 msgid "Execute a command…"
 msgstr "Vykdyti komandą…"
 
-#: src/apprt/gtk/class/application.zig:1708
+#: src/apprt/gtk/class/application.zig:1713
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1710
+#: src/apprt/gtk/class/application.zig:1715
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1721
+#: src/apprt/gtk/class/application.zig:1726
 msgid "Global keybind unavailable"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2027
+msgid "Export Terminal IO Events"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2030
+msgid "Export"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -358,14 +367,14 @@ msgstr "Keisti kortelės pavadinimą"
 msgid "Reloaded the configuration"
 msgstr "Konfigūracija įkelta iš naujo"
 
-#: src/apprt/gtk/class/window.zig:1705
+#: src/apprt/gtk/class/window.zig:1727
 msgid "Copied to clipboard"
 msgstr "Nukopijuota į iškarpinę"
 
-#: src/apprt/gtk/class/window.zig:1707
+#: src/apprt/gtk/class/window.zig:1729
 msgid "Cleared clipboard"
 msgstr "Iškarpinė išvalyta"
 
-#: src/apprt/gtk/class/window.zig:1847
+#: src/apprt/gtk/class/window.zig:1869
 msgid "Ghostty Developers"
 msgstr "Ghostty kūrėjai"

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-07-26 04:59+0200\n"
+"POT-Creation-Date: 2026-07-30 18:07+0200\n"
 "PO-Revision-Date: 2026-02-09 03:24+0200\n"
 "Last-Translator: Ēriks Remess <eriks@remess.lv>\n"
 "Language-Team: Latvian\n"
@@ -48,6 +48,7 @@ msgstr "Pārlādējiet konfigurāciju, lai šo uzvedni rādītu atkal"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
+#: src/apprt/gtk/class/application.zig:2031
 msgid "Cancel"
 msgstr "Atcelt"
 
@@ -239,7 +240,7 @@ msgstr "Komandu palete"
 msgid "Terminal Inspector"
 msgstr "Termināļa inspektors"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1888
 msgid "About Ghostty"
 msgstr "Par Ghostty"
 
@@ -251,16 +252,24 @@ msgstr "Iziet"
 msgid "Execute a command…"
 msgstr "Izpildīt komandu…"
 
-#: src/apprt/gtk/class/application.zig:1708
+#: src/apprt/gtk/class/application.zig:1713
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1710
+#: src/apprt/gtk/class/application.zig:1715
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1721
+#: src/apprt/gtk/class/application.zig:1726
 msgid "Global keybind unavailable"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2027
+msgid "Export Terminal IO Events"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2030
+msgid "Export"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -355,14 +364,14 @@ msgstr "Mainīt cilnes virsrakstu"
 msgid "Reloaded the configuration"
 msgstr "Konfigurācija pārlādēta"
 
-#: src/apprt/gtk/class/window.zig:1705
+#: src/apprt/gtk/class/window.zig:1727
 msgid "Copied to clipboard"
 msgstr "Nokopēts starpliktuvē"
 
-#: src/apprt/gtk/class/window.zig:1707
+#: src/apprt/gtk/class/window.zig:1729
 msgid "Cleared clipboard"
 msgstr "Starpliktuve notīrīta"
 
-#: src/apprt/gtk/class/window.zig:1847
+#: src/apprt/gtk/class/window.zig:1869
 msgid "Ghostty Developers"
 msgstr "Ghostty izstrādātāji"

--- a/po/mk.po
+++ b/po/mk.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-07-26 04:59+0200\n"
+"POT-Creation-Date: 2026-07-30 18:07+0200\n"
 "PO-Revision-Date: 2026-02-12 17:00+0100\n"
 "Last-Translator: Andrej Daskalov <andrej.daskalov@gmail.com>\n"
 "Language-Team: Macedonian\n"
@@ -48,6 +48,7 @@ msgstr "Одново вчитај конфигурација за да се по
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
+#: src/apprt/gtk/class/application.zig:2031
 msgid "Cancel"
 msgstr "Откажи"
 
@@ -242,7 +243,7 @@ msgstr "Командна палета"
 msgid "Terminal Inspector"
 msgstr "Инспектор на терминал"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1888
 msgid "About Ghostty"
 msgstr "За Ghostty"
 
@@ -254,16 +255,24 @@ msgstr "Излез"
 msgid "Execute a command…"
 msgstr "Изврши команда…"
 
-#: src/apprt/gtk/class/application.zig:1708
+#: src/apprt/gtk/class/application.zig:1713
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1710
+#: src/apprt/gtk/class/application.zig:1715
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1721
+#: src/apprt/gtk/class/application.zig:1726
 msgid "Global keybind unavailable"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2027
+msgid "Export Terminal IO Events"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2030
+msgid "Export"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -358,14 +367,14 @@ msgstr "Промени наслов на јазиче"
 msgid "Reloaded the configuration"
 msgstr "Конфигурацијата е одново вчитана"
 
-#: src/apprt/gtk/class/window.zig:1705
+#: src/apprt/gtk/class/window.zig:1727
 msgid "Copied to clipboard"
 msgstr "Копирано во привремена меморија"
 
-#: src/apprt/gtk/class/window.zig:1707
+#: src/apprt/gtk/class/window.zig:1729
 msgid "Cleared clipboard"
 msgstr "Исчистена привремена меморија"
 
-#: src/apprt/gtk/class/window.zig:1847
+#: src/apprt/gtk/class/window.zig:1869
 msgid "Ghostty Developers"
 msgstr "Развивачи на Ghostty"

--- a/po/nb.po
+++ b/po/nb.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-07-26 04:59+0200\n"
+"POT-Creation-Date: 2026-07-30 18:07+0200\n"
 "PO-Revision-Date: 2026-02-12 15:50+0000\n"
 "Last-Translator: Hanna Rose <me@hanna.lol>\n"
 "Language-Team: Norwegian Bokmal <l10n-no@lister.huftis.org>\n"
@@ -51,6 +51,7 @@ msgstr "Last inn konfigurasjonen på nytt for å vise denne meldingen igjen"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
+#: src/apprt/gtk/class/application.zig:2031
 msgid "Cancel"
 msgstr "Avbryt"
 
@@ -243,7 +244,7 @@ msgstr "Kommandopalett"
 msgid "Terminal Inspector"
 msgstr "Terminalinspektør"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1888
 msgid "About Ghostty"
 msgstr "Om Ghostty"
 
@@ -255,16 +256,24 @@ msgstr "Avslutt"
 msgid "Execute a command…"
 msgstr "Kjør en kommando…"
 
-#: src/apprt/gtk/class/application.zig:1708
+#: src/apprt/gtk/class/application.zig:1713
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1710
+#: src/apprt/gtk/class/application.zig:1715
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1721
+#: src/apprt/gtk/class/application.zig:1726
 msgid "Global keybind unavailable"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2027
+msgid "Export Terminal IO Events"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2030
+msgid "Export"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -359,14 +368,14 @@ msgstr "Endre fanetittel"
 msgid "Reloaded the configuration"
 msgstr "Konfigurasjonen ble lastet på nytt"
 
-#: src/apprt/gtk/class/window.zig:1705
+#: src/apprt/gtk/class/window.zig:1727
 msgid "Copied to clipboard"
 msgstr "Kopiert til utklippstavlen"
 
-#: src/apprt/gtk/class/window.zig:1707
+#: src/apprt/gtk/class/window.zig:1729
 msgid "Cleared clipboard"
 msgstr "Utklippstavle tømt"
 
-#: src/apprt/gtk/class/window.zig:1847
+#: src/apprt/gtk/class/window.zig:1869
 msgid "Ghostty Developers"
 msgstr "Ghostty-utviklere"

--- a/po/nl.po
+++ b/po/nl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-07-26 04:59+0200\n"
+"POT-Creation-Date: 2026-07-30 18:07+0200\n"
 "PO-Revision-Date: 2026-02-18 20:59+0100\n"
 "Last-Translator: Nico Geesink <geesinknico@gmail.com>\n"
 "Language-Team: Dutch <vertaling@vrijschrift.org>\n"
@@ -49,6 +49,7 @@ msgstr "Herlaad de configuratie om deze prompt opnieuw weer te geven"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
+#: src/apprt/gtk/class/application.zig:2031
 msgid "Cancel"
 msgstr "Annuleren"
 
@@ -243,7 +244,7 @@ msgstr "Opdrachtpalet"
 msgid "Terminal Inspector"
 msgstr "Terminalinspecteur"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1888
 msgid "About Ghostty"
 msgstr "Over Ghostty"
 
@@ -255,16 +256,24 @@ msgstr "Afsluiten"
 msgid "Execute a command…"
 msgstr "Voer een commando uit…"
 
-#: src/apprt/gtk/class/application.zig:1708
+#: src/apprt/gtk/class/application.zig:1713
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1710
+#: src/apprt/gtk/class/application.zig:1715
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1721
+#: src/apprt/gtk/class/application.zig:1726
 msgid "Global keybind unavailable"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2027
+msgid "Export Terminal IO Events"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2030
+msgid "Export"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -359,14 +368,14 @@ msgstr "Wijzig tabbladtitel"
 msgid "Reloaded the configuration"
 msgstr "De configuratie is herladen"
 
-#: src/apprt/gtk/class/window.zig:1705
+#: src/apprt/gtk/class/window.zig:1727
 msgid "Copied to clipboard"
 msgstr "Gekopieerd naar klembord"
 
-#: src/apprt/gtk/class/window.zig:1707
+#: src/apprt/gtk/class/window.zig:1729
 msgid "Cleared clipboard"
 msgstr "Klembord geleegd"
 
-#: src/apprt/gtk/class/window.zig:1847
+#: src/apprt/gtk/class/window.zig:1869
 msgid "Ghostty Developers"
 msgstr "Ghostty-ontwikkelaars"

--- a/po/pl.po
+++ b/po/pl.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-07-26 04:59+0200\n"
+"POT-Creation-Date: 2026-07-30 18:07+0200\n"
 "PO-Revision-Date: 2026-02-11 14:12+0100\n"
 "Last-Translator: trag1c <dev@jakubr.me>\n"
 "Language-Team: Polish <translation-team-pl@lists.sourceforge.net>\n"
@@ -51,6 +51,7 @@ msgstr "Przeładuj konfigurację, by ponownie wyświetlić ten komunikat"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
+#: src/apprt/gtk/class/application.zig:2031
 msgid "Cancel"
 msgstr "Anuluj"
 
@@ -243,7 +244,7 @@ msgstr "Paleta komend"
 msgid "Terminal Inspector"
 msgstr "Inspektor terminala"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1888
 msgid "About Ghostty"
 msgstr "O Ghostty"
 
@@ -255,16 +256,24 @@ msgstr "Zamknij"
 msgid "Execute a command…"
 msgstr "Wykonaj komendę…"
 
-#: src/apprt/gtk/class/application.zig:1708
+#: src/apprt/gtk/class/application.zig:1713
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1710
+#: src/apprt/gtk/class/application.zig:1715
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1721
+#: src/apprt/gtk/class/application.zig:1726
 msgid "Global keybind unavailable"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2027
+msgid "Export Terminal IO Events"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2030
+msgid "Export"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -359,14 +368,14 @@ msgstr "Zmień tytuł karty"
 msgid "Reloaded the configuration"
 msgstr "Przeładowano konfigurację"
 
-#: src/apprt/gtk/class/window.zig:1705
+#: src/apprt/gtk/class/window.zig:1727
 msgid "Copied to clipboard"
 msgstr "Skopiowano do schowka"
 
-#: src/apprt/gtk/class/window.zig:1707
+#: src/apprt/gtk/class/window.zig:1729
 msgid "Cleared clipboard"
 msgstr "Wyczyszczono schowek"
 
-#: src/apprt/gtk/class/window.zig:1847
+#: src/apprt/gtk/class/window.zig:1869
 msgid "Ghostty Developers"
 msgstr "Twórcy Ghostty"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-07-26 04:59+0200\n"
+"POT-Creation-Date: 2026-07-30 18:07+0200\n"
 "PO-Revision-Date: 2026-02-18 10:50-0300\n"
 "Last-Translator: Guilherme Tiscoski <github@guilhermetiscoski.com>\n"
 "Language-Team: Brazilian Portuguese <ldpbr-"
@@ -52,6 +52,7 @@ msgstr "Recarregue a configuração para mostrar este aviso novamente"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
+#: src/apprt/gtk/class/application.zig:2031
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -245,7 +246,7 @@ msgstr "Paleta de comandos"
 msgid "Terminal Inspector"
 msgstr "Inspetor de terminal"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1888
 msgid "About Ghostty"
 msgstr "Sobre o Ghostty"
 
@@ -257,16 +258,24 @@ msgstr "Sair"
 msgid "Execute a command…"
 msgstr "Executar um comando…"
 
-#: src/apprt/gtk/class/application.zig:1708
+#: src/apprt/gtk/class/application.zig:1713
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1710
+#: src/apprt/gtk/class/application.zig:1715
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1721
+#: src/apprt/gtk/class/application.zig:1726
 msgid "Global keybind unavailable"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2027
+msgid "Export Terminal IO Events"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2030
+msgid "Export"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -361,14 +370,14 @@ msgstr "Mudar título da aba"
 msgid "Reloaded the configuration"
 msgstr "Configuração recarregada"
 
-#: src/apprt/gtk/class/window.zig:1705
+#: src/apprt/gtk/class/window.zig:1727
 msgid "Copied to clipboard"
 msgstr "Copiado para a área de transferência"
 
-#: src/apprt/gtk/class/window.zig:1707
+#: src/apprt/gtk/class/window.zig:1729
 msgid "Cleared clipboard"
 msgstr "Área de transferência limpa"
 
-#: src/apprt/gtk/class/window.zig:1847
+#: src/apprt/gtk/class/window.zig:1869
 msgid "Ghostty Developers"
 msgstr "Desenvolvedores do Ghostty"

--- a/po/ru.po
+++ b/po/ru.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-07-26 04:59+0200\n"
+"POT-Creation-Date: 2026-07-30 18:07+0200\n"
 "PO-Revision-Date: 2025-02-18 10:20+0100\n"
 "Last-Translator: Ivan Bastrakov <bastaynav@proton.me>\n"
 "Language-Team: Russian <gnu@d07.ru>\n"
@@ -50,6 +50,7 @@ msgstr "Перезагрузите конфигурацию, чтобы снов
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
+#: src/apprt/gtk/class/application.zig:2031
 msgid "Cancel"
 msgstr "Отмена"
 
@@ -244,7 +245,7 @@ msgstr "Палитра команд"
 msgid "Terminal Inspector"
 msgstr "Инспектор терминала"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1888
 msgid "About Ghostty"
 msgstr "О Ghostty"
 
@@ -256,16 +257,24 @@ msgstr "Выход"
 msgid "Execute a command…"
 msgstr "Выполнить команду…"
 
-#: src/apprt/gtk/class/application.zig:1708
+#: src/apprt/gtk/class/application.zig:1713
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1710
+#: src/apprt/gtk/class/application.zig:1715
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1721
+#: src/apprt/gtk/class/application.zig:1726
 msgid "Global keybind unavailable"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2027
+msgid "Export Terminal IO Events"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2030
+msgid "Export"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -360,14 +369,14 @@ msgstr "Переименовать вкладку"
 msgid "Reloaded the configuration"
 msgstr "Конфигурация перезагружена"
 
-#: src/apprt/gtk/class/window.zig:1705
+#: src/apprt/gtk/class/window.zig:1727
 msgid "Copied to clipboard"
 msgstr "Скопировано в буфер обмена"
 
-#: src/apprt/gtk/class/window.zig:1707
+#: src/apprt/gtk/class/window.zig:1729
 msgid "Cleared clipboard"
 msgstr "Буфер обмена очищен"
 
-#: src/apprt/gtk/class/window.zig:1847
+#: src/apprt/gtk/class/window.zig:1869
 msgid "Ghostty Developers"
 msgstr "Разработчики Ghostty"

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-07-26 04:59+0200\n"
+"POT-Creation-Date: 2026-07-30 18:07+0200\n"
 "PO-Revision-Date: 2026-02-09 22:18+0300\n"
 "Last-Translator: Emir SARI <emir_sari@icloud.com>\n"
 "Language-Team: Turkish\n"
@@ -48,6 +48,7 @@ msgstr "Bu istemi tekrar göstermek için yapılandırmayı yeniden yükle"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
+#: src/apprt/gtk/class/application.zig:2031
 msgid "Cancel"
 msgstr "İptal"
 
@@ -243,7 +244,7 @@ msgstr "Komut Paleti"
 msgid "Terminal Inspector"
 msgstr "Uçbirim Denetçisi"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1888
 msgid "About Ghostty"
 msgstr "Ghostty Hakkında"
 
@@ -255,16 +256,24 @@ msgstr "Çık"
 msgid "Execute a command…"
 msgstr "Bir komut çalıştır…"
 
-#: src/apprt/gtk/class/application.zig:1708
+#: src/apprt/gtk/class/application.zig:1713
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1710
+#: src/apprt/gtk/class/application.zig:1715
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1721
+#: src/apprt/gtk/class/application.zig:1726
 msgid "Global keybind unavailable"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2027
+msgid "Export Terminal IO Events"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2030
+msgid "Export"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -359,14 +368,14 @@ msgstr "Sekme Başlığını Değiştir"
 msgid "Reloaded the configuration"
 msgstr "Yapılandırma yeniden yüklendi"
 
-#: src/apprt/gtk/class/window.zig:1705
+#: src/apprt/gtk/class/window.zig:1727
 msgid "Copied to clipboard"
 msgstr "Panoya kopyalandı"
 
-#: src/apprt/gtk/class/window.zig:1707
+#: src/apprt/gtk/class/window.zig:1729
 msgid "Cleared clipboard"
 msgstr "Pano temizlendi"
 
-#: src/apprt/gtk/class/window.zig:1847
+#: src/apprt/gtk/class/window.zig:1869
 msgid "Ghostty Developers"
 msgstr "Ghostty Geliştiricileri"

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-07-26 04:59+0200\n"
+"POT-Creation-Date: 2026-07-30 18:07+0200\n"
 "PO-Revision-Date: 2026-02-18 13:14+0100\n"
 "Last-Translator: Volodymyr Chernetskyi "
 "<19735328+chernetskyi@users.noreply.github.com>\n"
@@ -50,6 +50,7 @@ msgstr "Перезавантажте налаштування, щоб показ
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
+#: src/apprt/gtk/class/application.zig:2031
 msgid "Cancel"
 msgstr "Скасувати"
 
@@ -242,7 +243,7 @@ msgstr "Палітра команд"
 msgid "Terminal Inspector"
 msgstr "Інспектор терміналу"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1888
 msgid "About Ghostty"
 msgstr "Про Ghostty"
 
@@ -254,16 +255,24 @@ msgstr "Завершити"
 msgid "Execute a command…"
 msgstr "Виконати команду…"
 
-#: src/apprt/gtk/class/application.zig:1708
+#: src/apprt/gtk/class/application.zig:1713
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1710
+#: src/apprt/gtk/class/application.zig:1715
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1721
+#: src/apprt/gtk/class/application.zig:1726
 msgid "Global keybind unavailable"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2027
+msgid "Export Terminal IO Events"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2030
+msgid "Export"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -358,14 +367,14 @@ msgstr "Змінити заголовок вкладки"
 msgid "Reloaded the configuration"
 msgstr "Налаштування перезавантажено"
 
-#: src/apprt/gtk/class/window.zig:1705
+#: src/apprt/gtk/class/window.zig:1727
 msgid "Copied to clipboard"
 msgstr "Скопійовано до буферa обміну"
 
-#: src/apprt/gtk/class/window.zig:1707
+#: src/apprt/gtk/class/window.zig:1729
 msgid "Cleared clipboard"
 msgstr "Буфер обміну очищено"
 
-#: src/apprt/gtk/class/window.zig:1847
+#: src/apprt/gtk/class/window.zig:1869
 msgid "Ghostty Developers"
 msgstr "Розробники Ghostty"

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-07-26 04:59+0200\n"
+"POT-Creation-Date: 2026-07-30 18:07+0200\n"
 "PO-Revision-Date: 2026-03-04 09:32+0700\n"
 "Last-Translator: Anh Thang <buianhthang89@gmail.com>\n"
 "Language-Team: Vietnamese <translation-team-vi@lists.sourceforge.net>\n"
@@ -48,6 +48,7 @@ msgstr "Tải lại cấu hình để hiển thị lại thông báo này"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
+#: src/apprt/gtk/class/application.zig:2031
 msgid "Cancel"
 msgstr "Hủy"
 
@@ -241,7 +242,7 @@ msgstr "Bảng lệnh"
 msgid "Terminal Inspector"
 msgstr "Bộ kiểm tra Terminal"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1888
 msgid "About Ghostty"
 msgstr "Về Ghostty"
 
@@ -253,16 +254,24 @@ msgstr "Thoát"
 msgid "Execute a command…"
 msgstr "Chạy một lệnh…"
 
-#: src/apprt/gtk/class/application.zig:1708
+#: src/apprt/gtk/class/application.zig:1713
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1710
+#: src/apprt/gtk/class/application.zig:1715
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1721
+#: src/apprt/gtk/class/application.zig:1726
 msgid "Global keybind unavailable"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2027
+msgid "Export Terminal IO Events"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2030
+msgid "Export"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -357,14 +366,14 @@ msgstr "Đổi tiêu đề Tab"
 msgid "Reloaded the configuration"
 msgstr "Đã tải lại cấu hình"
 
-#: src/apprt/gtk/class/window.zig:1705
+#: src/apprt/gtk/class/window.zig:1727
 msgid "Copied to clipboard"
 msgstr "Đã sao chép vào bảng tạm"
 
-#: src/apprt/gtk/class/window.zig:1707
+#: src/apprt/gtk/class/window.zig:1729
 msgid "Cleared clipboard"
 msgstr "Đã xóa sạch bảng tạm"
 
-#: src/apprt/gtk/class/window.zig:1847
+#: src/apprt/gtk/class/window.zig:1869
 msgid "Ghostty Developers"
 msgstr "Các nhà phát triển Ghostty"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-07-26 04:59+0200\n"
+"POT-Creation-Date: 2026-07-30 18:07+0200\n"
 "PO-Revision-Date: 2026-02-12 01:56+0800\n"
 "Last-Translator: Leah <hi@pluie.me>\n"
 "Language-Team: Chinese (simplified) <i18n-zh@googlegroups.com>\n"
@@ -49,6 +49,7 @@ msgstr "本提示将在重载配置后再次出现"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
+#: src/apprt/gtk/class/application.zig:2031
 msgid "Cancel"
 msgstr "取消"
 
@@ -239,7 +240,7 @@ msgstr "命令面板"
 msgid "Terminal Inspector"
 msgstr "终端调试器"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1888
 msgid "About Ghostty"
 msgstr "关于 Ghostty"
 
@@ -251,16 +252,24 @@ msgstr "退出"
 msgid "Execute a command…"
 msgstr "选择要执行的命令…"
 
-#: src/apprt/gtk/class/application.zig:1708
+#: src/apprt/gtk/class/application.zig:1713
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1710
+#: src/apprt/gtk/class/application.zig:1715
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1721
+#: src/apprt/gtk/class/application.zig:1726
 msgid "Global keybind unavailable"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2027
+msgid "Export Terminal IO Events"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2030
+msgid "Export"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -349,14 +358,14 @@ msgstr "更改标签页标题"
 msgid "Reloaded the configuration"
 msgstr "已重新加载配置"
 
-#: src/apprt/gtk/class/window.zig:1705
+#: src/apprt/gtk/class/window.zig:1727
 msgid "Copied to clipboard"
 msgstr "已复制至剪贴板"
 
-#: src/apprt/gtk/class/window.zig:1707
+#: src/apprt/gtk/class/window.zig:1729
 msgid "Cleared clipboard"
 msgstr "已清空剪贴板"
 
-#: src/apprt/gtk/class/window.zig:1847
+#: src/apprt/gtk/class/window.zig:1869
 msgid "Ghostty Developers"
 msgstr "Ghostty 开发团队"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-07-26 04:59+0200\n"
+"POT-Creation-Date: 2026-07-30 18:07+0200\n"
 "PO-Revision-Date: 2026-02-18 13:58+0800\n"
 "Last-Translator: Yi-Jyun Pan <me@pan93.com>\n"
 "Language-Team: Chinese (traditional)\n"
@@ -48,6 +48,7 @@ msgstr "重新載入設定以再次顯示此提示"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
+#: src/apprt/gtk/class/application.zig:2031
 msgid "Cancel"
 msgstr "取消"
 
@@ -237,7 +238,7 @@ msgstr "命令面板"
 msgid "Terminal Inspector"
 msgstr "終端機檢查工具"
 
-#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1866
+#: src/apprt/gtk/ui/1.5/window.blp:307 src/apprt/gtk/class/window.zig:1888
 msgid "About Ghostty"
 msgstr "關於 Ghostty"
 
@@ -249,16 +250,24 @@ msgstr "結束"
 msgid "Execute a command…"
 msgstr "執行命令…"
 
-#: src/apprt/gtk/class/application.zig:1708
+#: src/apprt/gtk/class/application.zig:1713
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1710
+#: src/apprt/gtk/class/application.zig:1715
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1721
+#: src/apprt/gtk/class/application.zig:1726
 msgid "Global keybind unavailable"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2027
+msgid "Export Terminal IO Events"
+msgstr ""
+
+#: src/apprt/gtk/class/application.zig:2030
+msgid "Export"
 msgstr ""
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
@@ -347,14 +356,14 @@ msgstr "變更分頁標題"
 msgid "Reloaded the configuration"
 msgstr "已重新載入設定"
 
-#: src/apprt/gtk/class/window.zig:1705
+#: src/apprt/gtk/class/window.zig:1727
 msgid "Copied to clipboard"
 msgstr "已複製到剪貼簿"
 
-#: src/apprt/gtk/class/window.zig:1707
+#: src/apprt/gtk/class/window.zig:1729
 msgid "Cleared clipboard"
 msgstr "已清除剪貼簿"
 
-#: src/apprt/gtk/class/window.zig:1847
+#: src/apprt/gtk/class/window.zig:1869
 msgid "Ghostty Developers"
 msgstr "Ghostty 開發者"

--- a/src/apprt/action.zig
+++ b/src/apprt/action.zig
@@ -196,6 +196,9 @@ pub const Action = union(Key) {
     /// rendered at the next opportunity.
     render_inspector,
 
+    /// Export the Terminal IO inspector event log.
+    export_terminal_io: ExportTerminalIO,
+
     /// Show a desktop notification.
     desktop_notification: DesktopNotification,
 
@@ -381,6 +384,7 @@ pub const Action = union(Key) {
         inspector,
         show_gtk_inspector,
         render_inspector,
+        export_terminal_io,
         desktop_notification,
         set_title,
         set_tab_title,
@@ -609,6 +613,37 @@ pub const Inspector = enum(c_int) {
 
     test "ghostty.h Inspector" {
         try lib.checkGhosttyHEnum(Inspector, "GHOSTTY_INSPECTOR_");
+    }
+};
+
+/// Terminal IO inspector contents to export. The contents are only valid for
+/// the duration of the action callback.
+pub const ExportTerminalIO = struct {
+    contents: []const u8,
+
+    // Sync with: ghostty_action_export_terminal_io_s
+    pub const C = extern struct {
+        contents: [*]const u8,
+        len: usize,
+    };
+
+    pub fn cval(self: ExportTerminalIO) C {
+        return .{
+            .contents = self.contents.ptr,
+            .len = self.contents.len,
+        };
+    }
+
+    pub fn format(
+        value: @This(),
+        comptime _: []const u8,
+        _: std.fmt.Options,
+        writer: *std.Io.Writer,
+    ) !void {
+        try writer.print(
+            "{s}{{ contents: {d} bytes }}",
+            .{ @typeName(@This()), value.contents.len },
+        );
     }
 };
 

--- a/src/apprt/gtk/class/application.zig
+++ b/src/apprt/gtk/class/application.zig
@@ -703,6 +703,11 @@ pub const Application = extern struct {
             .initial_size => return Action.initialSize(target, value),
 
             .inspector => return Action.controlInspector(target, value),
+            .export_terminal_io => return try Action.exportTerminalIO(
+                self,
+                target,
+                value,
+            ),
 
             .key_sequence => return Action.keySequence(target, value),
             .key_table => return Action.keyTable(target, value),
@@ -1996,6 +2001,99 @@ const Action = struct {
             .surface => |v| v.rt_surface.gobj().copyTitleToClipboard(),
         };
     }
+
+    pub fn exportTerminalIO(
+        self: *Application,
+        target: apprt.Target,
+        value: apprt.Action.Value(.export_terminal_io),
+    ) Allocator.Error!bool {
+        const surface = switch (target) {
+            .app => return false,
+            .surface => |v| v.rt_surface.gobj(),
+        };
+
+        const alloc = self.allocator();
+        const contents = try alloc.dupe(u8, value.contents);
+        errdefer alloc.free(contents);
+        const request = try alloc.create(ExportTerminalIORequest);
+        errdefer alloc.destroy(request);
+        request.* = .{
+            .alloc = alloc,
+            .contents = contents,
+        };
+
+        const parent = ext.getAncestor(gtk.Window, surface.as(gtk.Widget));
+        const dialog = gtk.FileChooserNative.new(
+            i18n._("Export Terminal IO Events"),
+            parent,
+            .save,
+            i18n._("Export"),
+            i18n._("Cancel"),
+        );
+        const chooser = dialog.as(gtk.FileChooser);
+        chooser.setCreateFolders(1);
+        chooser.setCurrentName("ghostty-terminal-io.txt");
+
+        const native = dialog.as(gtk.NativeDialog);
+        _ = gtk.NativeDialog.signals.response.connect(
+            native,
+            *ExportTerminalIORequest,
+            ExportTerminalIORequest.response,
+            request,
+            .{ .destroyData = ExportTerminalIORequest.destroy },
+        );
+        native.show();
+        return true;
+    }
+
+    const ExportTerminalIORequest = struct {
+        alloc: Allocator,
+        contents: []u8,
+
+        fn destroy(self: *ExportTerminalIORequest) callconv(.c) void {
+            self.alloc.free(self.contents);
+            self.alloc.destroy(self);
+        }
+
+        fn response(
+            dialog: *gtk.NativeDialog,
+            response_id: c_int,
+            self: *ExportTerminalIORequest,
+        ) callconv(.c) void {
+            defer dialog.unref();
+
+            if (response_id != @intFromEnum(gtk.ResponseType.accept)) return;
+
+            const file = dialog.as(gtk.FileChooser).getFile() orelse {
+                log.warn("inspector export dialog returned no file", .{});
+                return;
+            };
+            defer file.unref();
+
+            var gerr: ?*glib.Error = null;
+            const replaced = file.replaceContents(
+                self.contents.ptr,
+                self.contents.len,
+                null,
+                0,
+                .{},
+                null,
+                null,
+                &gerr,
+            );
+            if (gerr) |err| {
+                defer err.free();
+                log.err(
+                    "failed to export terminal IO events err={s}",
+                    .{err.f_message orelse "(unknown)"},
+                );
+                return;
+            }
+            if (replaced == 0) {
+                log.err("failed to export terminal IO events", .{});
+            }
+        }
+    };
 
     pub fn configChange(
         self: *Application,

--- a/src/apprt/gtk/class/application.zig
+++ b/src/apprt/gtk/class/application.zig
@@ -2034,15 +2034,14 @@ const Action = struct {
         chooser.setCreateFolders(1);
         chooser.setCurrentName("ghostty-terminal-io.txt");
 
-        const native = dialog.as(gtk.NativeDialog);
         _ = gtk.NativeDialog.signals.response.connect(
-            native,
+            dialog,
             *ExportTerminalIORequest,
             ExportTerminalIORequest.response,
             request,
             .{ .destroyData = ExportTerminalIORequest.destroy },
         );
-        native.show();
+        dialog.as(gtk.NativeDialog).show();
         return true;
     }
 
@@ -2056,7 +2055,7 @@ const Action = struct {
         }
 
         fn response(
-            dialog: *gtk.NativeDialog,
+            dialog: *gtk.FileChooserNative,
             response_id: c_int,
             self: *ExportTerminalIORequest,
         ) callconv(.c) void {

--- a/src/inspector/widgets/surface.zig
+++ b/src/inspector/widgets/surface.zig
@@ -47,7 +47,7 @@ pub const Inspector = struct {
 
     pub fn draw(
         self: *Inspector,
-        surface: *const Surface,
+        surface: *Surface,
         mouse: Mouse,
     ) void {
         // Create our dockspace first. If we had to setup our dockspace,
@@ -111,7 +111,7 @@ pub const Inspector = struct {
                 defer cimgui.c.ImGui_End();
                 if (open) {
                     self.vt_stream.draw(
-                        surface.alloc,
+                        surface,
                         &t.colors.palette.current,
                     );
                 }

--- a/src/inspector/widgets/termio.zig
+++ b/src/inspector/widgets/termio.zig
@@ -7,6 +7,8 @@ const CircBuf = @import("../../datastruct/main.zig").CircBuf;
 const Surface = @import("../../Surface.zig");
 const screen = @import("screen.zig");
 
+const log = std.log.scoped(.inspector_terminal_io);
+
 /// VT event stream inspector widget.
 pub const Stream = struct {
     events: VTEvent.Ring,
@@ -59,9 +61,10 @@ pub const Stream = struct {
 
     pub fn draw(
         self: *Stream,
-        alloc: Allocator,
+        surface: *Surface,
         palette: *const terminal.color.Palette,
     ) void {
+        const alloc = surface.alloc;
         const events = &self.events;
         const handler = &self.parser_stream.handler;
         const popup_filter = "Filter";
@@ -92,6 +95,16 @@ pub const Stream = struct {
                     events.clear();
 
                     handler.current_seq = 1;
+                }
+
+                cimgui.c.ImGui_SameLineEx(0, cimgui.c.ImGui_GetStyle().*.ItemInnerSpacing.x);
+                if (cimgui.c.ImGui_Button("Copy")) {
+                    self.copyEvents(surface);
+                }
+
+                cimgui.c.ImGui_SameLineEx(0, cimgui.c.ImGui_GetStyle().*.ItemInnerSpacing.x);
+                if (cimgui.c.ImGui_Button("Export to file")) {
+                    self.exportEvents(surface);
                 }
             }
         }
@@ -329,6 +342,73 @@ pub const Stream = struct {
                 cimgui.c.ImGui_CloseCurrentPopup();
             }
         } // filter popup
+    }
+
+    /// Copy all recorded events to the standard clipboard in chronological
+    /// order.
+    fn copyEvents(
+        self: *const Stream,
+        surface: *Surface,
+    ) void {
+        const alloc = surface.alloc;
+        const contents = self.formatEvents(alloc) catch |err| {
+            log.err("failed to format terminal IO events for copy err={}", .{err});
+            return;
+        };
+        defer alloc.free(contents);
+
+        surface.rt_surface.setClipboard(.standard, &.{.{
+            .mime = "text/plain",
+            .data = contents,
+        }}, false) catch |err| {
+            log.err("failed to copy terminal IO events err={}", .{err});
+        };
+    }
+
+    /// Ask the application runtime to save all recorded events to a file.
+    fn exportEvents(
+        self: *const Stream,
+        surface: *Surface,
+    ) void {
+        const alloc = surface.alloc;
+        const contents = self.formatEvents(alloc) catch |err| {
+            log.err("failed to format terminal IO events for export err={}", .{err});
+            return;
+        };
+        defer alloc.free(contents);
+
+        const handled = surface.rt_app.performAction(
+            .{ .surface = surface },
+            .export_terminal_io,
+            .{ .contents = contents },
+        ) catch |err| {
+            log.err("failed to export terminal IO events err={}", .{err});
+            return;
+        };
+        if (!handled) {
+            log.warn("application runtime does not support exporting terminal IO events", .{});
+        }
+    }
+
+    /// Format all recorded events as tab-separated text. Events are exported
+    /// oldest-first even though the inspector displays the newest event first.
+    fn formatEvents(
+        self: *const Stream,
+        alloc: Allocator,
+    ) ![:0]u8 {
+        var buf: std.Io.Writer.Allocating = .init(alloc);
+        errdefer buf.deinit();
+
+        try buf.writer.writeAll("Seq\tKind\tDescription\n");
+        var it = self.events.iterator(.forward);
+        while (it.next()) |ev| {
+            try buf.writer.print(
+                "{d}\t{s}\t{s}\n",
+                .{ ev.seq, @tagName(ev.kind), ev.raw_description },
+            );
+        }
+
+        return try buf.toOwnedSliceSentinel(0);
     }
 };
 


### PR DESCRIPTION
Adds "Copy" and "Export to file" buttons to the Terminal IO inspector so recorded VT events can be saved outside the app for sharing or analysis.

Found myself needing/wishing for this while I was debugging my tmux fork with libghostty-vt. 


Disclaimer: I haven't considered performance at all, so please lmk if there are anything here you would like me to optimize. 