### PR TITLE
build: update iOS deployment target to 13

### DIFF
--- a/src/build/Config.zig
+++ b/src/build/Config.zig
@@ -692,9 +692,9 @@ pub fn osVersionMin(tag: std.Target.Os.Tag) ?std.Target.Query.OsVersion {
             .patch = 0,
         } },
 
-        // iOS 17 picked arbitrarily
+        // We do not have dependencies requiring newer deployment target.
         .ios => .{ .semver = .{
-            .major = 17,
+            .major = 13,
             .minor = 0,
             .patch = 0,
         } },


### PR DESCRIPTION
The core dependencies used in libghostty-vt don't require newer iOS deployment targets, so we can use the older version to maximize compatibility with consumers targeting older iOS versions.

This is primarily for convenience (the same can be achieved with `-Dtarget` build option). It establishes the baseline for future prebuilt dylibs, which must be compiled for earlier supported iOS versions by consumers.

Initially applied the build option to the [libghostty binding](https://github.com/elias8/libghostty/pull/133), but then thought the default belongs here.