### PR TITLE
macOS: fix update error pill is not showing properly

### DIFF
--- a/macos/Sources/Features/Update/UpdateDriver.swift
+++ b/macos/Sources/Features/Update/UpdateDriver.swift
@@ -95,14 +95,12 @@ class UpdateDriver: NSObject, SPUUserDriver {
                     delegate.checkForUpdates(self)
                 }
             },
-            dismiss: { [weak viewModel] in
-                viewModel?.state = .idle
+            dismiss: {
+                acknowledgement()
             }))
 
         if !hasUnobtrusiveTarget {
             standard.showUpdaterError(error, acknowledgement: acknowledgement)
-        } else {
-            acknowledgement()
         }
     }
 


### PR DESCRIPTION
`acknowledgement` will call `dismissUpdateInstallation` so the error state will never happen.