### PR TITLE
libghostty(formatter): fix superfluous newline in html formatting

### DIFF
--- a/src/terminal/formatter.zig
+++ b/src/terminal/formatter.zig
@@ -1354,6 +1354,9 @@ pub const PageFormatter = struct {
                     closing.len,
                 );
             }
+            // Closing the div creates a newline in the output
+            // so make sure to create one less newline
+            if (blank_rows >= 1) blank_rows -= 1;
         }
 
         return .{ .rows = blank_rows, .cells = blank_cells };

--- a/src/terminal/formatter.zig
+++ b/src/terminal/formatter.zig
@@ -5514,6 +5514,43 @@ test "Page html with unicode as numeric entities" {
     );
 }
 
+test "Page html trailing blank lines" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    var builder: std.Io.Writer.Allocating = .init(alloc);
+    defer builder.deinit();
+
+    var t = try Terminal.init(io, alloc, .{
+        .cols = 80,
+        .rows = 24,
+    });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+
+    s.nextSlice("hello\r\nworld\r\n\r\n");
+
+    const pages = &t.screens.active.pages;
+    try testing.expect(pages.pages.first != null);
+    try testing.expect(pages.pages.first == pages.pages.last);
+
+    const page = pages.pages.last.?.page();
+    var formatter: PageFormatter = .init(page, .{ .emit = .html });
+
+    const state = try formatter.formatWithState(&builder.writer);
+    const output = builder.writer.buffered();
+
+    // The closing div behaves as a newline
+    try testing.expectEqual(@as(usize, page.size.rows - 2), state.rows);
+    try testing.expectEqualStrings(
+        "<div style=\"font-family: monospace; white-space: pre;\">hello\nworld</div>",
+        output,
+    );
+}
+
 test "Page html ascii characters unchanged" {
     const testing = std.testing;
     const alloc = testing.allocator;


### PR DESCRIPTION
In the html formatter every page is formatted in a div. When the div closes it causes a newline in the html rendering. In order to fix this a newline is now removed whenever the div is closed (if there are any newlines waiting to be rendered - as far as I could see in my testing there was always one).

I thought of trying to add a test but could not think of a way to do so without adding a massive blob of html into the file.

Before (orange was added by me to show where the div ends):
<img width="1278" height="586" alt="image" src="https://github.com/user-attachments/assets/473ba28d-bec0-481f-9a89-a6a72c9a3657" />

After:
<img width="959" height="439" alt="image" src="https://github.com/user-attachments/assets/27bae0d3-cc82-4dc8-aa72-c4a8b0f7d424" />

No AI was used in this pr.