### PR TITLE
font/shaper: fix trailing punctuation in RTL paragraphs (rebased #11079 + regression test)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -43,9 +43,9 @@
             .hash = "uucode-0.2.0-ZZjBPqZVVABQepOqZHR7vV_NcaN-wats0IB6o-Exj6m9",
         },
         .itijah = .{
-            // DiaaEddin/itijah v0.1.8
-            .url = "https://github.com/DiaaEddin/itijah/archive/refs/tags/v0.1.8.tar.gz",
-            .hash = "itijah-0.1.8-keFZYUxOAwA1hVxPuikQIE-IXXg3yoNixfmzk8qVCrdN",
+            // DiaaEddin/itijah v0.2.0
+            .url = "https://github.com/DiaaEddin/itijah/archive/refs/tags/v0.2.0.tar.gz",
+            .hash = "itijah-0.2.0-keFZYcWLAwCOBysWA5aBhNsHhB6AtldnB4sajzJwPAtm",
             .lazy = true,
         },
         .zig_wayland = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -42,6 +42,11 @@
             .url = "https://deps.files.ghostty.org/uucode-0.2.0-ZZjBPqZVVABQepOqZHR7vV_NcaN-wats0IB6o-Exj6m9.tar.gz",
             .hash = "uucode-0.2.0-ZZjBPqZVVABQepOqZHR7vV_NcaN-wats0IB6o-Exj6m9",
         },
+        .itijah = .{
+            // DiaaEddin/itijah v0.1.7
+            .url = "https://github.com/DiaaEddin/itijah/archive/refs/tags/v0.1.7.tar.gz",
+            .hash = "itijah-0.1.3-keFZYZNNAwB3BixVaaXZxOQHDqN5frrkxGPUE90U7bOL",
+        },
         .zig_wayland = .{
             // codeberg ifreund/zig-wayland
             .url = "https://deps.files.ghostty.org/zig_wayland-1b5c038ec10da20ed3a15b0b2a6db1c21383e8ea.tar.gz",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -43,9 +43,10 @@
             .hash = "uucode-0.2.0-ZZjBPqZVVABQepOqZHR7vV_NcaN-wats0IB6o-Exj6m9",
         },
         .itijah = .{
-            // DiaaEddin/itijah v0.1.7
-            .url = "https://github.com/DiaaEddin/itijah/archive/refs/tags/v0.1.7.tar.gz",
-            .hash = "itijah-0.1.3-keFZYZNNAwB3BixVaaXZxOQHDqN5frrkxGPUE90U7bOL",
+            // DiaaEddin/itijah v0.1.8
+            .url = "https://github.com/DiaaEddin/itijah/archive/refs/tags/v0.1.8.tar.gz",
+            .hash = "itijah-0.1.8-keFZYUxOAwA1hVxPuikQIE-IXXg3yoNixfmzk8qVCrdN",
+            .lazy = true,
         },
         .zig_wayland = .{
             // codeberg ifreund/zig-wayland

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -43,9 +43,9 @@
             .hash = "uucode-0.2.0-ZZjBPqZVVABQepOqZHR7vV_NcaN-wats0IB6o-Exj6m9",
         },
         .itijah = .{
-            // DiaaEddin/itijah v0.2.0
-            .url = "https://github.com/DiaaEddin/itijah/archive/refs/tags/v0.2.0.tar.gz",
-            .hash = "itijah-0.2.0-keFZYcWLAwCOBysWA5aBhNsHhB6AtldnB4sajzJwPAtm",
+            // DiaaEddin/itijah v0.2.1
+            .url = "https://github.com/DiaaEddin/itijah/archive/refs/tags/v0.2.1.tar.gz",
+            .hash = "itijah-0.2.1-keFZYfC1AwAKbdNB2ksZYamTycTESResjOdSkE40GkLX",
             .lazy = true,
         },
         .zig_wayland = .{

--- a/src/build/GhosttyZig.zig
+++ b/src/build/GhosttyZig.zig
@@ -135,7 +135,8 @@ fn initVt(
     deps.unicode_tables.addModuleImport(vt);
 
     // We need uucode for grapheme break support
-    deps.addUucode(b, vt, cfg.target, cfg.optimize);
+    const uucode_mod = deps.addUucode(b, vt, cfg.target, cfg.optimize);
+    deps.addItijah(b, vt, cfg.target, cfg.optimize, uucode_mod);
 
     // If SIMD is enabled, add all our SIMD dependencies.
     if (cfg.simd) {

--- a/src/build/SharedDeps.zig
+++ b/src/build/SharedDeps.zig
@@ -473,7 +473,14 @@ pub fn add(
     })) |dep| {
         step.root_module.addImport("z2d", dep.module("z2d"));
     }
-    self.addUucode(b, step.root_module, target, optimize);
+    const uucode_mod = self.addUucode(b, step.root_module, target, optimize);
+    self.addItijah(
+        b,
+        step.root_module,
+        target,
+        optimize,
+        uucode_mod,
+    );
     if (b.lazyDependency("zf", .{
         .target = target,
         .optimize = optimize,
@@ -970,15 +977,38 @@ pub fn addUucode(
     module: *std.Build.Module,
     target: std.Build.ResolvedTarget,
     optimize: std.builtin.OptimizeMode,
-) void {
+) ?*std.Build.Module {
     if (b.lazyDependency("uucode", .{
         .target = target,
         .optimize = optimize,
         .tables_path = self.uucode_tables,
         .build_config_path = b.path("src/build/uucode_config.zig"),
     })) |dep| {
-        module.addImport("uucode", dep.module("uucode"));
+        const uucode_mod = dep.module("uucode");
+        module.addImport("uucode", uucode_mod);
+        return uucode_mod;
     }
+
+    return null;
+}
+
+pub fn addItijah(
+    _: *const SharedDeps,
+    b: *std.Build,
+    module: *std.Build.Module,
+    target: std.Build.ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
+    uucode_mod: ?*std.Build.Module,
+) void {
+    const uucode_ = uucode_mod orelse return;
+    const itijah_dep = b.lazyDependency("itijah", .{}) orelse return;
+    const itijah_mod = b.createModule(.{
+        .root_source_file = itijah_dep.path("src/lib.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    itijah_mod.addImport("uucode", uucode_);
+    module.addImport("itijah", itijah_mod);
 }
 
 // For dynamic linking, we prefer dynamic linking and to search by

--- a/src/build/uucode_config.zig
+++ b/src/build/uucode_config.zig
@@ -88,6 +88,10 @@ pub const tables = [_]config.Table{
         .fields = &.{
             d.field("is_emoji_presentation"),
             d.field("case_folding_full"),
+            d.field("bidi_class"),
+            d.field("bidi_paired_bracket"),
+            d.field("joining_type"),
+            d.field("is_bidi_mirrored"),
         },
     },
     .{

--- a/src/font/shaper/bidi_helpers.zig
+++ b/src/font/shaper/bidi_helpers.zig
@@ -1,7 +1,8 @@
 /// Returns true for Arabic combining marks used by the RTL shaper fallback.
 ///
-/// This is intentionally scoped to Arabic marks to avoid regressing other
-/// scripts with different mark emission behavior (e.g. Chakma/Bengali).
+/// Scoped to Arabic marks to avoid regressing other scripts with different
+/// mark emission behavior (e.g. Chakma/Bengali). Uses explicit ranges because
+/// script/general_category are not yet exposed as runtime uucode fields.
 pub fn isArabicCombiningMark(cp: u32) bool {
     return switch (cp) {
         0x0610...0x061A,

--- a/src/font/shaper/bidi_helpers.zig
+++ b/src/font/shaper/bidi_helpers.zig
@@ -1,0 +1,14 @@
+/// Returns true for Arabic combining marks used by the RTL shaper fallback.
+///
+/// This is intentionally scoped to Arabic marks to avoid regressing other
+/// scripts with different mark emission behavior (e.g. Chakma/Bengali).
+pub fn isArabicCombiningMark(cp: u32) bool {
+    return switch (cp) {
+        0x0610...0x061A,
+        0x064B...0x065F,
+        0x0670,
+        0x06D6...0x06ED,
+        => true,
+        else => false,
+    };
+}

--- a/src/font/shaper/bidi_helpers.zig
+++ b/src/font/shaper/bidi_helpers.zig
@@ -1,8 +1,11 @@
-/// Returns true for Arabic combining marks used by the RTL shaper fallback.
+/// Returns true for Arabic vowel/sign marks used by the RTL shaper fallback.
 ///
-/// Scoped to Arabic marks to avoid regressing other scripts with different
-/// mark emission behavior (e.g. Chakma/Bengali). Uses explicit ranges because
-/// script/general_category are not yet exposed as runtime uucode fields.
+/// In Arabic RTL runs, shapers can report a mark before the base glyph that
+/// owns the cell. We only apply that fallback to Arabic marks because other
+/// scripts have different mark ordering rules, and using the same fallback for
+/// every zero-width mark moves some Bengali/Chakma marks to the wrong x
+/// position. Uses explicit ranges because script/general_category are not yet
+/// exposed as runtime uucode fields.
 pub fn isArabicCombiningMark(cp: u32) bool {
     return switch (cp) {
         0x0610...0x061A,

--- a/src/font/shaper/coretext.zig
+++ b/src/font/shaper/coretext.zig
@@ -2968,6 +2968,12 @@ test "shape arabic end tashkeel no overlap" {
         try testing.expect(cell.x < run.cells);
         seen[cell.x] = true;
         if (cell.x == qaf_cluster.?) qaf_cell_glyphs += 1;
+
+        // Base glyphs after the tashkeel cluster must not carry a
+        // spurious x_offset from position.x/run_offset.x divergence.
+        if (cell.x != qaf_cluster.?) {
+            try testing.expectEqual(@as(i32, 0), cell.x_offset);
+        }
     }
     try testing.expect(seen[0]);
     try testing.expect(seen[1]);
@@ -3035,6 +3041,12 @@ test "shape arabic end tanween no overlap" {
         try testing.expect(cell.x < run.cells);
         seen[cell.x] = true;
         if (cell.x == nun_cluster.?) nun_cell_glyphs += 1;
+
+        // Base glyphs after the tanween cluster must not carry a
+        // spurious x_offset from position.x/run_offset.x divergence.
+        if (cell.x != nun_cluster.?) {
+            try testing.expectEqual(@as(i32, 0), cell.x_offset);
+        }
     }
     try testing.expect(seen[0]);
     try testing.expect(seen[1]);

--- a/src/font/shaper/coretext.zig
+++ b/src/font/shaper/coretext.zig
@@ -55,6 +55,8 @@ pub const Shaper = struct {
     /// The values in this never change so we can avoid overhead
     /// by just creating it once and saving it for reuse.
     typesetter_attr_dict: *macos.foundation.Dictionary,
+    /// Same as above but with embedding level 1 (RTL).
+    typesetter_attr_dict_rtl: *macos.foundation.Dictionary,
 
     /// List where we cache fonts, so we don't have to remake them for
     /// every single shaping operation.
@@ -172,27 +174,16 @@ pub const Shaper = struct {
         var run_state = RunState.init();
         errdefer run_state.deinit(alloc);
 
-        // For now we only support LTR text. If we shape RTL text then
-        // rendering will be very wrong so we need to explicitly force
-        // LTR no matter what.
+        // Use kCTTypesetterOptionForcedEmbeddingLevel to control BiDi
+        // embedding. We force embedding level 0 (LTR) for LTR runs and
+        // embedding level 1 (RTL) for RTL runs. Our run iterator already
+        // splits runs at direction boundaries, so each run is guaranteed
+        // to be single-direction.
         //
         // See: https://github.com/mitchellh/ghostty/issues/1737
         // See: https://github.com/mitchellh/ghostty/issues/1442
-        //
-        // We used to do this by setting the writing direction attribute
-        // on the attributed string we used, but it seems like that will
-        // still allow some weird results, for example a single space at
-        // the end of a line composed of RTL characters will be cause it
-        // to output a run containing just that space, BEFORE it outputs
-        // the rest of the line as a separate run, very weirdly with the
-        // "right to left" flag set in the single space run's run status...
-        //
-        // So instead what we do is use a CTTypesetter to create our line,
-        // using the kCTTypesetterOptionForcedEmbeddingLevel attribute to
-        // force CoreText not to try doing any sort of BiDi, instead just
-        // treat all text as embedding level 0 (left to right).
         const typesetter_attr_dict = dict: {
-            const num = try macos.foundation.Number.create(.int, &0);
+            const num = try macos.foundation.Number.create(.int, &@as(c_int, 0));
             defer num.release();
             break :dict try macos.foundation.Dictionary.create(
                 &.{macos.c.kCTTypesetterOptionForcedEmbeddingLevel},
@@ -200,6 +191,16 @@ pub const Shaper = struct {
             );
         };
         errdefer typesetter_attr_dict.release();
+
+        const typesetter_attr_dict_rtl = dict: {
+            const num = try macos.foundation.Number.create(.int, &@as(c_int, 1));
+            defer num.release();
+            break :dict try macos.foundation.Dictionary.create(
+                &.{macos.c.kCTTypesetterOptionForcedEmbeddingLevel},
+                &.{num},
+            );
+        };
+        errdefer typesetter_attr_dict_rtl.release();
 
         // Create the CF release thread.
         var cf_release_thread = try alloc.create(CFReleaseThread);
@@ -222,6 +223,7 @@ pub const Shaper = struct {
             .features = features,
             .features_no_default = features_no_default,
             .typesetter_attr_dict = typesetter_attr_dict,
+            .typesetter_attr_dict_rtl = typesetter_attr_dict_rtl,
             .cached_fonts = .{},
             .cached_font_grid = 0,
             .cf_release_pool = .{},
@@ -236,6 +238,7 @@ pub const Shaper = struct {
         self.features.release();
         self.features_no_default.release();
         self.typesetter_attr_dict.release();
+        self.typesetter_attr_dict_rtl.release();
 
         {
             for (self.cached_fonts.items) |ft| {
@@ -370,12 +373,16 @@ pub const Shaper = struct {
         );
         self.cf_release_pool.appendAssumeCapacity(attr_str);
 
-        // Create a typesetter from the attributed string and the cached
-        // attr dict. (See comment in init for more info on the attr dict.)
+        // Create a typesetter from the attributed string. Use the RTL
+        // embedding level dict for RTL runs so CoreText shapes correctly.
+        const ts_dict = if (run.rtl)
+            self.typesetter_attr_dict_rtl
+        else
+            self.typesetter_attr_dict;
         const typesetter =
             try macos.text.Typesetter.createWithAttributedStringAndOptions(
                 attr_str,
-                self.typesetter_attr_dict,
+                ts_dict,
             );
         self.cf_release_pool.appendAssumeCapacity(typesetter);
 
@@ -521,7 +528,7 @@ pub const Shaper = struct {
         }
 
         // If our buffer contains some non-ltr sections we need to sort it :/
-        if (non_ltr) {
+        if (non_ltr or run.rtl) {
             // This is EXCEPTIONALLY rare. Only happens for languages with
             // complex shaping which we don't even really support properly
             // right now, so are very unlikely to be used heavily by users
@@ -2515,6 +2522,87 @@ test "shape high plane sprite font codepoint" {
     try testing.expectEqual(null, try it.next(alloc));
 }
 
+test "shape LTR neutral RTL splits and sets direction" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var testdata = try testShaperWithFont(alloc, .arabic);
+    defer testdata.deinit();
+
+    // "Hello مرحبا" — LTR "Hello" then neutral space then RTL Arabic.
+    var t = try terminal.Terminal.init(alloc, .{ .cols = 30, .rows = 3 });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    try s.nextSlice("Hello مرحبا");
+
+    var state: terminal.RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &t);
+
+    var shaper = &testdata.shaper;
+    var it = shaper.runIterator(.{
+        .grid = testdata.grid,
+        .cells = state.row_data.get(0).cells.slice(),
+    });
+
+    var runs: [10]font.shape.TextRun = undefined;
+    var count: usize = 0;
+    while (try it.next(alloc)) |run| {
+        if (count < runs.len) runs[count] = run;
+        count += 1;
+    }
+
+    try testing.expectEqual(@as(usize, 2), count);
+    try testing.expect(!runs[0].rtl);
+    try testing.expectEqual(@as(u16, 0), runs[0].offset);
+    try testing.expect(runs[1].rtl);
+    try testing.expect(runs[1].offset > 0);
+}
+
+test "shape arabic with tashkeel at EOL" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var testdata = try testShaperWithFont(alloc, .arabic);
+    defer testdata.deinit();
+
+    var t = try terminal.Terminal.init(alloc, .{ .cols = 30, .rows = 3 });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    try s.nextSlice("مرحباً");
+
+    var state: terminal.RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &t);
+
+    var shaper = &testdata.shaper;
+    var it = shaper.runIterator(.{
+        .grid = testdata.grid,
+        .cells = state.row_data.get(0).cells.slice(),
+    });
+
+    const run = (try it.next(alloc)).?;
+    try testing.expect(run.rtl);
+    try testing.expectEqual(@as(u16, 5), run.cells);
+    const cells = try shaper.shape(run);
+    try testing.expect(cells.len > 1);
+
+    var prev_x: u16 = cells[0].x;
+    for (cells[1..]) |cell| {
+        try testing.expect(cell.x >= prev_x);
+        prev_x = cell.x;
+    }
+    for (cells) |cell| {
+        try testing.expect(cell.x < run.cells);
+    }
+
+    try testing.expectEqual(try it.next(alloc), null);
+}
+
 const TestShaper = struct {
     alloc: Allocator,
     shaper: Shaper,
@@ -2530,6 +2618,7 @@ const TestShaper = struct {
 };
 
 const TestFont = enum {
+    arabic,
     code_new_roman,
     geist_mono,
     inconsolata,
@@ -2547,6 +2636,7 @@ fn testShaperWithFont(alloc: Allocator, font_req: TestFont) !TestShaper {
     const testEmoji = font.embedded.emoji;
     const testEmojiText = font.embedded.emoji_text;
     const testFont = switch (font_req) {
+        .arabic => font.embedded.arabic,
         .code_new_roman => font.embedded.code_new_roman,
         .inconsolata => font.embedded.inconsolata,
         .geist_mono => font.embedded.geist_mono,

--- a/src/font/shaper/coretext.zig
+++ b/src/font/shaper/coretext.zig
@@ -24,6 +24,17 @@ const CFReleaseThread = os.CFReleaseThread;
 
 const log = std.log.scoped(.font_shaper);
 
+fn isArabicCombiningMark(cp: u32) bool {
+    return switch (cp) {
+        0x0610...0x061A,
+        0x064B...0x065F,
+        0x0670,
+        0x06D6...0x06ED,
+        => true,
+        else => false,
+    };
+}
+
 /// Shaper that uses CoreText.
 ///
 /// CoreText shaping differs in subtle ways from HarfBuzz so it may result
@@ -51,6 +62,10 @@ pub const Shaper = struct {
 
     /// The shared memory used for shaping results.
     cell_buf: CellBuf,
+    /// Per-cluster x anchors captured when a cluster first establishes its
+    /// cell offset. This lets out-of-order combining marks re-anchor to the
+    /// correct base cluster.
+    cluster_anchor_x: std.ArrayListUnmanaged(f64),
 
     /// Cached attributes dict for creating CTTypesetter objects.
     /// The values in this never change so we can avoid overhead
@@ -223,6 +238,7 @@ pub const Shaper = struct {
         return .{
             .alloc = alloc,
             .cell_buf = .{},
+            .cluster_anchor_x = .{},
             .run_state = run_state,
             .features = features,
             .features_no_default = features_no_default,
@@ -238,6 +254,7 @@ pub const Shaper = struct {
 
     pub fn deinit(self: *Shaper) void {
         self.cell_buf.deinit(self.alloc);
+        self.cluster_anchor_x.deinit(self.alloc);
         self.run_state.deinit(self.alloc);
         self.features.release();
         self.features_no_default.release();
@@ -401,6 +418,10 @@ pub const Shaper = struct {
 
         // This keeps track of the cell starting x and cluster.
         var cell_offset: Offset = .{};
+        const anchor_sentinel = std.math.nan(f64);
+        self.cluster_anchor_x.clearRetainingCapacity();
+        try self.cluster_anchor_x.ensureUnusedCapacity(self.alloc, run.cells);
+        self.cluster_anchor_x.appendNTimesAssumeCapacity(anchor_sentinel, run.cells);
 
         // For debugging positions, turn this on:
         //var run_offset_y: f64 = 0.0;
@@ -448,6 +469,9 @@ pub const Shaper = struct {
                 // Our cluster is also our cell X position. If the cluster changes
                 // then we need to reset our current cell offsets.
                 const cluster = state.codepoints.items[index].cluster;
+                const source_codepoint = state.codepoints.items[index].codepoint;
+                const is_combining_mark = source_codepoint != 0 and
+                    unicode.table.get(@intCast(source_codepoint)).width_zero_in_grapheme;
                 if (cell_offset.cluster != cluster) {
                     // We previously asserted that the new cluster is greater
                     // than cell_offset.cluster, but this isn't always true.
@@ -497,16 +521,63 @@ pub const Shaper = struct {
                     // exceptions to this heuristic for detecting ligatures,
                     // but using the logging below seems to show it works
                     // well.)
-                    if (is_first_codepoint_in_cluster and
-                        !is_after_glyph_from_current_or_next_clusters)
-                    {
-                        cell_offset = .{
-                            .cluster = cluster,
-                            .x = run_offset.x,
-                        };
+                    if (is_first_codepoint_in_cluster) {
+                        const should_reset = (run.rtl and !is_combining_mark) or
+                            !is_after_glyph_from_current_or_next_clusters;
+                        if (should_reset) {
+                            cell_offset = .{
+                                .cluster = cluster,
+                                .x = run_offset.x,
+                            };
 
-                        // For debugging positions, turn this on:
-                        //cell_offset_y = run_offset_y;
+                            const cluster_i: usize = @intCast(cluster);
+                            if (cluster_i < self.cluster_anchor_x.items.len) {
+                                self.cluster_anchor_x.items[cluster_i] = run_offset.x;
+                            }
+                        }
+                    } else if (!run.rtl and !is_combining_mark) {
+                        // In LTR scripts, a cluster's first codepoint can be
+                        // absent from the glyph stream (due to ligature
+                        // composition). If this is the first glyph we see for
+                        // that cluster, establish an anchor now.
+                        const cluster_i: usize = @intCast(cluster);
+                        if (cluster_i < self.cluster_anchor_x.items.len and
+                            std.math.isNan(self.cluster_anchor_x.items[cluster_i]))
+                        {
+                            cell_offset = .{
+                                .cluster = cluster,
+                                .x = run_offset.x,
+                            };
+                            self.cluster_anchor_x.items[cluster_i] = run_offset.x;
+                        }
+                    } else if (run.rtl and is_combining_mark) {
+                        const cluster_i: usize = @intCast(cluster);
+                        if (cluster_i < self.cluster_anchor_x.items.len) {
+                            const anchor_x = self.cluster_anchor_x.items[cluster_i];
+                            // Keep this scoped to Arabic RTL marks only:
+                            // broadening this fallback regresses scripts with
+                            // out-of-order vowels/marks (e.g.
+                            // Chakma/Bengali tests).
+                            const allow_non_first_fallback = run.rtl and
+                                isArabicCombiningMark(source_codepoint);
+                            if (!std.math.isNan(anchor_x)) {
+                                cell_offset = .{
+                                    .cluster = cluster,
+                                    .x = anchor_x,
+                                };
+                            } else if (allow_non_first_fallback) {
+                                // A non-first combining mark can still be
+                                // emitted before its base glyph in visual
+                                // stream order. If we don't have a prior
+                                // anchor yet, establish one at the current
+                                // run offset.
+                                cell_offset = .{
+                                    .cluster = cluster,
+                                    .x = run_offset.x,
+                                };
+                                self.cluster_anchor_x.items[cluster_i] = run_offset.x;
+                            }
+                        }
                     }
                 }
 
@@ -1838,13 +1909,8 @@ test "shape Chakma vowel sign with ligature (vowel sign renders first)" {
         const cells = try shaper.shape(run);
         try testing.expectEqual(@as(usize, 4), cells.len);
         try testing.expectEqual(@as(u16, 0), cells[0].x);
-        // See the giant "We need to reset the `cell_offset`" comment, but here
-        // we should technically have the rest of these be `x` of 1, but that
-        // would require going back in the stream to adjust past cells, and
-        // we don't take on that complexity.
-        try testing.expectEqual(@as(u16, 0), cells[1].x);
-        try testing.expectEqual(@as(u16, 0), cells[2].x);
-        try testing.expectEqual(@as(u16, 0), cells[3].x);
+        for (cells) |cell| try testing.expect(cell.x < run.cells);
+        for (cells[1..], 0..) |cell, i| try testing.expect(cell.x >= cells[i].x);
 
         // The vowel sign U renders before the TAA:
         try testing.expect(cells[1].x_offset < cells[2].x_offset);
@@ -1908,23 +1974,143 @@ test "shape Bengali ligatures with out of order vowels" {
 
         const cells = try shaper.shape(run);
         try testing.expectEqual(@as(usize, 8), cells.len);
-        try testing.expectEqual(@as(u16, 0), cells[0].x);
-        try testing.expectEqual(@as(u16, 0), cells[1].x);
-        // See the giant "We need to reset the `cell_offset`" comment, but here
-        // we should technically have the rest of these be `x` of 2, but that
-        // would require going back in the stream to adjust past cells, and
-        // we don't take on that complexity.
-        try testing.expectEqual(@as(u16, 0), cells[2].x);
-        try testing.expectEqual(@as(u16, 0), cells[3].x);
-        try testing.expectEqual(@as(u16, 0), cells[4].x);
-        try testing.expectEqual(@as(u16, 0), cells[5].x);
-        try testing.expectEqual(@as(u16, 0), cells[6].x);
-        try testing.expectEqual(@as(u16, 0), cells[7].x);
+        for (cells) |cell| try testing.expect(cell.x < run.cells);
+        for (cells[1..], 0..) |cell, i| try testing.expect(cell.x >= cells[i].x);
+
+        var distinct: usize = 1;
+        var prev_x = cells[0].x;
+        for (cells[1..]) |cell| {
+            if (cell.x != prev_x) {
+                distinct += 1;
+                prev_x = cell.x;
+            }
+        }
+        try testing.expect(distinct >= 2);
 
         // The vowel sign E renders before the SSA:
         try testing.expect(cells[2].x_offset < cells[3].x_offset);
     }
     try testing.expectEqual(@as(usize, 1), count);
+}
+
+test "shape Bengali sentence keeps base clusters anchored" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var testdata = testShaperWithDiscoveredFont(
+        alloc,
+        "Arial Unicode MS",
+    ) catch return error.SkipZigTest;
+    defer testdata.deinit();
+
+    var t = try terminal.Terminal.init(alloc, .{ .cols = 200, .rows = 3 });
+    defer t.deinit(alloc);
+
+    t.modes.set(.grapheme_cluster, true);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    try s.nextSlice("পছন্দের ভাষা টাইপ করা আরো সহজ করে তোলে৷ আরো জানুন");
+
+    var state: terminal.RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &t);
+
+    var shaper = &testdata.shaper;
+    var it = shaper.runIterator(.{
+        .grid = testdata.grid,
+        .cells = state.row_data.get(0).cells.slice(),
+    });
+
+    var saw_run = false;
+    while (try it.next(alloc)) |run| {
+        saw_run = true;
+
+        var expected = try alloc.alloc(bool, run.cells);
+        defer alloc.free(expected);
+        @memset(expected, false);
+
+        for (shaper.run_state.codepoints.items) |entry| {
+            if (entry.codepoint == 0) continue;
+            if (unicode.table.get(@intCast(entry.codepoint)).width_zero_in_grapheme) continue;
+            const cluster_i: usize = @intCast(entry.cluster);
+            if (cluster_i < expected.len) expected[cluster_i] = true;
+        }
+
+        const cells = try shaper.shape(run);
+        var actual = try alloc.alloc(bool, run.cells);
+        defer alloc.free(actual);
+        @memset(actual, false);
+
+        for (cells) |cell| {
+            if (cell.x < actual.len) actual[cell.x] = true;
+        }
+        for (expected, 0..) |need, i| {
+            if (need) try testing.expect(actual[i]);
+        }
+    }
+    try testing.expect(saw_run);
+}
+
+test "shape Bengali sentence in mixed-direction line keeps base clusters anchored" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var testdata = testShaperWithDiscoveredFont(
+        alloc,
+        "Arial Unicode MS",
+    ) catch return error.SkipZigTest;
+    defer testdata.deinit();
+
+    var t = try terminal.Terminal.init(alloc, .{ .cols = 220, .rows = 3 });
+    defer t.deinit(alloc);
+
+    t.modes.set(.grapheme_cluster, true);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    try s.nextSlice("ABC পছন্দের ভাষা টাইপ করা আরো সহজ করে তোলে৷ আরো জানুন مرحبا");
+
+    var state: terminal.RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &t);
+
+    var shaper = &testdata.shaper;
+    var it = shaper.runIterator(.{
+        .grid = testdata.grid,
+        .cells = state.row_data.get(0).cells.slice(),
+    });
+
+    var saw_bengali = false;
+    while (try it.next(alloc)) |run| {
+        var expected = try alloc.alloc(bool, run.cells);
+        defer alloc.free(expected);
+        @memset(expected, false);
+
+        var has_bengali = false;
+        for (shaper.run_state.codepoints.items) |entry| {
+            if (entry.codepoint == 0) continue;
+            if (entry.codepoint >= 0x0980 and entry.codepoint <= 0x09FF) has_bengali = true;
+            if (unicode.table.get(@intCast(entry.codepoint)).width_zero_in_grapheme) continue;
+            const cluster_i: usize = @intCast(entry.cluster);
+            if (cluster_i < expected.len) expected[cluster_i] = true;
+        }
+        if (!has_bengali) continue;
+        saw_bengali = true;
+
+        const cells = try shaper.shape(run);
+        var actual = try alloc.alloc(bool, run.cells);
+        defer alloc.free(actual);
+        @memset(actual, false);
+
+        for (cells) |cell| {
+            if (cell.x < actual.len) actual[cell.x] = true;
+        }
+        for (expected, 0..) |need, i| {
+            if (need) try testing.expect(actual[i]);
+        }
+    }
+    try testing.expect(saw_bengali);
 }
 
 test "shape box glyphs" {
@@ -2610,6 +2796,99 @@ test "shape arabic with tashkeel at EOL" {
     }
 
     try testing.expectEqual(try it.next(alloc), null);
+}
+
+test "shape arabic with tashkeel on middle letters" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var testdata = try testShaperWithFont(alloc, .arabic);
+    defer testdata.deinit();
+
+    var t = try terminal.Terminal.init(alloc, .{ .cols = 30, .rows = 3 });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    try s.nextSlice("وفُكَّ");
+
+    var state: terminal.RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &t);
+
+    var shaper = &testdata.shaper;
+    var it = shaper.runIterator(.{
+        .grid = testdata.grid,
+        .cells = state.row_data.get(0).cells.slice(),
+    });
+
+    const run = (try it.next(alloc)).?;
+    try testing.expect(run.rtl);
+    try testing.expectEqual(@as(u16, 3), run.cells);
+
+    const cells = try shaper.shape(run);
+    try testing.expect(cells.len > 0);
+
+    var seen = [_]bool{ false, false, false };
+    for (cells) |cell| {
+        try testing.expect(cell.x < run.cells);
+        seen[cell.x] = true;
+    }
+    try testing.expect(seen[0]);
+    try testing.expect(seen[1]);
+    try testing.expect(seen[2]);
+
+    try testing.expectEqual(@as(?font.shape.TextRun, null), try it.next(alloc));
+}
+
+test "shape arabic tanween stays on hamza before space" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var testdata = try testShaperWithFont(alloc, .arabic);
+    defer testdata.deinit();
+
+    var t = try terminal.Terminal.init(alloc, .{ .cols = 30, .rows = 3 });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    try s.nextSlice("شيءٍ جميل");
+
+    var state: terminal.RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &t);
+
+    var shaper = &testdata.shaper;
+    var it = shaper.runIterator(.{
+        .grid = testdata.grid,
+        .cells = state.row_data.get(0).cells.slice(),
+    });
+
+    const run = (try it.next(alloc)).?;
+    try testing.expect(run.rtl);
+    try testing.expectEqual(@as(u16, 8), run.cells);
+
+    var hamza_cluster: ?u32 = null;
+    var tanween_cluster: ?u32 = null;
+    for (shaper.run_state.codepoints.items) |entry| {
+        if (entry.codepoint == 0x0621 and hamza_cluster == null) hamza_cluster = entry.cluster;
+        if (entry.codepoint == 0x064D and tanween_cluster == null) tanween_cluster = entry.cluster;
+    }
+    try testing.expect(hamza_cluster != null);
+    try testing.expect(tanween_cluster != null);
+    try testing.expectEqual(hamza_cluster.?, tanween_cluster.?);
+
+    const cells = try shaper.shape(run);
+    try testing.expect(cells.len > 0);
+
+    var hamza_cell_glyphs: usize = 0;
+    for (cells) |cell| {
+        if (cell.x == hamza_cluster.?) hamza_cell_glyphs += 1;
+    }
+    try testing.expect(hamza_cell_glyphs >= 2);
+
+    try testing.expectEqual(@as(?font.shape.TextRun, null), try it.next(alloc));
 }
 
 const TestShaper = struct {

--- a/src/font/shaper/coretext.zig
+++ b/src/font/shaper/coretext.zig
@@ -2771,6 +2771,50 @@ test "shape LTR neutral RTL splits and sets direction" {
     try testing.expect(runs[1].offset > 0);
 }
 
+test "shape hebrew RTL" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var testdata = try testShaperWithFont(alloc, .julia_mono);
+    defer testdata.deinit();
+
+    var t = try terminal.Terminal.init(alloc, .{ .cols = 30, .rows = 3 });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    try s.nextSlice("שלום עולם");
+
+    var state: terminal.RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &t);
+
+    var shaper = &testdata.shaper;
+    var it = shaper.runIterator(.{
+        .grid = testdata.grid,
+        .cells = state.row_data.get(0).cells.slice(),
+    });
+
+    var count: usize = 0;
+    while (try it.next(alloc)) |run| {
+        count += 1;
+        try testing.expect(run.rtl);
+        try testing.expectEqual(@as(u16, 9), run.cells);
+
+        const cells = try shaper.shape(run);
+        try testing.expect(cells.len > 1);
+
+        var x: u16 = cells[0].x;
+        try testing.expect(x < run.cells);
+        for (cells[1..]) |cell| {
+            try testing.expect(cell.x < run.cells);
+            try testing.expect(cell.x >= x);
+            x = cell.x;
+        }
+    }
+    try testing.expectEqual(@as(usize, 1), count);
+}
+
 test "shape arabic with tashkeel at EOL" {
     const testing = std.testing;
     const alloc = testing.allocator;
@@ -3152,6 +3196,7 @@ const TestFont = enum {
     geist_mono,
     inconsolata,
     jetbrains_mono,
+    julia_mono,
     monaspace_neon,
     nerd_font,
 };
@@ -3170,6 +3215,7 @@ fn testShaperWithFont(alloc: Allocator, font_req: TestFont) !TestShaper {
         .inconsolata => font.embedded.inconsolata,
         .geist_mono => font.embedded.geist_mono,
         .jetbrains_mono => font.embedded.jetbrains_mono,
+        .julia_mono => font.embedded.julia_mono,
         .monaspace_neon => font.embedded.monaspace_neon,
         .nerd_font => font.embedded.test_nerd_font,
     };

--- a/src/font/shaper/coretext.zig
+++ b/src/font/shaper/coretext.zig
@@ -4,6 +4,7 @@ const assert = @import("../../quirks.zig").inlineAssert;
 const Allocator = std.mem.Allocator;
 const macos = @import("macos");
 const itijah = @import("itijah");
+const bidi_helpers = @import("bidi_helpers.zig");
 const font = @import("../main.zig");
 const os = @import("../../os/main.zig");
 const terminal = @import("../../terminal/main.zig");
@@ -23,17 +24,6 @@ const Presentation = font.Presentation;
 const CFReleaseThread = os.CFReleaseThread;
 
 const log = std.log.scoped(.font_shaper);
-
-fn isArabicCombiningMark(cp: u32) bool {
-    return switch (cp) {
-        0x0610...0x061A,
-        0x064B...0x065F,
-        0x0670,
-        0x06D6...0x06ED,
-        => true,
-        else => false,
-    };
-}
 
 /// Shaper that uses CoreText.
 ///
@@ -525,14 +515,15 @@ pub const Shaper = struct {
                         const should_reset = (run.rtl and !is_combining_mark) or
                             !is_after_glyph_from_current_or_next_clusters;
                         if (should_reset) {
+                            const reset_x = if (run.rtl) position.x else run_offset.x;
                             cell_offset = .{
                                 .cluster = cluster,
-                                .x = run_offset.x,
+                                .x = reset_x,
                             };
 
                             const cluster_i: usize = @intCast(cluster);
                             if (cluster_i < self.cluster_anchor_x.items.len) {
-                                self.cluster_anchor_x.items[cluster_i] = run_offset.x;
+                                self.cluster_anchor_x.items[cluster_i] = reset_x;
                             }
                         }
                     } else if (!run.rtl and !is_combining_mark) {
@@ -558,8 +549,8 @@ pub const Shaper = struct {
                             // broadening this fallback regresses scripts with
                             // out-of-order vowels/marks (e.g.
                             // Chakma/Bengali tests).
-                            const allow_non_first_fallback = run.rtl and
-                                isArabicCombiningMark(source_codepoint);
+                            const allow_non_first_fallback =
+                                bidi_helpers.isArabicCombiningMark(source_codepoint);
                             if (!std.math.isNan(anchor_x)) {
                                 cell_offset = .{
                                     .cluster = cluster,
@@ -573,10 +564,34 @@ pub const Shaper = struct {
                                 // run offset.
                                 cell_offset = .{
                                     .cluster = cluster,
-                                    .x = run_offset.x,
+                                    .x = position.x,
                                 };
-                                self.cluster_anchor_x.items[cluster_i] = run_offset.x;
+                                self.cluster_anchor_x.items[cluster_i] = position.x;
                             }
+                        }
+                    }
+                } else if (run.rtl and source_codepoint != 0 and !is_combining_mark) {
+                    const is_first_codepoint_in_cluster = blk: {
+                        var i = index;
+                        while (i > 0) {
+                            i -= 1;
+                            const codepoint = state.codepoints.items[i];
+
+                            // Skip surrogate pair padding
+                            if (codepoint.codepoint == 0) continue;
+                            break :blk codepoint.cluster != cluster;
+                        } else break :blk true;
+                    };
+
+                    // In RTL runs, a combining mark can establish a cluster
+                    // anchor before the base glyph arrives. Re-anchor to the
+                    // base glyph position once the first logical codepoint in
+                    // the cluster is seen.
+                    if (is_first_codepoint_in_cluster) {
+                        const cluster_i: usize = @intCast(cluster);
+                        cell_offset.x = position.x;
+                        if (cluster_i < self.cluster_anchor_x.items.len) {
+                            self.cluster_anchor_x.items[cluster_i] = position.x;
                         }
                     }
                 }
@@ -2887,6 +2902,220 @@ test "shape arabic tanween stays on hamza before space" {
         if (cell.x == hamza_cluster.?) hamza_cell_glyphs += 1;
     }
     try testing.expect(hamza_cell_glyphs >= 2);
+
+    try testing.expectEqual(@as(?font.shape.TextRun, null), try it.next(alloc));
+}
+
+test "shape arabic end tashkeel no overlap" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var testdata = try testShaperWithFont(alloc, .arabic);
+    defer testdata.deinit();
+
+    var t = try terminal.Terminal.init(alloc, .{ .cols = 30, .rows = 3 });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    try s.nextSlice("بحقِّ");
+
+    var state: terminal.RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &t);
+
+    var shaper = &testdata.shaper;
+    var it = shaper.runIterator(.{
+        .grid = testdata.grid,
+        .cells = state.row_data.get(0).cells.slice(),
+    });
+
+    const run = (try it.next(alloc)).?;
+    try testing.expect(run.rtl);
+    try testing.expectEqual(@as(u16, 3), run.cells);
+
+    var qaf_cluster: ?u32 = null;
+    var kasra_cluster: ?u32 = null;
+    var shadda_cluster: ?u32 = null;
+    var ha_cluster: ?u32 = null;
+    for (shaper.run_state.codepoints.items) |entry| {
+        if (entry.codepoint == 0) continue;
+        if (entry.codepoint == 0x0642 and qaf_cluster == null) qaf_cluster = entry.cluster;
+        if (entry.codepoint == 0x0650 and kasra_cluster == null) kasra_cluster = entry.cluster;
+        if (entry.codepoint == 0x0651 and shadda_cluster == null) shadda_cluster = entry.cluster;
+        if (entry.codepoint == 0x062D and ha_cluster == null) ha_cluster = entry.cluster;
+    }
+    try testing.expect(qaf_cluster != null);
+    try testing.expect(kasra_cluster != null);
+    try testing.expect(shadda_cluster != null);
+    try testing.expect(ha_cluster != null);
+    try testing.expectEqual(qaf_cluster.?, kasra_cluster.?);
+    try testing.expectEqual(qaf_cluster.?, shadda_cluster.?);
+    try testing.expect(qaf_cluster.? != ha_cluster.?);
+
+    const cells = try shaper.shape(run);
+    try testing.expect(cells.len > 0);
+
+    var prev_x: u16 = cells[0].x;
+    for (cells[1..]) |cell| {
+        try testing.expect(cell.x >= prev_x);
+        prev_x = cell.x;
+    }
+
+    var seen = [_]bool{ false, false, false };
+    var qaf_cell_glyphs: usize = 0;
+    for (cells) |cell| {
+        try testing.expect(cell.x < run.cells);
+        seen[cell.x] = true;
+        if (cell.x == qaf_cluster.?) qaf_cell_glyphs += 1;
+    }
+    try testing.expect(seen[0]);
+    try testing.expect(seen[1]);
+    try testing.expect(seen[2]);
+    try testing.expect(qaf_cell_glyphs >= 2);
+
+    try testing.expectEqual(@as(?font.shape.TextRun, null), try it.next(alloc));
+}
+
+test "shape arabic end tanween no overlap" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var testdata = try testShaperWithFont(alloc, .arabic);
+    defer testdata.deinit();
+
+    var t = try terminal.Terminal.init(alloc, .{ .cols = 30, .rows = 3 });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    try s.nextSlice("عينٍ");
+
+    var state: terminal.RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &t);
+
+    var shaper = &testdata.shaper;
+    var it = shaper.runIterator(.{
+        .grid = testdata.grid,
+        .cells = state.row_data.get(0).cells.slice(),
+    });
+
+    const run = (try it.next(alloc)).?;
+    try testing.expect(run.rtl);
+    try testing.expectEqual(@as(u16, 3), run.cells);
+
+    var nun_cluster: ?u32 = null;
+    var tanween_cluster: ?u32 = null;
+    var ya_cluster: ?u32 = null;
+    for (shaper.run_state.codepoints.items) |entry| {
+        if (entry.codepoint == 0) continue;
+        if (entry.codepoint == 0x0646 and nun_cluster == null) nun_cluster = entry.cluster;
+        if (entry.codepoint == 0x064D and tanween_cluster == null) tanween_cluster = entry.cluster;
+        if (entry.codepoint == 0x064A and ya_cluster == null) ya_cluster = entry.cluster;
+    }
+    try testing.expect(nun_cluster != null);
+    try testing.expect(tanween_cluster != null);
+    try testing.expect(ya_cluster != null);
+    try testing.expectEqual(nun_cluster.?, tanween_cluster.?);
+    try testing.expect(nun_cluster.? != ya_cluster.?);
+
+    const cells = try shaper.shape(run);
+    try testing.expect(cells.len > 0);
+
+    var prev_x: u16 = cells[0].x;
+    for (cells[1..]) |cell| {
+        try testing.expect(cell.x >= prev_x);
+        prev_x = cell.x;
+    }
+
+    var seen = [_]bool{ false, false, false };
+    var nun_cell_glyphs: usize = 0;
+    for (cells) |cell| {
+        try testing.expect(cell.x < run.cells);
+        seen[cell.x] = true;
+        if (cell.x == nun_cluster.?) nun_cell_glyphs += 1;
+    }
+    try testing.expect(seen[0]);
+    try testing.expect(seen[1]);
+    try testing.expect(seen[2]);
+    try testing.expect(nun_cell_glyphs >= 2);
+
+    try testing.expectEqual(@as(?font.shape.TextRun, null), try it.next(alloc));
+}
+
+test "shape arabic multiword end tashkeel stays anchored" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var testdata = try testShaperWithFont(alloc, .arabic);
+    defer testdata.deinit();
+
+    var t = try terminal.Terminal.init(alloc, .{ .cols = 30, .rows = 3 });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    try s.nextSlice("الحيِّ الذي");
+
+    var state: terminal.RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &t);
+
+    var shaper = &testdata.shaper;
+    var it = shaper.runIterator(.{
+        .grid = testdata.grid,
+        .cells = state.row_data.get(0).cells.slice(),
+    });
+
+    const run = (try it.next(alloc)).?;
+    try testing.expect(run.rtl);
+
+    var kasra_cluster: ?u32 = null;
+    var shadda_cluster: ?u32 = null;
+    for (shaper.run_state.codepoints.items) |entry| {
+        if (entry.codepoint == 0) continue;
+        if (entry.codepoint == 0x0650 and kasra_cluster == null) kasra_cluster = entry.cluster;
+        if (entry.codepoint == 0x0651 and shadda_cluster == null) shadda_cluster = entry.cluster;
+    }
+    try testing.expect(kasra_cluster != null);
+    try testing.expect(shadda_cluster != null);
+    try testing.expectEqual(kasra_cluster.?, shadda_cluster.?);
+    const ya_cluster = kasra_cluster.?;
+
+    var ha_cluster: ?u32 = null;
+    for (shaper.run_state.codepoints.items) |entry| {
+        if (entry.codepoint == 0) continue;
+        if (entry.codepoint == 0x062D and ha_cluster == null) ha_cluster = entry.cluster;
+    }
+    try testing.expect(ha_cluster != null);
+    try testing.expect(ha_cluster.? != ya_cluster);
+
+    const cells = try shaper.shape(run);
+    try testing.expect(cells.len > 0);
+
+    var prev_x: u16 = cells[0].x;
+    var saw_ha = false;
+    var saw_ya = false;
+    var ya_base_near_zero = false;
+    for (cells) |cell| {
+        try testing.expect(cell.x < run.cells);
+        try testing.expect(cell.x >= prev_x);
+        prev_x = cell.x;
+
+        const xoff: i32 = cell.x_offset;
+        try testing.expect(@abs(xoff) < 200);
+        if (cell.x == ha_cluster.?) saw_ha = true;
+        if (cell.x == ya_cluster) {
+            saw_ya = true;
+            if (@abs(xoff) <= 5 and @abs(@as(i32, cell.y_offset)) <= 5) {
+                ya_base_near_zero = true;
+            }
+        }
+    }
+    try testing.expect(saw_ha);
+    try testing.expect(saw_ya);
+    try testing.expect(ya_base_near_zero);
 
     try testing.expectEqual(@as(?font.shape.TextRun, null), try it.next(alloc));
 }

--- a/src/font/shaper/coretext.zig
+++ b/src/font/shaper/coretext.zig
@@ -3,6 +3,7 @@ const builtin = @import("builtin");
 const assert = @import("../../quirks.zig").inlineAssert;
 const Allocator = std.mem.Allocator;
 const macos = @import("macos");
+const itijah = @import("itijah");
 const font = @import("../main.zig");
 const os = @import("../../os/main.zig");
 const terminal = @import("../../terminal/main.zig");
@@ -79,6 +80,9 @@ pub const Shaper = struct {
     /// callback logic.
     cf_release_thread: *CFReleaseThread,
     cf_release_thr: std.Thread,
+
+    /// Scratch reused for terminal bidi layout resolution.
+    bidi_layout_scratch: itijah.VisualLayoutScratch = .{},
 
     const CellBuf = std.ArrayListUnmanaged(font.shape.Cell);
     const CodepointList = std.ArrayListUnmanaged(Codepoint);
@@ -239,6 +243,7 @@ pub const Shaper = struct {
         self.features_no_default.release();
         self.typesetter_attr_dict.release();
         self.typesetter_attr_dict_rtl.release();
+        self.bidi_layout_scratch.deinit(self.alloc);
 
         {
             for (self.cached_fonts.items) |ft| {
@@ -690,6 +695,10 @@ pub const Shaper = struct {
 
         pub fn finalize(self: RunIteratorHook) void {
             _ = self;
+        }
+
+        pub fn bidiLayoutScratch(self: RunIteratorHook) *itijah.VisualLayoutScratch {
+            return &self.shaper.bidi_layout_scratch;
         }
     };
 

--- a/src/font/shaper/coretext.zig
+++ b/src/font/shaper/coretext.zig
@@ -184,10 +184,14 @@ pub const Shaper = struct {
         errdefer run_state.deinit(alloc);
 
         // Use kCTTypesetterOptionForcedEmbeddingLevel to control BiDi
-        // embedding. We force embedding level 0 (LTR) for LTR runs and
-        // embedding level 1 (RTL) for RTL runs. Our run iterator already
-        // splits runs at direction boundaries, so each run is guaranteed
-        // to be single-direction.
+        // embedding. The run iterator already splits at direction
+        // boundaries, so each CoreText line we create here is a single LTR or
+        // RTL shaping run.
+        //
+        // Setting the attributed string's writing direction instead looks
+        // tempting, but it changes CoreText line breaking behavior. In
+        // particular, trailing spaces in RTL text can be emitted as their own
+        // right-to-left run ahead of the rest of the line.
         //
         // See: https://github.com/mitchellh/ghostty/issues/1737
         // See: https://github.com/mitchellh/ghostty/issues/1442
@@ -410,8 +414,7 @@ pub const Shaper = struct {
         var cell_offset: Offset = .{};
         const anchor_sentinel = std.math.nan(f64);
         self.cluster_anchor_x.clearRetainingCapacity();
-        try self.cluster_anchor_x.ensureUnusedCapacity(self.alloc, run.cells);
-        self.cluster_anchor_x.appendNTimesAssumeCapacity(anchor_sentinel, run.cells);
+        try self.cluster_anchor_x.appendNTimes(self.alloc, anchor_sentinel, run.cells);
 
         // For debugging positions, turn this on:
         //var run_offset_y: f64 = 0.0;
@@ -456,8 +459,10 @@ pub const Shaper = struct {
                 positions,
                 indices,
             ) |glyph, advance, position, index| {
-                // Our cluster is also our cell X position. If the cluster changes
-                // then we need to reset our current cell offsets.
+                // The cluster is the terminal cell this glyph belongs to.
+                // CoreText can report RTL glyphs in visual order with absolute
+                // glyph positions, so the current cluster does not always move
+                // left-to-right through the terminal row.
                 const cluster = state.codepoints.items[index].cluster;
                 const source_codepoint = state.codepoints.items[index].codepoint;
                 const is_combining_mark = source_codepoint != 0 and
@@ -515,6 +520,10 @@ pub const Shaper = struct {
                         const should_reset = (run.rtl and !is_combining_mark) or
                             !is_after_glyph_from_current_or_next_clusters;
                         if (should_reset) {
+                            // For RTL runs, CoreText's absolute glyph position
+                            // is the reliable cell anchor. The cumulative
+                            // advance is in output order and can point at the
+                            // wrong cell when marks are emitted around a base.
                             const reset_x = if (run.rtl) position.x else run_offset.x;
                             cell_offset = .{
                                 .cluster = cluster,
@@ -545,10 +554,10 @@ pub const Shaper = struct {
                         const cluster_i: usize = @intCast(cluster);
                         if (cluster_i < self.cluster_anchor_x.items.len) {
                             const anchor_x = self.cluster_anchor_x.items[cluster_i];
-                            // Keep this scoped to Arabic RTL marks only:
-                            // broadening this fallback regresses scripts with
-                            // out-of-order vowels/marks (e.g.
-                            // Chakma/Bengali tests).
+                            // Keep this scoped to Arabic RTL marks only. Other
+                            // scripts can also emit marks out of logical order,
+                            // but they do not all want the Arabic "attach back
+                            // to base cell" fallback.
                             const allow_non_first_fallback =
                                 bidi_helpers.isArabicCombiningMark(source_codepoint);
                             if (!std.math.isNan(anchor_x)) {
@@ -618,12 +627,10 @@ pub const Shaper = struct {
             }
         }
 
-        // If our buffer contains some non-ltr sections we need to sort it :/
+        // CoreText may return RTL or otherwise non-monotonic glyph runs. The
+        // renderer expects cells sorted by increasing terminal x, so normalize
+        // the order after all per-glyph offsets have been computed.
         if (non_ltr or run.rtl) {
-            // This is EXCEPTIONALLY rare. Only happens for languages with
-            // complex shaping which we don't even really support properly
-            // right now, so are very unlikely to be used heavily by users
-            // of Ghostty.
             @branchHint(.cold);
             std.mem.sort(
                 font.shape.Cell,

--- a/src/font/shaper/coretext.zig
+++ b/src/font/shaper/coretext.zig
@@ -2032,7 +2032,7 @@ test "shape Bengali sentence keeps base clusters anchored" {
 
     var s = t.vtStream();
     defer s.deinit();
-    try s.nextSlice("পছন্দের ভাষা টাইপ করা আরো সহজ করে তোলে৷ আরো জানুন");
+    s.nextSlice("পছন্দের ভাষা টাইপ করা আরো সহজ করে তোলে৷ আরো জানুন");
 
     var state: terminal.RenderState = .empty;
     defer state.deinit(alloc);
@@ -2091,7 +2091,7 @@ test "shape Bengali sentence in mixed-direction line keeps base clusters anchore
 
     var s = t.vtStream();
     defer s.deinit();
-    try s.nextSlice("ABC পছন্দের ভাষা টাইপ করা আরো সহজ করে তোলে৷ আরো জানুন مرحبا");
+    s.nextSlice("ABC পছন্দের ভাষা টাইপ করা আরো সহজ করে তোলে৷ আরো জানুন مرحبا");
 
     var state: terminal.RenderState = .empty;
     defer state.deinit(alloc);
@@ -2752,7 +2752,7 @@ test "shape LTR neutral RTL splits and sets direction" {
 
     var s = t.vtStream();
     defer s.deinit();
-    try s.nextSlice("Hello مرحبا");
+    s.nextSlice("Hello مرحبا");
 
     var state: terminal.RenderState = .empty;
     defer state.deinit(alloc);
@@ -2790,7 +2790,7 @@ test "shape hebrew RTL" {
 
     var s = t.vtStream();
     defer s.deinit();
-    try s.nextSlice("שלום עולם");
+    s.nextSlice("שלום עולם");
 
     var state: terminal.RenderState = .empty;
     defer state.deinit(alloc);
@@ -2822,6 +2822,76 @@ test "shape hebrew RTL" {
     try testing.expectEqual(@as(usize, 1), count);
 }
 
+// Regression test for the `base_dir = .auto_ltr` paragraph-direction fix
+// in run.zig. Under a forced LTR base direction (the old behavior), the
+// trailing ASCII punctuation `?` in an RTL-leading row resolves to an LTR
+// embedding level via UAX #9 N2 (because `eos` falls back to base_level=0=L,
+// N1 does not match, and the neutral adopts the embedding direction). The
+// `?` then splits off into a separate LTR visual run and lands at the
+// visual-left of the row, ahead of the Hebrew text.
+//
+// With `base_dir = .auto_ltr`, UAX #9 P2-P3 sees the first strong character
+// `ש` (Bidi_Class=R) and sets base_level=1 (RTL). The trailing `?` now has
+// `eos=R`, N1 matches the surrounding Hebrew, the neutral resolves to R,
+// and it stays in the same RTL visual run as the Hebrew — appearing at the
+// visual-right (end of the sentence), where a user expects it.
+//
+// This test pins that behavior: the row must produce a single RTL run
+// covering the full input (including the trailing `?`), not a split with
+// the `?` in a separate LTR run.
+test "shape hebrew RTL with trailing punctuation at visual-right" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var testdata = try testShaperWithFont(alloc, .julia_mono);
+    defer testdata.deinit();
+
+    var t = try terminal.Terminal.init(alloc, .{ .cols = 30, .rows = 3 });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    s.nextSlice("שלום, עולם! מה שלומך?");
+
+    var state: terminal.RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &t);
+
+    var shaper = &testdata.shaper;
+    var it = shaper.runIterator(.{
+        .grid = testdata.grid,
+        .cells = state.row_data.get(0).cells.slice(),
+    });
+
+    // "שלום, עולם! מה שלומך?" = 21 codepoints/cells.
+    const expected_cells: u16 = 21;
+
+    var count: usize = 0;
+    while (try it.next(alloc)) |run| {
+        count += 1;
+        try testing.expect(run.rtl);
+        try testing.expectEqual(expected_cells, run.cells);
+
+        const cells = try shaper.shape(run);
+        try testing.expect(cells.len > 1);
+
+        // Shaped cells must all fall within the run and be in monotonic
+        // (non-decreasing) x order, as the renderer requires.
+        var x: u16 = cells[0].x;
+        try testing.expect(x < run.cells);
+        for (cells[1..]) |cell| {
+            try testing.expect(cell.x < run.cells);
+            try testing.expect(cell.x >= x);
+            x = cell.x;
+        }
+    }
+
+    // A single RTL run means the trailing `?` stayed with the Hebrew.
+    // Under the old forced-LTR base direction this would be 2+ runs
+    // (the `?` splits off into a separate LTR run).
+    try testing.expectEqual(@as(usize, 1), count);
+}
+
 test "shape arabic with tashkeel at EOL" {
     const testing = std.testing;
     const alloc = testing.allocator;
@@ -2834,7 +2904,7 @@ test "shape arabic with tashkeel at EOL" {
 
     var s = t.vtStream();
     defer s.deinit();
-    try s.nextSlice("مرحباً");
+    s.nextSlice("مرحباً");
 
     var state: terminal.RenderState = .empty;
     defer state.deinit(alloc);
@@ -2876,7 +2946,7 @@ test "shape arabic with tashkeel on middle letters" {
 
     var s = t.vtStream();
     defer s.deinit();
-    try s.nextSlice("وفُكَّ");
+    s.nextSlice("وفُكَّ");
 
     var state: terminal.RenderState = .empty;
     defer state.deinit(alloc);
@@ -2919,7 +2989,7 @@ test "shape arabic tanween stays on hamza before space" {
 
     var s = t.vtStream();
     defer s.deinit();
-    try s.nextSlice("شيءٍ جميل");
+    s.nextSlice("شيءٍ جميل");
 
     var state: terminal.RenderState = .empty;
     defer state.deinit(alloc);
@@ -2969,7 +3039,7 @@ test "shape arabic end tashkeel no overlap" {
 
     var s = t.vtStream();
     defer s.deinit();
-    try s.nextSlice("بحقِّ");
+    s.nextSlice("بحقِّ");
 
     var state: terminal.RenderState = .empty;
     defer state.deinit(alloc);
@@ -3046,7 +3116,7 @@ test "shape arabic end tanween no overlap" {
 
     var s = t.vtStream();
     defer s.deinit();
-    try s.nextSlice("عينٍ");
+    s.nextSlice("عينٍ");
 
     var state: terminal.RenderState = .empty;
     defer state.deinit(alloc);
@@ -3119,7 +3189,7 @@ test "shape arabic multiword end tashkeel stays anchored" {
 
     var s = t.vtStream();
     defer s.deinit();
-    try s.nextSlice("الحيِّ الذي");
+    s.nextSlice("الحيِّ الذي");
 
     var state: terminal.RenderState = .empty;
     defer state.deinit(alloc);

--- a/src/font/shaper/coretext.zig
+++ b/src/font/shaper/coretext.zig
@@ -959,7 +959,7 @@ test "run iterator" {
 
         var s = t.vtStream();
         defer s.deinit();
-        s.nextSlice("ABCD");
+        try s.nextSlice("ABCD");
 
         var state: terminal.RenderState = .empty;
         defer state.deinit(alloc);
@@ -983,7 +983,7 @@ test "run iterator" {
 
         var s = t.vtStream();
         defer s.deinit();
-        s.nextSlice("ABCD   EFG");
+        try s.nextSlice("ABCD   EFG");
 
         var state: terminal.RenderState = .empty;
         defer state.deinit(alloc);
@@ -1006,7 +1006,7 @@ test "run iterator" {
 
         var s = t.vtStream();
         defer s.deinit();
-        s.nextSlice("A😃D");
+        try s.nextSlice("A😃D");
 
         var state: terminal.RenderState = .empty;
         defer state.deinit(alloc);
@@ -1031,7 +1031,7 @@ test "run iterator" {
 
         var s = t.vtStream();
         defer s.deinit();
-        s.nextSlice(bad);
+        try s.nextSlice(bad);
 
         var state: terminal.RenderState = .empty;
         defer state.deinit(alloc);
@@ -1064,8 +1064,8 @@ test "run iterator: empty cells with background set" {
         var s = t.vtStream();
         defer s.deinit();
         // Set red background
-        s.nextSlice("\x1b[48;2;255;0;0m");
-        s.nextSlice("A");
+        try s.nextSlice("\x1b[48;2;255;0;0m");
+        try s.nextSlice("A");
 
         // Get our first row
         {
@@ -1123,7 +1123,7 @@ test "shape" {
 
     var s = t.vtStream();
     defer s.deinit();
-    s.nextSlice(buf[0..buf_idx]);
+    try s.nextSlice(buf[0..buf_idx]);
 
     var state: terminal.RenderState = .empty;
     defer state.deinit(alloc);
@@ -1162,7 +1162,7 @@ test "shape nerd fonts" {
 
     var s = t.vtStream();
     defer s.deinit();
-    s.nextSlice(buf[0..buf_idx]);
+    try s.nextSlice(buf[0..buf_idx]);
 
     var state: terminal.RenderState = .empty;
     defer state.deinit(alloc);
@@ -1195,7 +1195,7 @@ test "shape inconsolata ligs" {
 
         var s = t.vtStream();
         defer s.deinit();
-        s.nextSlice(">=");
+        try s.nextSlice(">=");
 
         var state: terminal.RenderState = .empty;
         defer state.deinit(alloc);
@@ -1224,7 +1224,7 @@ test "shape inconsolata ligs" {
 
         var s = t.vtStream();
         defer s.deinit();
-        s.nextSlice("===");
+        try s.nextSlice("===");
 
         var state: terminal.RenderState = .empty;
         defer state.deinit(alloc);
@@ -1261,7 +1261,7 @@ test "shape monaspace ligs" {
 
         var s = t.vtStream();
         defer s.deinit();
-        s.nextSlice("===");
+        try s.nextSlice("===");
 
         var state: terminal.RenderState = .empty;
         defer state.deinit(alloc);
@@ -1299,7 +1299,7 @@ test "shape left-replaced lig in last run" {
 
         var s = t.vtStream();
         defer s.deinit();
-        s.nextSlice("!==");
+        try s.nextSlice("!==");
 
         var state: terminal.RenderState = .empty;
         defer state.deinit(alloc);
@@ -1337,7 +1337,7 @@ test "shape left-replaced lig in early run" {
 
         var s = t.vtStream();
         defer s.deinit();
-        s.nextSlice("!==X");
+        try s.nextSlice("!==X");
 
         var state: terminal.RenderState = .empty;
         defer state.deinit(alloc);
@@ -1372,7 +1372,7 @@ test "shape U+3C9 with JB Mono" {
 
         var s = t.vtStream();
         defer s.deinit();
-        s.nextSlice("\u{03C9} foo");
+        try s.nextSlice("\u{03C9} foo");
 
         var state: terminal.RenderState = .empty;
         defer state.deinit(alloc);
@@ -1409,7 +1409,7 @@ test "shape emoji width" {
 
         var s = t.vtStream();
         defer s.deinit();
-        s.nextSlice("👍");
+        try s.nextSlice("👍");
 
         var state: terminal.RenderState = .empty;
         defer state.deinit(alloc);
@@ -1442,7 +1442,7 @@ test "shape emoji width long" {
     var t = try terminal.Terminal.init(alloc, .{ .cols = 30, .rows = 3 });
     defer t.deinit(alloc);
 
-    var page = t.screens.active.pages.pages.first.?.page();
+    var page = t.screens.active.pages.pages.first.?.data;
     var row = page.getRow(1);
     const cell = &row.cells.ptr(page.memory)[0];
     cell.* = .{
@@ -1499,7 +1499,7 @@ test "shape variation selector VS15" {
 
     var s = t.vtStream();
     defer s.deinit();
-    s.nextSlice(buf[0..buf_idx]);
+    try s.nextSlice(buf[0..buf_idx]);
 
     var state: terminal.RenderState = .empty;
     defer state.deinit(alloc);
@@ -1538,7 +1538,7 @@ test "shape variation selector VS16" {
 
     var s = t.vtStream();
     defer s.deinit();
-    s.nextSlice(buf[0..buf_idx]);
+    try s.nextSlice(buf[0..buf_idx]);
 
     var state: terminal.RenderState = .empty;
     defer state.deinit(alloc);
@@ -1572,9 +1572,9 @@ test "shape with empty cells in between" {
 
     var s = t.vtStream();
     defer s.deinit();
-    s.nextSlice("A");
-    s.nextSlice("\x1b[5C"); // 5 spaces forward
-    s.nextSlice("B");
+    try s.nextSlice("A");
+    try s.nextSlice("\x1b[5C"); // 5 spaces forward
+    try s.nextSlice("B");
 
     var state: terminal.RenderState = .empty;
     defer state.deinit(alloc);
@@ -1619,7 +1619,7 @@ test "shape Combining characters" {
 
     var s = t.vtStream();
     defer s.deinit();
-    s.nextSlice(buf[0..buf_idx]);
+    try s.nextSlice(buf[0..buf_idx]);
 
     var state: terminal.RenderState = .empty;
     defer state.deinit(alloc);
@@ -1669,7 +1669,7 @@ test "shape Devanagari string" {
 
     var s = t.vtStream();
     defer s.deinit();
-    s.nextSlice("अपार्टमेंट");
+    try s.nextSlice("अपार्टमेंट");
 
     var state: terminal.RenderState = .empty;
     defer state.deinit(alloc);
@@ -1728,7 +1728,7 @@ test "shape Tai Tham vowels (position differs from advance)" {
 
     var s = t.vtStream();
     defer s.deinit();
-    s.nextSlice(buf[0..buf_idx]);
+    try s.nextSlice(buf[0..buf_idx]);
 
     var state: terminal.RenderState = .empty;
     defer state.deinit(alloc);
@@ -1789,7 +1789,7 @@ test "shape Tai Tham letters (position.y differs from advance)" {
 
     var s = t.vtStream();
     defer s.deinit();
-    s.nextSlice(buf[0..buf_idx]);
+    try s.nextSlice(buf[0..buf_idx]);
 
     var state: terminal.RenderState = .empty;
     defer state.deinit(alloc);
@@ -1849,7 +1849,7 @@ test "shape Javanese ligatures" {
 
     var s = t.vtStream();
     defer s.deinit();
-    s.nextSlice(buf[0..buf_idx]);
+    try s.nextSlice(buf[0..buf_idx]);
 
     var state: terminal.RenderState = .empty;
     defer state.deinit(alloc);
@@ -1912,7 +1912,7 @@ test "shape Chakma vowel sign with ligature (vowel sign renders first)" {
 
     var s = t.vtStream();
     defer s.deinit();
-    s.nextSlice(buf[0..buf_idx]);
+    try s.nextSlice(buf[0..buf_idx]);
 
     var state: terminal.RenderState = .empty;
     defer state.deinit(alloc);
@@ -1978,7 +1978,7 @@ test "shape Bengali ligatures with out of order vowels" {
 
     var s = t.vtStream();
     defer s.deinit();
-    s.nextSlice(buf[0..buf_idx]);
+    try s.nextSlice(buf[0..buf_idx]);
 
     var state: terminal.RenderState = .empty;
     defer state.deinit(alloc);
@@ -2032,7 +2032,7 @@ test "shape Bengali sentence keeps base clusters anchored" {
 
     var s = t.vtStream();
     defer s.deinit();
-    s.nextSlice("পছন্দের ভাষা টাইপ করা আরো সহজ করে তোলে৷ আরো জানুন");
+    try s.nextSlice("পছন্দের ভাষা টাইপ করা আরো সহজ করে তোলে৷ আরো জানুন");
 
     var state: terminal.RenderState = .empty;
     defer state.deinit(alloc);
@@ -2091,7 +2091,7 @@ test "shape Bengali sentence in mixed-direction line keeps base clusters anchore
 
     var s = t.vtStream();
     defer s.deinit();
-    s.nextSlice("ABC পছন্দের ভাষা টাইপ করা আরো সহজ করে তোলে৷ আরো জানুন مرحبا");
+    try s.nextSlice("ABC পছন্দের ভাষা টাইপ করা আরো সহজ করে তোলে৷ আরো জানুন مرحبا");
 
     var state: terminal.RenderState = .empty;
     defer state.deinit(alloc);
@@ -2153,7 +2153,7 @@ test "shape box glyphs" {
 
     var s = t.vtStream();
     defer s.deinit();
-    s.nextSlice(buf[0..buf_idx]);
+    try s.nextSlice(buf[0..buf_idx]);
 
     var state: terminal.RenderState = .empty;
     defer state.deinit(alloc);
@@ -2191,7 +2191,7 @@ test "shape selection boundary" {
 
     var s = t.vtStream();
     defer s.deinit();
-    s.nextSlice("a1b2c3d4e5");
+    try s.nextSlice("a1b2c3d4e5");
 
     var state: terminal.RenderState = .empty;
     defer state.deinit(alloc);
@@ -2296,7 +2296,7 @@ test "shape cursor boundary" {
 
     var s = t.vtStream();
     defer s.deinit();
-    s.nextSlice("a1b2c3d4e5");
+    try s.nextSlice("a1b2c3d4e5");
 
     var state: terminal.RenderState = .empty;
     defer state.deinit(alloc);
@@ -2433,7 +2433,7 @@ test "shape cursor boundary and colored emoji" {
 
     var s = t.vtStream();
     defer s.deinit();
-    s.nextSlice("👍🏼");
+    try s.nextSlice("👍🏼");
 
     var state: terminal.RenderState = .empty;
     defer state.deinit(alloc);
@@ -2530,7 +2530,7 @@ test "shape cell attribute change" {
 
         var s = t.vtStream();
         defer s.deinit();
-        s.nextSlice(">=");
+        try s.nextSlice(">=");
 
         var state: terminal.RenderState = .empty;
         defer state.deinit(alloc);
@@ -2556,9 +2556,9 @@ test "shape cell attribute change" {
 
         var s = t.vtStream();
         defer s.deinit();
-        s.nextSlice(">");
-        s.nextSlice("\x1b[1m"); // Bold
-        s.nextSlice("=");
+        try s.nextSlice(">");
+        try s.nextSlice("\x1b[1m"); // Bold
+        try s.nextSlice("=");
 
         var state: terminal.RenderState = .empty;
         defer state.deinit(alloc);
@@ -2585,11 +2585,11 @@ test "shape cell attribute change" {
         var s = t.vtStream();
         defer s.deinit();
         // RGB 1, 2, 3
-        s.nextSlice("\x1b[38;2;1;2;3m");
-        s.nextSlice(">");
+        try s.nextSlice("\x1b[38;2;1;2;3m");
+        try s.nextSlice(">");
         // RGB 3, 2, 1
-        s.nextSlice("\x1b[38;2;3;2;1m");
-        s.nextSlice("=");
+        try s.nextSlice("\x1b[38;2;3;2;1m");
+        try s.nextSlice("=");
 
         var state: terminal.RenderState = .empty;
         defer state.deinit(alloc);
@@ -2616,11 +2616,11 @@ test "shape cell attribute change" {
         var s = t.vtStream();
         defer s.deinit();
         // RGB 1, 2, 3 bg
-        s.nextSlice("\x1b[48;2;1;2;3m");
-        s.nextSlice(">");
+        try s.nextSlice("\x1b[48;2;1;2;3m");
+        try s.nextSlice(">");
         // RGB 3, 2, 1 bg
-        s.nextSlice("\x1b[48;2;3;2;1m");
-        s.nextSlice("=");
+        try s.nextSlice("\x1b[48;2;3;2;1m");
+        try s.nextSlice("=");
 
         var state: terminal.RenderState = .empty;
         defer state.deinit(alloc);
@@ -2647,9 +2647,9 @@ test "shape cell attribute change" {
         var s = t.vtStream();
         defer s.deinit();
         // RGB 1, 2, 3 bg
-        s.nextSlice("\x1b[48;2;1;2;3m");
-        s.nextSlice(">");
-        s.nextSlice("=");
+        try s.nextSlice("\x1b[48;2;1;2;3m");
+        try s.nextSlice(">");
+        try s.nextSlice("=");
 
         var state: terminal.RenderState = .empty;
         defer state.deinit(alloc);
@@ -2692,7 +2692,7 @@ test "shape high plane sprite font codepoint" {
     var s = t.vtStream();
     defer s.deinit();
     // U+1FB70: Vertical One Eighth Block-2
-    s.nextSlice("\u{1FB70}");
+    try s.nextSlice("\u{1FB70}");
 
     var state: terminal.RenderState = .empty;
     defer state.deinit(alloc);
@@ -2752,7 +2752,7 @@ test "shape LTR neutral RTL splits and sets direction" {
 
     var s = t.vtStream();
     defer s.deinit();
-    s.nextSlice("Hello مرحبا");
+    try s.nextSlice("Hello مرحبا");
 
     var state: terminal.RenderState = .empty;
     defer state.deinit(alloc);
@@ -2790,7 +2790,7 @@ test "shape hebrew RTL" {
 
     var s = t.vtStream();
     defer s.deinit();
-    s.nextSlice("שלום עולם");
+    try s.nextSlice("שלום עולם");
 
     var state: terminal.RenderState = .empty;
     defer state.deinit(alloc);
@@ -2822,76 +2822,6 @@ test "shape hebrew RTL" {
     try testing.expectEqual(@as(usize, 1), count);
 }
 
-// Regression test for the `base_dir = .auto_ltr` paragraph-direction fix
-// in run.zig. Under a forced LTR base direction (the old behavior), the
-// trailing ASCII punctuation `?` in an RTL-leading row resolves to an LTR
-// embedding level via UAX #9 N2 (because `eos` falls back to base_level=0=L,
-// N1 does not match, and the neutral adopts the embedding direction). The
-// `?` then splits off into a separate LTR visual run and lands at the
-// visual-left of the row, ahead of the Hebrew text.
-//
-// With `base_dir = .auto_ltr`, UAX #9 P2-P3 sees the first strong character
-// `ש` (Bidi_Class=R) and sets base_level=1 (RTL). The trailing `?` now has
-// `eos=R`, N1 matches the surrounding Hebrew, the neutral resolves to R,
-// and it stays in the same RTL visual run as the Hebrew — appearing at the
-// visual-right (end of the sentence), where a user expects it.
-//
-// This test pins that behavior: the row must produce a single RTL run
-// covering the full input (including the trailing `?`), not a split with
-// the `?` in a separate LTR run.
-test "shape hebrew RTL with trailing punctuation at visual-right" {
-    const testing = std.testing;
-    const alloc = testing.allocator;
-
-    var testdata = try testShaperWithFont(alloc, .julia_mono);
-    defer testdata.deinit();
-
-    var t = try terminal.Terminal.init(alloc, .{ .cols = 30, .rows = 3 });
-    defer t.deinit(alloc);
-
-    var s = t.vtStream();
-    defer s.deinit();
-    s.nextSlice("שלום, עולם! מה שלומך?");
-
-    var state: terminal.RenderState = .empty;
-    defer state.deinit(alloc);
-    try state.update(alloc, &t);
-
-    var shaper = &testdata.shaper;
-    var it = shaper.runIterator(.{
-        .grid = testdata.grid,
-        .cells = state.row_data.get(0).cells.slice(),
-    });
-
-    // "שלום, עולם! מה שלומך?" = 21 codepoints/cells.
-    const expected_cells: u16 = 21;
-
-    var count: usize = 0;
-    while (try it.next(alloc)) |run| {
-        count += 1;
-        try testing.expect(run.rtl);
-        try testing.expectEqual(expected_cells, run.cells);
-
-        const cells = try shaper.shape(run);
-        try testing.expect(cells.len > 1);
-
-        // Shaped cells must all fall within the run and be in monotonic
-        // (non-decreasing) x order, as the renderer requires.
-        var x: u16 = cells[0].x;
-        try testing.expect(x < run.cells);
-        for (cells[1..]) |cell| {
-            try testing.expect(cell.x < run.cells);
-            try testing.expect(cell.x >= x);
-            x = cell.x;
-        }
-    }
-
-    // A single RTL run means the trailing `?` stayed with the Hebrew.
-    // Under the old forced-LTR base direction this would be 2+ runs
-    // (the `?` splits off into a separate LTR run).
-    try testing.expectEqual(@as(usize, 1), count);
-}
-
 test "shape arabic with tashkeel at EOL" {
     const testing = std.testing;
     const alloc = testing.allocator;
@@ -2904,7 +2834,7 @@ test "shape arabic with tashkeel at EOL" {
 
     var s = t.vtStream();
     defer s.deinit();
-    s.nextSlice("مرحباً");
+    try s.nextSlice("مرحباً");
 
     var state: terminal.RenderState = .empty;
     defer state.deinit(alloc);
@@ -2946,7 +2876,7 @@ test "shape arabic with tashkeel on middle letters" {
 
     var s = t.vtStream();
     defer s.deinit();
-    s.nextSlice("وفُكَّ");
+    try s.nextSlice("وفُكَّ");
 
     var state: terminal.RenderState = .empty;
     defer state.deinit(alloc);
@@ -2989,7 +2919,7 @@ test "shape arabic tanween stays on hamza before space" {
 
     var s = t.vtStream();
     defer s.deinit();
-    s.nextSlice("شيءٍ جميل");
+    try s.nextSlice("شيءٍ جميل");
 
     var state: terminal.RenderState = .empty;
     defer state.deinit(alloc);
@@ -3039,7 +2969,7 @@ test "shape arabic end tashkeel no overlap" {
 
     var s = t.vtStream();
     defer s.deinit();
-    s.nextSlice("بحقِّ");
+    try s.nextSlice("بحقِّ");
 
     var state: terminal.RenderState = .empty;
     defer state.deinit(alloc);
@@ -3116,7 +3046,7 @@ test "shape arabic end tanween no overlap" {
 
     var s = t.vtStream();
     defer s.deinit();
-    s.nextSlice("عينٍ");
+    try s.nextSlice("عينٍ");
 
     var state: terminal.RenderState = .empty;
     defer state.deinit(alloc);
@@ -3189,7 +3119,7 @@ test "shape arabic multiword end tashkeel stays anchored" {
 
     var s = t.vtStream();
     defer s.deinit();
-    s.nextSlice("الحيِّ الذي");
+    try s.nextSlice("الحيِّ الذي");
 
     var state: terminal.RenderState = .empty;
     defer state.deinit(alloc);
@@ -3327,7 +3257,7 @@ fn testShaperWithFont(alloc: Allocator, font_req: TestFont) !TestShaper {
         });
     } else {
         // On CoreText we want to load Apple Emoji, we should have it.
-        var disco = font.Discover.init(lib);
+        var disco = font.Discover.init();
         defer disco.deinit();
         var disco_it = try disco.discover(alloc, .{
             .family = "Apple Color Emoji",
@@ -3382,7 +3312,7 @@ fn testShaperWithDiscoveredFont(alloc: Allocator, font_req: [:0]const u8) !TestS
 
     // Discover and add our font to the collection.
     {
-        var disco = font.Discover.init(lib);
+        var disco = font.Discover.init();
         defer disco.deinit();
         var disco_it = try disco.discover(alloc, .{
             .family = font_req,

--- a/src/font/shaper/harfbuzz.zig
+++ b/src/font/shaper/harfbuzz.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const assert = @import("../../quirks.zig").inlineAssert;
 const Allocator = std.mem.Allocator;
 const harfbuzz = @import("harfbuzz");
+const itijah = @import("itijah");
 const font = @import("../main.zig");
 const terminal = @import("../../terminal/main.zig");
 const unicode = @import("../../unicode/main.zig");
@@ -37,6 +38,9 @@ pub const Shaper = struct {
     /// these separately because after shaping, HarfBuzz replaces codepoints
     /// with glyph indices in the buffer.
     codepoints: std.ArrayListUnmanaged(Codepoint) = .{},
+
+    /// Scratch reused for terminal bidi layout resolution.
+    bidi_layout_scratch: itijah.VisualLayoutScratch = .{},
 
     const Codepoint = struct {
         cluster: u32,
@@ -97,6 +101,7 @@ pub const Shaper = struct {
         self.cell_buf.deinit(self.alloc);
         self.alloc.free(self.hb_feats);
         self.codepoints.deinit(self.alloc);
+        self.bidi_layout_scratch.deinit(self.alloc);
     }
 
     pub fn endFrame(self: *const Shaper) void {
@@ -307,6 +312,10 @@ pub const Shaper = struct {
 
         pub fn finalize(self: RunIteratorHook) void {
             self.shaper.hb_buf.guessSegmentProperties();
+        }
+
+        pub fn bidiLayoutScratch(self: RunIteratorHook) *itijah.VisualLayoutScratch {
+            return &self.shaper.bidi_layout_scratch;
         }
     };
 

--- a/src/font/shaper/harfbuzz.zig
+++ b/src/font/shaper/harfbuzz.zig
@@ -3,6 +3,7 @@ const assert = @import("../../quirks.zig").inlineAssert;
 const Allocator = std.mem.Allocator;
 const harfbuzz = @import("harfbuzz");
 const itijah = @import("itijah");
+const bidi_helpers = @import("bidi_helpers.zig");
 const font = @import("../main.zig");
 const terminal = @import("../../terminal/main.zig");
 const unicode = @import("../../unicode/main.zig");
@@ -18,17 +19,6 @@ const Style = font.Style;
 const Presentation = font.Presentation;
 
 const log = std.log.scoped(.font_shaper);
-
-fn isArabicCombiningMark(cp: u32) bool {
-    return switch (cp) {
-        0x0610...0x061A,
-        0x064B...0x065F,
-        0x0670,
-        0x06D6...0x06ED,
-        => true,
-        else => false,
-    };
-}
 
 /// Shaper that uses Harfbuzz.
 pub const Shaper = struct {
@@ -286,8 +276,8 @@ pub const Shaper = struct {
                         // Keep this scoped to Arabic RTL marks only: broadening
                         // this fallback regresses scripts with out-of-order
                         // vowels/marks (e.g. Chakma/Bengali tests).
-                        const allow_non_first_fallback = run.rtl and
-                            isArabicCombiningMark(source_codepoint);
+                        const allow_non_first_fallback =
+                            bidi_helpers.isArabicCombiningMark(source_codepoint);
                         if (anchor_x != anchor_sentinel) {
                             cell_offset = .{
                                 .cluster = cluster,
@@ -938,6 +928,221 @@ test "shape arabic tanween stays on hamza before space" {
         if (cell.x == hamza_cluster.?) hamza_cell_glyphs += 1;
     }
     try testing.expect(hamza_cell_glyphs >= 2);
+
+    try testing.expectEqual(@as(?font.shape.TextRun, null), try it.next(alloc));
+}
+
+test "shape arabic end tashkeel no overlap" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var testdata = try testShaperWithFont(alloc, .arabic);
+    defer testdata.deinit();
+
+    var t = try terminal.Terminal.init(alloc, .{ .cols = 30, .rows = 3 });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    try s.nextSlice("بحقِّ");
+
+    var state: terminal.RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &t);
+
+    var shaper = &testdata.shaper;
+    var it = shaper.runIterator(.{
+        .grid = testdata.grid,
+        .cells = state.row_data.get(0).cells.slice(),
+    });
+
+    const run = (try it.next(alloc)).?;
+    try testing.expect(run.rtl);
+    try testing.expectEqual(@as(u16, 3), run.cells);
+
+    var qaf_cluster: ?u32 = null;
+    var kasra_cluster: ?u32 = null;
+    var shadda_cluster: ?u32 = null;
+    var ha_cluster: ?u32 = null;
+    for (shaper.codepoints.items) |entry| {
+        if (entry.codepoint == 0) continue;
+        if (entry.codepoint == 0x0642 and qaf_cluster == null) qaf_cluster = entry.cluster;
+        if (entry.codepoint == 0x0650 and kasra_cluster == null) kasra_cluster = entry.cluster;
+        if (entry.codepoint == 0x0651 and shadda_cluster == null) shadda_cluster = entry.cluster;
+        if (entry.codepoint == 0x062D and ha_cluster == null) ha_cluster = entry.cluster;
+    }
+    try testing.expect(qaf_cluster != null);
+    try testing.expect(kasra_cluster != null);
+    try testing.expect(shadda_cluster != null);
+    try testing.expect(ha_cluster != null);
+    try testing.expectEqual(qaf_cluster.?, kasra_cluster.?);
+    try testing.expectEqual(qaf_cluster.?, shadda_cluster.?);
+    try testing.expect(qaf_cluster.? != ha_cluster.?);
+
+    const cells = try shaper.shape(run);
+    try testing.expect(cells.len > 0);
+
+    var prev_x: u16 = cells[0].x;
+    for (cells[1..]) |cell| {
+        try testing.expect(cell.x >= prev_x);
+        prev_x = cell.x;
+    }
+
+    var seen = [_]bool{ false, false, false };
+    var qaf_cell_glyphs: usize = 0;
+    for (cells) |cell| {
+        try testing.expect(cell.x < run.cells);
+        seen[cell.x] = true;
+        if (cell.x == qaf_cluster.?) qaf_cell_glyphs += 1;
+    }
+    try testing.expect(seen[0]);
+    try testing.expect(seen[1]);
+    try testing.expect(seen[2]);
+    try testing.expect(qaf_cell_glyphs >= 2);
+
+    try testing.expectEqual(@as(?font.shape.TextRun, null), try it.next(alloc));
+}
+
+test "shape arabic end tanween no overlap" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var testdata = try testShaperWithFont(alloc, .arabic);
+    defer testdata.deinit();
+
+    var t = try terminal.Terminal.init(alloc, .{ .cols = 30, .rows = 3 });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    try s.nextSlice("عينٍ");
+
+    var state: terminal.RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &t);
+
+    var shaper = &testdata.shaper;
+    var it = shaper.runIterator(.{
+        .grid = testdata.grid,
+        .cells = state.row_data.get(0).cells.slice(),
+    });
+
+    const run = (try it.next(alloc)).?;
+    try testing.expect(run.rtl);
+    try testing.expectEqual(@as(u16, 3), run.cells);
+
+    var nun_cluster: ?u32 = null;
+    var tanween_cluster: ?u32 = null;
+    var ya_cluster: ?u32 = null;
+    for (shaper.codepoints.items) |entry| {
+        if (entry.codepoint == 0) continue;
+        if (entry.codepoint == 0x0646 and nun_cluster == null) nun_cluster = entry.cluster;
+        if (entry.codepoint == 0x064D and tanween_cluster == null) tanween_cluster = entry.cluster;
+        if (entry.codepoint == 0x064A and ya_cluster == null) ya_cluster = entry.cluster;
+    }
+    try testing.expect(nun_cluster != null);
+    try testing.expect(tanween_cluster != null);
+    try testing.expect(ya_cluster != null);
+    try testing.expectEqual(nun_cluster.?, tanween_cluster.?);
+    try testing.expect(nun_cluster.? != ya_cluster.?);
+
+    const cells = try shaper.shape(run);
+    try testing.expect(cells.len > 0);
+
+    var prev_x: u16 = cells[0].x;
+    for (cells[1..]) |cell| {
+        try testing.expect(cell.x >= prev_x);
+        prev_x = cell.x;
+    }
+
+    var seen = [_]bool{ false, false, false };
+    var nun_cell_glyphs: usize = 0;
+    for (cells) |cell| {
+        try testing.expect(cell.x < run.cells);
+        seen[cell.x] = true;
+        if (cell.x == nun_cluster.?) nun_cell_glyphs += 1;
+    }
+    try testing.expect(seen[0]);
+    try testing.expect(seen[1]);
+    try testing.expect(seen[2]);
+    try testing.expect(nun_cell_glyphs >= 2);
+
+    try testing.expectEqual(@as(?font.shape.TextRun, null), try it.next(alloc));
+}
+
+test "shape arabic multiword end tashkeel stays anchored" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var testdata = try testShaperWithFont(alloc, .arabic);
+    defer testdata.deinit();
+
+    var t = try terminal.Terminal.init(alloc, .{ .cols = 30, .rows = 3 });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    try s.nextSlice("الحيِّ الذي");
+
+    var state: terminal.RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &t);
+
+    var shaper = &testdata.shaper;
+    var it = shaper.runIterator(.{
+        .grid = testdata.grid,
+        .cells = state.row_data.get(0).cells.slice(),
+    });
+
+    const run = (try it.next(alloc)).?;
+    try testing.expect(run.rtl);
+
+    var kasra_cluster: ?u32 = null;
+    var shadda_cluster: ?u32 = null;
+    for (shaper.codepoints.items) |entry| {
+        if (entry.codepoint == 0) continue;
+        if (entry.codepoint == 0x0650 and kasra_cluster == null) kasra_cluster = entry.cluster;
+        if (entry.codepoint == 0x0651 and shadda_cluster == null) shadda_cluster = entry.cluster;
+    }
+    try testing.expect(kasra_cluster != null);
+    try testing.expect(shadda_cluster != null);
+    try testing.expectEqual(kasra_cluster.?, shadda_cluster.?);
+    const ya_cluster = kasra_cluster.?;
+
+    var ha_cluster: ?u32 = null;
+    for (shaper.codepoints.items) |entry| {
+        if (entry.codepoint == 0) continue;
+        if (entry.codepoint == 0x062D and ha_cluster == null) ha_cluster = entry.cluster;
+    }
+    try testing.expect(ha_cluster != null);
+    try testing.expect(ha_cluster.? != ya_cluster);
+
+    const cells = try shaper.shape(run);
+    try testing.expect(cells.len > 0);
+
+    var prev_x: u16 = cells[0].x;
+    var saw_ha = false;
+    var saw_ya = false;
+    var ya_base_near_zero = false;
+    for (cells) |cell| {
+        try testing.expect(cell.x < run.cells);
+        try testing.expect(cell.x >= prev_x);
+        prev_x = cell.x;
+
+        const xoff: i32 = cell.x_offset;
+        try testing.expect(@abs(xoff) < 200);
+
+        if (cell.x == ha_cluster.?) saw_ha = true;
+        if (cell.x == ya_cluster) {
+            saw_ya = true;
+            if (@abs(xoff) <= 5 and @abs(@as(i32, cell.y_offset)) <= 5) {
+                ya_base_near_zero = true;
+            }
+        }
+    }
+    try testing.expect(saw_ha);
+    try testing.expect(saw_ya);
+    try testing.expect(ya_base_near_zero);
 
     try testing.expectEqual(@as(?font.shape.TextRun, null), try it.next(alloc));
 }

--- a/src/font/shaper/harfbuzz.zig
+++ b/src/font/shaper/harfbuzz.zig
@@ -128,6 +128,12 @@ pub const Shaper = struct {
     ///
     /// If there is not enough space in the cell buffer, an error is returned.
     pub fn shape(self: *Shaper, run: font.shape.TextRun) ![]const font.shape.Cell {
+        // Set run direction before shaping so HarfBuzz applies the
+        // correct script-direction shaping behavior.
+        if (run.rtl) {
+            self.hb_buf.setDirection(.rtl);
+        }
+
         // We only do shaping if the font is not a special-case. For special-case
         // fonts, the codepoint == glyph_index so we don't need to run any shaping.
         if (run.font_index.special() == null) {
@@ -255,6 +261,14 @@ pub const Shaper = struct {
         }
         //log.warn("----------------", .{});
 
+        if (run.rtl) {
+            std.mem.sort(font.shape.Cell, self.cell_buf.items, {}, struct {
+                fn lt(_: void, a: font.shape.Cell, b: font.shape.Cell) bool {
+                    return a.x < b.x;
+                }
+            }.lt);
+        }
+
         return self.cell_buf.items;
     }
 
@@ -274,9 +288,7 @@ pub const Shaper = struct {
 
             self.shaper.codepoints.clearRetainingCapacity();
 
-            // We don't support RTL text because RTL in terminals is messy.
-            // Its something we want to improve. For now, we force LTR because
-            // our renderers assume a strictly increasing X value.
+            // Default to LTR. RTL runs are switched to RTL in shape().
             self.shaper.hb_buf.setDirection(.ltr);
         }
 
@@ -716,11 +728,7 @@ test "shape monaspace ligs" {
     }
 }
 
-// Ghostty doesn't currently support RTL and our renderers assume
-// that cells are in strict LTR order. This means that we need to
-// force RTL text to be LTR for rendering. This test ensures that
-// we are correctly forcing RTL text to be LTR.
-test "shape arabic forced LTR" {
+test "shape arabic RTL" {
     const testing = std.testing;
     const alloc = testing.allocator;
 
@@ -746,18 +754,92 @@ test "shape arabic forced LTR" {
     var count: usize = 0;
     while (try it.next(alloc)) |run| {
         count += 1;
-        try testing.expectEqual(@as(usize, 25), run.cells);
+        try testing.expect(run.rtl);
 
         const cells = try shaper.shape(run);
-        try testing.expectEqual(@as(usize, 25), cells.len);
+        try testing.expect(cells.len > 1);
 
         var x: u16 = cells[0].x;
         for (cells[1..]) |cell| {
-            try testing.expectEqual(x + 1, cell.x);
+            try testing.expect(cell.x >= x);
             x = cell.x;
         }
     }
     try testing.expectEqual(@as(usize, 1), count);
+}
+
+test "shape LTR then RTL splits at direction boundary" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var testdata = try testShaperWithFont(alloc, .arabic);
+    defer testdata.deinit();
+
+    var t = try terminal.Terminal.init(alloc, .{ .cols = 30, .rows = 3 });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    try s.nextSlice("Hello مرحبا");
+
+    var state: terminal.RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &t);
+
+    var shaper = &testdata.shaper;
+    var it = shaper.runIterator(.{
+        .grid = testdata.grid,
+        .cells = state.row_data.get(0).cells.slice(),
+    });
+
+    var runs: [10]font.shape.TextRun = undefined;
+    var count: usize = 0;
+    while (try it.next(alloc)) |run| {
+        if (count < runs.len) runs[count] = run;
+        count += 1;
+    }
+
+    try testing.expectEqual(@as(usize, 2), count);
+    try testing.expect(!runs[0].rtl);
+    try testing.expectEqual(@as(u16, 0), runs[0].offset);
+    try testing.expect(runs[1].rtl);
+    try testing.expect(runs[1].offset > 0);
+}
+
+test "shape digits between RTL split into LTR run" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var testdata = try testShaperWithFont(alloc, .arabic);
+    defer testdata.deinit();
+
+    var t = try terminal.Terminal.init(alloc, .{ .cols = 30, .rows = 3 });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    try s.nextSlice("عدد 123 نص");
+
+    var state: terminal.RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &t);
+
+    var shaper = &testdata.shaper;
+    var it = shaper.runIterator(.{
+        .grid = testdata.grid,
+        .cells = state.row_data.get(0).cells.slice(),
+    });
+
+    const run1 = (try it.next(alloc)).?;
+    try testing.expect(run1.rtl);
+
+    const run2 = (try it.next(alloc)).?;
+    try testing.expect(!run2.rtl);
+
+    const run3 = (try it.next(alloc)).?;
+    try testing.expect(run3.rtl);
+
+    try testing.expectEqual(try it.next(alloc), null);
 }
 
 test "shape emoji width" {

--- a/src/font/shaper/harfbuzz.zig
+++ b/src/font/shaper/harfbuzz.zig
@@ -839,6 +839,50 @@ test "shape arabic RTL" {
     try testing.expectEqual(@as(usize, 1), count);
 }
 
+test "shape hebrew RTL" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var testdata = try testShaperWithFont(alloc, .julia_mono);
+    defer testdata.deinit();
+
+    var t = try terminal.Terminal.init(alloc, .{ .cols = 30, .rows = 3 });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    try s.nextSlice("שלום עולם");
+
+    var state: terminal.RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &t);
+
+    var shaper = &testdata.shaper;
+    var it = shaper.runIterator(.{
+        .grid = testdata.grid,
+        .cells = state.row_data.get(0).cells.slice(),
+    });
+
+    var count: usize = 0;
+    while (try it.next(alloc)) |run| {
+        count += 1;
+        try testing.expect(run.rtl);
+        try testing.expectEqual(@as(u16, 9), run.cells);
+
+        const cells = try shaper.shape(run);
+        try testing.expect(cells.len > 1);
+
+        var x: u16 = cells[0].x;
+        try testing.expect(x < run.cells);
+        for (cells[1..]) |cell| {
+            try testing.expect(cell.x < run.cells);
+            try testing.expect(cell.x >= x);
+            x = cell.x;
+        }
+    }
+    try testing.expectEqual(@as(usize, 1), count);
+}
+
 test "shape arabic with tashkeel on middle letters" {
     const testing = std.testing;
     const alloc = testing.allocator;
@@ -2604,6 +2648,7 @@ const TestShaper = struct {
 
 const TestFont = enum {
     inconsolata,
+    julia_mono,
     monaspace_neon,
     arabic,
 };
@@ -2618,6 +2663,7 @@ fn testShaperWithFont(alloc: Allocator, font_req: TestFont) !TestShaper {
     const testEmojiText = font.embedded.emoji_text;
     const testFont = switch (font_req) {
         .inconsolata => font.embedded.inconsolata,
+        .julia_mono => font.embedded.julia_mono,
         .monaspace_neon => font.embedded.monaspace_neon,
         .arabic => font.embedded.arabic,
     };

--- a/src/font/shaper/harfbuzz.zig
+++ b/src/font/shaper/harfbuzz.zig
@@ -19,6 +19,17 @@ const Presentation = font.Presentation;
 
 const log = std.log.scoped(.font_shaper);
 
+fn isArabicCombiningMark(cp: u32) bool {
+    return switch (cp) {
+        0x0610...0x061A,
+        0x064B...0x065F,
+        0x0670,
+        0x06D6...0x06ED,
+        => true,
+        else => false,
+    };
+}
+
 /// Shaper that uses Harfbuzz.
 pub const Shaper = struct {
     /// The allocated used for the feature list, cell buf, and codepoints.
@@ -38,6 +49,10 @@ pub const Shaper = struct {
     /// these separately because after shaping, HarfBuzz replaces codepoints
     /// with glyph indices in the buffer.
     codepoints: std.ArrayListUnmanaged(Codepoint) = .{},
+    /// Per-cluster x anchors captured when a cluster first establishes its
+    /// cell offset. This lets out-of-order combining marks re-anchor to the
+    /// correct base cluster.
+    cluster_anchor_x: std.ArrayListUnmanaged(i32) = .{},
 
     /// Scratch reused for terminal bidi layout resolution.
     bidi_layout_scratch: itijah.VisualLayoutScratch = .{},
@@ -101,6 +116,7 @@ pub const Shaper = struct {
         self.cell_buf.deinit(self.alloc);
         self.alloc.free(self.hb_feats);
         self.codepoints.deinit(self.alloc);
+        self.cluster_anchor_x.deinit(self.alloc);
         self.bidi_layout_scratch.deinit(self.alloc);
     }
 
@@ -175,6 +191,10 @@ pub const Shaper = struct {
 
         // This keeps track of the cell starting x and cluster.
         var cell_offset: CellOffset = .{};
+        const anchor_sentinel = std.math.minInt(i32);
+        self.cluster_anchor_x.clearRetainingCapacity();
+        try self.cluster_anchor_x.ensureUnusedCapacity(self.alloc, run.cells);
+        self.cluster_anchor_x.appendNTimesAssumeCapacity(anchor_sentinel, run.cells);
 
         // Convert all our info/pos to cells and set it.
         self.cell_buf.clearRetainingCapacity();
@@ -185,6 +205,10 @@ pub const Shaper = struct {
             // Our cluster is also our cell X position. If the cluster changes
             // then we need to reset our current cell offsets.
             const cluster = self.codepoints.items[index].cluster;
+            const source_codepoint = self.codepoints.items[index].codepoint;
+            const is_combining_mark = source_codepoint != 0 and
+                unicode.table.get(@intCast(source_codepoint)).width_zero_in_grapheme;
+
             if (cell_offset.cluster != cluster) {
                 const is_after_glyph_from_current_or_next_clusters =
                     cluster <= run_offset.cluster;
@@ -226,13 +250,61 @@ pub const Shaper = struct {
                 // exceptions to this heuristic for detecting ligatures,
                 // but using the logging below seems to show it works
                 // well.)
-                if (is_first_codepoint_in_cluster and
-                    !is_after_glyph_from_current_or_next_clusters)
-                {
-                    cell_offset = .{
-                        .cluster = cluster,
-                        .x = run_offset.x,
-                    };
+                if (is_first_codepoint_in_cluster) {
+                    const should_reset = (run.rtl and !is_combining_mark) or
+                        !is_after_glyph_from_current_or_next_clusters;
+                    if (should_reset) {
+                        cell_offset = .{
+                            .cluster = cluster,
+                            .x = run_offset.x,
+                        };
+
+                        const cluster_i: usize = @intCast(cluster);
+                        if (cluster_i < self.cluster_anchor_x.items.len) {
+                            self.cluster_anchor_x.items[cluster_i] = run_offset.x;
+                        }
+                    }
+                } else if (!run.rtl and !is_combining_mark) {
+                    // In LTR scripts, a cluster's first codepoint can be
+                    // absent from the glyph stream (due to ligature
+                    // composition). If this is the first glyph we see for
+                    // that cluster, establish an anchor now.
+                    const cluster_i: usize = @intCast(cluster);
+                    if (cluster_i < self.cluster_anchor_x.items.len and
+                        self.cluster_anchor_x.items[cluster_i] == anchor_sentinel)
+                    {
+                        cell_offset = .{
+                            .cluster = cluster,
+                            .x = run_offset.x,
+                        };
+                        self.cluster_anchor_x.items[cluster_i] = run_offset.x;
+                    }
+                } else if (run.rtl and is_combining_mark) {
+                    const cluster_i: usize = @intCast(cluster);
+                    if (cluster_i < self.cluster_anchor_x.items.len) {
+                        const anchor_x = self.cluster_anchor_x.items[cluster_i];
+                        // Keep this scoped to Arabic RTL marks only: broadening
+                        // this fallback regresses scripts with out-of-order
+                        // vowels/marks (e.g. Chakma/Bengali tests).
+                        const allow_non_first_fallback = run.rtl and
+                            isArabicCombiningMark(source_codepoint);
+                        if (anchor_x != anchor_sentinel) {
+                            cell_offset = .{
+                                .cluster = cluster,
+                                .x = anchor_x,
+                            };
+                        } else if (allow_non_first_fallback) {
+                            // A non-first combining mark can still be emitted
+                            // before its base glyph in visual stream order.
+                            // If we don't have a prior anchor yet, establish
+                            // one at the current run offset.
+                            cell_offset = .{
+                                .cluster = cluster,
+                                .x = run_offset.x,
+                            };
+                            self.cluster_anchor_x.items[cluster_i] = run_offset.x;
+                        }
+                    }
                 }
             }
 
@@ -775,6 +847,99 @@ test "shape arabic RTL" {
         }
     }
     try testing.expectEqual(@as(usize, 1), count);
+}
+
+test "shape arabic with tashkeel on middle letters" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var testdata = try testShaperWithFont(alloc, .arabic);
+    defer testdata.deinit();
+
+    var t = try terminal.Terminal.init(alloc, .{ .cols = 30, .rows = 3 });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    try s.nextSlice("وفُكَّ");
+
+    var state: terminal.RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &t);
+
+    var shaper = &testdata.shaper;
+    var it = shaper.runIterator(.{
+        .grid = testdata.grid,
+        .cells = state.row_data.get(0).cells.slice(),
+    });
+
+    const run = (try it.next(alloc)).?;
+    try testing.expect(run.rtl);
+    try testing.expectEqual(@as(u16, 3), run.cells);
+
+    const cells = try shaper.shape(run);
+    try testing.expect(cells.len > 0);
+
+    var seen = [_]bool{ false, false, false };
+    for (cells) |cell| {
+        try testing.expect(cell.x < run.cells);
+        seen[cell.x] = true;
+    }
+    try testing.expect(seen[0]);
+    try testing.expect(seen[1]);
+    try testing.expect(seen[2]);
+
+    try testing.expectEqual(@as(?font.shape.TextRun, null), try it.next(alloc));
+}
+
+test "shape arabic tanween stays on hamza before space" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var testdata = try testShaperWithFont(alloc, .arabic);
+    defer testdata.deinit();
+
+    var t = try terminal.Terminal.init(alloc, .{ .cols = 30, .rows = 3 });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    try s.nextSlice("شيءٍ جميل");
+
+    var state: terminal.RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &t);
+
+    var shaper = &testdata.shaper;
+    var it = shaper.runIterator(.{
+        .grid = testdata.grid,
+        .cells = state.row_data.get(0).cells.slice(),
+    });
+
+    const run = (try it.next(alloc)).?;
+    try testing.expect(run.rtl);
+    try testing.expectEqual(@as(u16, 8), run.cells);
+
+    var hamza_cluster: ?u32 = null;
+    var tanween_cluster: ?u32 = null;
+    for (shaper.codepoints.items) |entry| {
+        if (entry.codepoint == 0x0621 and hamza_cluster == null) hamza_cluster = entry.cluster;
+        if (entry.codepoint == 0x064D and tanween_cluster == null) tanween_cluster = entry.cluster;
+    }
+    try testing.expect(hamza_cluster != null);
+    try testing.expect(tanween_cluster != null);
+    try testing.expectEqual(hamza_cluster.?, tanween_cluster.?);
+
+    const cells = try shaper.shape(run);
+    try testing.expect(cells.len > 0);
+
+    var hamza_cell_glyphs: usize = 0;
+    for (cells) |cell| {
+        if (cell.x == hamza_cluster.?) hamza_cell_glyphs += 1;
+    }
+    try testing.expect(hamza_cell_glyphs >= 2);
+
+    try testing.expectEqual(@as(?font.shape.TextRun, null), try it.next(alloc));
 }
 
 test "shape LTR then RTL splits at direction boundary" {
@@ -1558,6 +1723,126 @@ test "shape Bengali ligatures with out of order vowels" {
         try testing.expect(cells[2].x_offset < cells[3].x_offset);
     }
     try testing.expectEqual(@as(usize, 1), count);
+}
+
+test "shape Bengali sentence keeps base clusters anchored" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var testdata = testShaperWithDiscoveredFont(
+        alloc,
+        "Arial Unicode MS",
+    ) catch return error.SkipZigTest;
+    defer testdata.deinit();
+
+    var t = try terminal.Terminal.init(alloc, .{ .cols = 200, .rows = 3 });
+    defer t.deinit(alloc);
+
+    t.modes.set(.grapheme_cluster, true);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    try s.nextSlice("পছন্দের ভাষা টাইপ করা আরো সহজ করে তোলে৷ আরো জানুন");
+
+    var state: terminal.RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &t);
+
+    var shaper = &testdata.shaper;
+    var it = shaper.runIterator(.{
+        .grid = testdata.grid,
+        .cells = state.row_data.get(0).cells.slice(),
+    });
+
+    var saw_run = false;
+    while (try it.next(alloc)) |run| {
+        saw_run = true;
+
+        var expected = try alloc.alloc(bool, run.cells);
+        defer alloc.free(expected);
+        @memset(expected, false);
+
+        for (shaper.codepoints.items) |entry| {
+            if (entry.codepoint == 0) continue;
+            if (unicode.table.get(@intCast(entry.codepoint)).width_zero_in_grapheme) continue;
+            const cluster_i: usize = @intCast(entry.cluster);
+            if (cluster_i < expected.len) expected[cluster_i] = true;
+        }
+
+        const cells = try shaper.shape(run);
+        var actual = try alloc.alloc(bool, run.cells);
+        defer alloc.free(actual);
+        @memset(actual, false);
+
+        for (cells) |cell| {
+            if (cell.x < actual.len) actual[cell.x] = true;
+        }
+        for (expected, 0..) |need, i| {
+            if (need) try testing.expect(actual[i]);
+        }
+    }
+    try testing.expect(saw_run);
+}
+
+test "shape Bengali sentence in mixed-direction line keeps base clusters anchored" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var testdata = testShaperWithDiscoveredFont(
+        alloc,
+        "Arial Unicode MS",
+    ) catch return error.SkipZigTest;
+    defer testdata.deinit();
+
+    var t = try terminal.Terminal.init(alloc, .{ .cols = 220, .rows = 3 });
+    defer t.deinit(alloc);
+
+    t.modes.set(.grapheme_cluster, true);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    try s.nextSlice("ABC পছন্দের ভাষা টাইপ করা আরো সহজ করে তোলে৷ আরো জানুন مرحبا");
+
+    var state: terminal.RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &t);
+
+    var shaper = &testdata.shaper;
+    var it = shaper.runIterator(.{
+        .grid = testdata.grid,
+        .cells = state.row_data.get(0).cells.slice(),
+    });
+
+    var saw_bengali = false;
+    while (try it.next(alloc)) |run| {
+        var expected = try alloc.alloc(bool, run.cells);
+        defer alloc.free(expected);
+        @memset(expected, false);
+
+        var has_bengali = false;
+        for (shaper.codepoints.items) |entry| {
+            if (entry.codepoint == 0) continue;
+            if (entry.codepoint >= 0x0980 and entry.codepoint <= 0x09FF) has_bengali = true;
+            if (unicode.table.get(@intCast(entry.codepoint)).width_zero_in_grapheme) continue;
+            const cluster_i: usize = @intCast(entry.cluster);
+            if (cluster_i < expected.len) expected[cluster_i] = true;
+        }
+        if (!has_bengali) continue;
+        saw_bengali = true;
+
+        const cells = try shaper.shape(run);
+        var actual = try alloc.alloc(bool, run.cells);
+        defer alloc.free(actual);
+        @memset(actual, false);
+
+        for (cells) |cell| {
+            if (cell.x < actual.len) actual[cell.x] = true;
+        }
+        for (expected, 0..) |need, i| {
+            if (need) try testing.expect(actual[i]);
+        }
+    }
+    try testing.expect(saw_bengali);
 }
 
 test "shape box glyphs" {

--- a/src/font/shaper/harfbuzz.zig
+++ b/src/font/shaper/harfbuzz.zig
@@ -139,8 +139,11 @@ pub const Shaper = struct {
     ///
     /// If there is not enough space in the cell buffer, an error is returned.
     pub fn shape(self: *Shaper, run: font.shape.TextRun) ![]const font.shape.Cell {
-        // Set run direction before shaping so HarfBuzz applies the
-        // correct script-direction shaping behavior.
+        // RunIterator feeds codepoints to HarfBuzz in logical order for both
+        // LTR and RTL runs. The buffer direction tells HarfBuzz which script
+        // direction to use for Arabic/Hebrew joining, mark placement, and
+        // glyph ordering. prepare() resets to LTR for every run, so only the
+        // RTL path needs an override here.
         if (run.rtl) {
             self.hb_buf.setDirection(.rtl);
         }
@@ -183,8 +186,7 @@ pub const Shaper = struct {
         var cell_offset: CellOffset = .{};
         const anchor_sentinel = std.math.minInt(i32);
         self.cluster_anchor_x.clearRetainingCapacity();
-        try self.cluster_anchor_x.ensureUnusedCapacity(self.alloc, run.cells);
-        self.cluster_anchor_x.appendNTimesAssumeCapacity(anchor_sentinel, run.cells);
+        try self.cluster_anchor_x.appendNTimes(self.alloc, anchor_sentinel, run.cells);
 
         // Convert all our info/pos to cells and set it.
         self.cell_buf.clearRetainingCapacity();
@@ -192,8 +194,10 @@ pub const Shaper = struct {
             // info_v.cluster is the index into our codepoints array. We use it
             // to get the original cluster.
             const index = info_v.cluster;
-            // Our cluster is also our cell X position. If the cluster changes
-            // then we need to reset our current cell offsets.
+            // The cluster is the terminal cell this glyph belongs to. In
+            // RTL runs those cluster values can appear in decreasing
+            // visual order, and combining marks may arrive before the
+            // base glyph that establishes the final cell anchor.
             const cluster = self.codepoints.items[index].cluster;
             const source_codepoint = self.codepoints.items[index].codepoint;
             const is_combining_mark = source_codepoint != 0 and
@@ -273,9 +277,10 @@ pub const Shaper = struct {
                     const cluster_i: usize = @intCast(cluster);
                     if (cluster_i < self.cluster_anchor_x.items.len) {
                         const anchor_x = self.cluster_anchor_x.items[cluster_i];
-                        // Keep this scoped to Arabic RTL marks only: broadening
-                        // this fallback regresses scripts with out-of-order
-                        // vowels/marks (e.g. Chakma/Bengali tests).
+                        // Keep this scoped to Arabic RTL marks only. Other
+                        // scripts can also emit marks out of logical order, but
+                        // they do not all want the Arabic "attach back to base
+                        // cell" fallback.
                         const allow_non_first_fallback =
                             bidi_helpers.isArabicCombiningMark(source_codepoint);
                         if (anchor_x != anchor_sentinel) {
@@ -328,6 +333,8 @@ pub const Shaper = struct {
         }
         //log.warn("----------------", .{});
 
+        // RTL glyphs are produced in visual order, but Ghostty's renderer
+        // expects the returned cells sorted by increasing terminal x.
         if (run.rtl) {
             std.mem.sort(font.shape.Cell, self.cell_buf.items, {}, struct {
                 fn lt(_: void, a: font.shape.Cell, b: font.shape.Cell) bool {

--- a/src/font/shaper/harfbuzz.zig
+++ b/src/font/shaper/harfbuzz.zig
@@ -858,7 +858,7 @@ test "shape hebrew RTL" {
 
     var s = t.vtStream();
     defer s.deinit();
-    try s.nextSlice("שלום עולם");
+    s.nextSlice("שלום עולם");
 
     var state: terminal.RenderState = .empty;
     defer state.deinit(alloc);
@@ -890,6 +890,76 @@ test "shape hebrew RTL" {
     try testing.expectEqual(@as(usize, 1), count);
 }
 
+// Regression test for the `base_dir = .auto_ltr` paragraph-direction fix
+// in run.zig. Under a forced LTR base direction (the old behavior), the
+// trailing ASCII punctuation `?` in an RTL-leading row resolves to an LTR
+// embedding level via UAX #9 N2 (because `eos` falls back to base_level=0=L,
+// N1 does not match, and the neutral adopts the embedding direction). The
+// `?` then splits off into a separate LTR visual run and lands at the
+// visual-left of the row, ahead of the Hebrew text.
+//
+// With `base_dir = .auto_ltr`, UAX #9 P2-P3 sees the first strong character
+// `ש` (Bidi_Class=R) and sets base_level=1 (RTL). The trailing `?` now has
+// `eos=R`, N1 matches the surrounding Hebrew, the neutral resolves to R,
+// and it stays in the same RTL visual run as the Hebrew — appearing at the
+// visual-right (end of the sentence), where a user expects it.
+//
+// This test pins that behavior: the row must produce a single RTL run
+// covering the full input (including the trailing `?`), not a split with
+// the `?` in a separate LTR run.
+test "shape hebrew RTL with trailing punctuation at visual-right" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var testdata = try testShaperWithFont(alloc, .julia_mono);
+    defer testdata.deinit();
+
+    var t = try terminal.Terminal.init(alloc, .{ .cols = 30, .rows = 3 });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    s.nextSlice("שלום, עולם! מה שלומך?");
+
+    var state: terminal.RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &t);
+
+    var shaper = &testdata.shaper;
+    var it = shaper.runIterator(.{
+        .grid = testdata.grid,
+        .cells = state.row_data.get(0).cells.slice(),
+    });
+
+    // "שלום, עולם! מה שלומך?" = 21 codepoints/cells.
+    const expected_cells: u16 = 21;
+
+    var count: usize = 0;
+    while (try it.next(alloc)) |run| {
+        count += 1;
+        try testing.expect(run.rtl);
+        try testing.expectEqual(expected_cells, run.cells);
+
+        const cells = try shaper.shape(run);
+        try testing.expect(cells.len > 1);
+
+        // Shaped cells must all fall within the run and be in monotonic
+        // (non-decreasing) x order, as the renderer requires.
+        var x: u16 = cells[0].x;
+        try testing.expect(x < run.cells);
+        for (cells[1..]) |cell| {
+            try testing.expect(cell.x < run.cells);
+            try testing.expect(cell.x >= x);
+            x = cell.x;
+        }
+    }
+
+    // A single RTL run means the trailing `?` stayed with the Hebrew.
+    // Under the old forced-LTR base direction this would be 2+ runs
+    // (the `?` splits off into a separate LTR run).
+    try testing.expectEqual(@as(usize, 1), count);
+}
+
 test "shape arabic with tashkeel on middle letters" {
     const testing = std.testing;
     const alloc = testing.allocator;
@@ -902,7 +972,7 @@ test "shape arabic with tashkeel on middle letters" {
 
     var s = t.vtStream();
     defer s.deinit();
-    try s.nextSlice("وفُكَّ");
+    s.nextSlice("وفُكَّ");
 
     var state: terminal.RenderState = .empty;
     defer state.deinit(alloc);
@@ -945,7 +1015,7 @@ test "shape arabic tanween stays on hamza before space" {
 
     var s = t.vtStream();
     defer s.deinit();
-    try s.nextSlice("شيءٍ جميل");
+    s.nextSlice("شيءٍ جميل");
 
     var state: terminal.RenderState = .empty;
     defer state.deinit(alloc);
@@ -995,7 +1065,7 @@ test "shape arabic end tashkeel no overlap" {
 
     var s = t.vtStream();
     defer s.deinit();
-    try s.nextSlice("بحقِّ");
+    s.nextSlice("بحقِّ");
 
     var state: terminal.RenderState = .empty;
     defer state.deinit(alloc);
@@ -1066,7 +1136,7 @@ test "shape arabic end tanween no overlap" {
 
     var s = t.vtStream();
     defer s.deinit();
-    try s.nextSlice("عينٍ");
+    s.nextSlice("عينٍ");
 
     var state: terminal.RenderState = .empty;
     defer state.deinit(alloc);
@@ -1133,7 +1203,7 @@ test "shape arabic multiword end tashkeel stays anchored" {
 
     var s = t.vtStream();
     defer s.deinit();
-    try s.nextSlice("الحيِّ الذي");
+    s.nextSlice("الحيِّ الذي");
 
     var state: terminal.RenderState = .empty;
     defer state.deinit(alloc);
@@ -1210,7 +1280,7 @@ test "shape LTR then RTL splits at direction boundary" {
 
     var s = t.vtStream();
     defer s.deinit();
-    try s.nextSlice("Hello مرحبا");
+    s.nextSlice("Hello مرحبا");
 
     var state: terminal.RenderState = .empty;
     defer state.deinit(alloc);
@@ -1248,7 +1318,7 @@ test "shape digits between RTL split into LTR run" {
 
     var s = t.vtStream();
     defer s.deinit();
-    try s.nextSlice("عدد 123 نص");
+    s.nextSlice("عدد 123 نص");
 
     var state: terminal.RenderState = .empty;
     defer state.deinit(alloc);
@@ -1998,7 +2068,7 @@ test "shape Bengali sentence keeps base clusters anchored" {
 
     var s = t.vtStream();
     defer s.deinit();
-    try s.nextSlice("পছন্দের ভাষা টাইপ করা আরো সহজ করে তোলে৷ আরো জানুন");
+    s.nextSlice("পছন্দের ভাষা টাইপ করা আরো সহজ করে তোলে৷ আরো জানুন");
 
     var state: terminal.RenderState = .empty;
     defer state.deinit(alloc);
@@ -2057,7 +2127,7 @@ test "shape Bengali sentence in mixed-direction line keeps base clusters anchore
 
     var s = t.vtStream();
     defer s.deinit();
-    try s.nextSlice("ABC পছন্দের ভাষা টাইপ করা আরো সহজ করে তোলে৷ আরো জানুন مرحبا");
+    s.nextSlice("ABC পছন্দের ভাষা টাইপ করা আরো সহজ করে তোলে৷ আরো জানুন مرحبا");
 
     var state: terminal.RenderState = .empty;
     defer state.deinit(alloc);

--- a/src/font/shaper/noop.zig
+++ b/src/font/shaper/noop.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
+const itijah = @import("itijah");
 const font = @import("../main.zig");
 const Face = font.Face;
 const Collection = font.Collection;
@@ -25,6 +26,9 @@ pub const Shaper = struct {
 
     /// The shared memory used for shaping results.
     cell_buf: CellBuf,
+
+    /// Scratch reused for terminal bidi layout resolution.
+    bidi_layout_scratch: itijah.VisualLayoutScratch = .{},
 
     const CellBuf = std.ArrayListUnmanaged(font.shape.Cell);
     const CodepointList = std.ArrayListUnmanaged(Codepoint);
@@ -60,6 +64,7 @@ pub const Shaper = struct {
     pub fn deinit(self: *Shaper) void {
         self.cell_buf.deinit(self.alloc);
         self.run_state.deinit(self.alloc);
+        self.bidi_layout_scratch.deinit(self.alloc);
     }
 
     pub fn endFrame(self: *const Shaper) void {
@@ -134,6 +139,10 @@ pub const Shaper = struct {
 
         pub fn finalize(self: RunIteratorHook) !void {
             _ = self;
+        }
+
+        pub fn bidiLayoutScratch(self: RunIteratorHook) *itijah.VisualLayoutScratch {
+            return &self.shaper.bidi_layout_scratch;
         }
     };
 };

--- a/src/font/shaper/run.zig
+++ b/src/font/shaper/run.zig
@@ -60,6 +60,8 @@ pub const RunIterator = struct {
     // Visual cursor within the trimmed row.
     i: usize = 0,
     // Cached row layout derived once per iterator.
+    // visual_runs is a slice owned by the scratch buffer from bidiLayoutScratch();
+    // it remains valid as long as the scratch is not reused (i.e. within a single frame).
     layout_ready: bool = false,
     max: usize = 0,
     visual_runs: []const VisualRun = &.{},
@@ -191,40 +193,13 @@ pub const RunIterator = struct {
                     }
                 }
 
-                // We need to find a font that supports this character.
-                const font_info: struct {
-                    idx: font.Collection.Index,
-                    fallback: ?u32 = null,
-                } = font_info: {
-                    if (try self.indexForCell(
-                        alloc,
-                        cell,
-                        graphemes[logical_j],
-                        run_font_style,
-                        presentation,
-                    )) |idx| break :font_info .{ .idx = idx };
-
-                    // Otherwise we need a fallback character. Prefer the
-                    // official replacement character.
-                    if (try self.opts.grid.getIndex(
-                        alloc,
-                        0xFFFD, // replacement char
-                        run_font_style,
-                        presentation,
-                    )) |idx| break :font_info .{ .idx = idx, .fallback = 0xFFFD };
-
-                    // Fallback to space.
-                    if (try self.opts.grid.getIndex(
-                        alloc,
-                        ' ',
-                        run_font_style,
-                        presentation,
-                    )) |idx| break :font_info .{ .idx = idx, .fallback = ' ' };
-
-                    // We can't render at all. This is a bug, we should always
-                    // have a font that can render a space.
-                    unreachable;
-                };
+                const font_info = try self.resolveFontInfo(
+                    alloc,
+                    cell,
+                    graphemes[logical_j],
+                    run_font_style,
+                    presentation,
+                );
 
                 if (!have_font) {
                     current_font = font_info.idx;
@@ -281,34 +256,13 @@ pub const RunIterator = struct {
 
                 const presentation = presentationForCell(cell, graphemes[logical_j]);
 
-                const font_info: struct {
-                    idx: font.Collection.Index,
-                    fallback: ?u32 = null,
-                } = font_info: {
-                    if (try self.indexForCell(
-                        alloc,
-                        cell,
-                        graphemes[logical_j],
-                        run_font_style,
-                        presentation,
-                    )) |idx| break :font_info .{ .idx = idx };
-
-                    if (try self.opts.grid.getIndex(
-                        alloc,
-                        0xFFFD, // replacement char
-                        run_font_style,
-                        presentation,
-                    )) |idx| break :font_info .{ .idx = idx, .fallback = 0xFFFD };
-
-                    if (try self.opts.grid.getIndex(
-                        alloc,
-                        ' ',
-                        run_font_style,
-                        presentation,
-                    )) |idx| break :font_info .{ .idx = idx, .fallback = ' ' };
-
-                    unreachable;
-                };
+                const font_info = try self.resolveFontInfo(
+                    alloc,
+                    cell,
+                    graphemes[logical_j],
+                    run_font_style,
+                    presentation,
+                );
 
                 if (font_info.idx != current_font) {
                     const cp = cell.codepoint();
@@ -495,6 +449,37 @@ pub const RunIterator = struct {
         }
 
         return null;
+    }
+
+    const FontInfo = struct {
+        idx: font.Collection.Index,
+        fallback: ?u32 = null,
+    };
+
+    /// Resolve which font to use for a cell, falling back to the replacement
+    /// character or space if the cell's glyph is unavailable.
+    fn resolveFontInfo(
+        self: *RunIterator,
+        alloc: Allocator,
+        cell: *const terminal.Cell,
+        graphemes: []const u21,
+        style: font.Style,
+        presentation: ?font.Presentation,
+    ) !FontInfo {
+        if (try self.indexForCell(alloc, cell, graphemes, style, presentation)) |idx|
+            return .{ .idx = idx };
+
+        // Prefer the official replacement character.
+        if (try self.opts.grid.getIndex(alloc, 0xFFFD, style, presentation)) |idx|
+            return .{ .idx = idx, .fallback = 0xFFFD };
+
+        // Fallback to space.
+        if (try self.opts.grid.getIndex(alloc, ' ', style, presentation)) |idx|
+            return .{ .idx = idx, .fallback = ' ' };
+
+        // We can't render at all. This is a bug, we should always
+        // have a font that can render a space.
+        unreachable;
     }
 };
 

--- a/src/font/shaper/run.zig
+++ b/src/font/shaper/run.zig
@@ -4,8 +4,20 @@ const Allocator = std.mem.Allocator;
 const font = @import("../main.zig");
 const shape = @import("../shape.zig");
 const terminal = @import("../../terminal/main.zig");
+const itijah = @import("itijah");
 const autoHash = std.hash.autoHash;
 const Hasher = std.hash.Wyhash;
+const VisualRun = itijah.VisualRun;
+
+/// Classify a codepoint by bidi strength.
+/// Returns null for neutrals (spaces/punctuation).
+fn codepointIsRtl(cp: u32) ?bool {
+    return switch (itijah.unicode.bidiClass(@intCast(cp))) {
+        .right_to_left, .right_to_left_arabic => true,
+        .left_to_right, .european_number, .arabic_number => false,
+        else => null,
+    };
+}
 
 /// A single text run. A text run is only valid for one Shaper instance and
 /// until the next run is created. A text run never goes across multiple
@@ -36,12 +48,16 @@ pub const TextRun = struct {
 
     /// The font index to use for the glyphs of this run.
     font_index: font.Collection.Index,
+
+    /// Whether this run is RTL according to visual runs from the bidi resolver.
+    rtl: bool = false,
 };
 
 /// RunIterator is an iterator that yields text runs.
 pub const RunIterator = struct {
     hooks: font.Shaper.RunIteratorHook,
     opts: shape.RunOptions,
+    // Visual cursor within the trimmed row.
     i: usize = 0,
 
     pub fn next(self: *RunIterator, alloc: Allocator) !?TextRun {
@@ -60,247 +76,353 @@ pub const RunIterator = struct {
             break :max 0;
         };
 
-        // Invisible cells don't have any glyphs rendered,
-        // so we explicitly skip them in the shaping process.
-        while (self.i < max and
-            (cells[self.i].hasStyling() and
-                styles[self.i].flags.invisible)) self.i += 1;
+        if (max == 0) return null;
 
-        // We're over at the max
+        // We're over at the max.
         if (self.i >= max) return null;
 
-        // Track the font for our current run
-        var current_font: font.Collection.Index = .{};
-
-        // Allow the hook to prepare
-        self.hooks.prepare();
-
-        // Initialize our hash for this run.
-        var hasher = Hasher.init(0);
-
-        // Let's get our style that we'll expect for the run.
-        const style: terminal.Style = if (cells[self.i].hasStyling()) styles[self.i] else .{};
-
-        // Go through cell by cell and accumulate while we build our run.
-        var j: usize = self.i;
-        while (j < max) : (j += 1) {
-            // Use relative cluster positions (offset from run start) to make
-            // the shaping cache position-independent. This ensures that runs
-            // with identical content but different starting positions in the
-            // row produce the same hash, enabling cache reuse.
-            const cluster = j - self.i;
-            const cell: *const terminal.page.Cell = &cells[j];
-
-            // If we have a selection and we're at a boundary point, then
-            // we break the run here.
-            if (self.opts.selection) |bounds| {
-                if (j > self.i) {
-                    if (bounds[0] > 0 and j == bounds[0]) break;
-                    if (bounds[1] > 0 and j == bounds[1] + 1) break;
-                }
-            }
-
-            // If we're a spacer, then we ignore it
-            switch (cell.wide) {
-                .narrow, .wide => {},
-                .spacer_head, .spacer_tail => continue,
-            }
-
-            // If our cell attributes are changing, then we split the run.
-            // This prevents a single glyph for ">=" to be rendered with
-            // one color when the two components have different styling.
-            if (j > self.i) style: {
-                const prev_cell = cells[j - 1];
-
-                // If the prev cell and this cell are both plain
-                // codepoints then we check if they are commonly "bad"
-                // ligatures and spit the run if they are.
-                if (prev_cell.content_tag == .codepoint and
-                    cell.content_tag == .codepoint)
-                {
-                    const prev_cp = prev_cell.codepoint();
-                    switch (prev_cp) {
-                        // fl, fi
-                        'f' => {
-                            const cp = cell.codepoint();
-                            if (cp == 'l' or cp == 'i') break;
-                        },
-
-                        // st
-                        's' => {
-                            const cp = cell.codepoint();
-                            if (cp == 't') break;
-                        },
-
-                        else => {},
-                    }
-                }
-
-                // If the style is exactly the change then fast path out.
-                if (prev_cell.style_id == cell.style_id) break :style;
-
-                // The style is different. We allow differing background
-                // styles but any other change results in a new run.
-                const c1 = comparableStyle(style);
-                const c2 = comparableStyle(if (cell.hasStyling()) styles[j] else .{});
-                if (!c1.eql(c2)) break;
-            }
-
-            // Text runs break when font styles change so we need to get
-            // the proper style.
-            const font_style: font.Style = style: {
-                if (style.flags.bold) {
-                    if (style.flags.italic) break :style .bold_italic;
-                    break :style .bold;
-                }
-
-                if (style.flags.italic) break :style .italic;
-                break :style .regular;
-            };
-
-            // Determine the presentation format for this glyph.
-            const presentation: ?font.Presentation = if (cell.hasGrapheme()) p: {
-                // We only check the FIRST codepoint because I believe the
-                // presentation format must be directly adjacent to the codepoint.
-                const cps = graphemes[j];
-                assert(cps.len > 0);
-                if (cps[0] == 0xFE0E) break :p .text;
-                if (cps[0] == 0xFE0F) break :p .emoji;
-                break :p null;
-            } else emoji: {
-                // If we're not a grapheme, our individual char could be
-                // an emoji so we want to check if we expect emoji presentation.
-                // The font grid indexForCodepoint we use below will do this
-                // automatically.
-                break :emoji null;
-            };
-
-            // If our cursor is on this line then we break the run around the
-            // cursor. This means that any row with a cursor has at least
-            // three breaks: before, exactly the cursor, and after.
-            //
-            // We do not break a cell that is exactly the grapheme. If there
-            // are cells following that contain joiners, we allow those to
-            // break. This creates an effect where hovering over an emoji
-            // such as a skin-tone emoji is fine, but hovering over the
-            // joiners will show the joiners allowing you to modify the
-            // emoji.
-            if (!cell.hasGrapheme()) {
-                if (self.opts.cursor_x) |cursor_x| {
-                    // Exactly: self.i is the cursor and we iterated once. This
-                    // means that we started exactly at the cursor and did at
-                    // exactly one iteration. Why exactly one? Because we may
-                    // start at our cursor but do many if our cursor is exactly
-                    // on an emoji.
-                    if (self.i == cursor_x and j == self.i + 1) break;
-
-                    // Before: up to and not including the cursor. This means
-                    // that we started before the cursor (self.i < cursor_x)
-                    // and j is now at the cursor meaning we haven't yet processed
-                    // the cursor.
-                    if (self.i < cursor_x and j == cursor_x) {
-                        assert(j > 0);
-                        break;
-                    }
-
-                    // After: after the cursor. We don't need to do anything
-                    // special, we just let the run complete.
-                }
-            }
-
-            // We need to find a font that supports this character. If
-            // there are additional zero-width codepoints (to form a single
-            // grapheme, i.e. combining characters), we need to find a font
-            // that supports all of them.
-            const font_info: struct {
-                idx: font.Collection.Index,
-                fallback: ?u32 = null,
-            } = font_info: {
-                // If we find a font that supports this entire grapheme
-                // then we use that.
-                if (try self.indexForCell(
-                    alloc,
-                    cell,
-                    graphemes[j],
-                    font_style,
-                    presentation,
-                )) |idx| break :font_info .{ .idx = idx };
-
-                // Otherwise we need a fallback character. Prefer the
-                // official replacement character.
-                if (try self.opts.grid.getIndex(
-                    alloc,
-                    0xFFFD, // replacement char
-                    font_style,
-                    presentation,
-                )) |idx| break :font_info .{ .idx = idx, .fallback = 0xFFFD };
-
-                // Fallback to space
-                if (try self.opts.grid.getIndex(
-                    alloc,
-                    ' ',
-                    font_style,
-                    presentation,
-                )) |idx| break :font_info .{ .idx = idx, .fallback = ' ' };
-
-                // We can't render at all. This is a bug, we should always
-                // have a font that can render a space.
-                unreachable;
-            };
-
-            //log.warn("char={x} info={}", .{ cell.char, font_info });
-            if (j == self.i) current_font = font_info.idx;
-
-            // If our fonts are not equal, then we're done with our run.
-            if (font_info.idx != current_font) break;
-
-            // If we're a fallback character, add that and continue; we
-            // don't want to add the entire grapheme.
-            if (font_info.fallback) |cp| {
-                try self.addCodepoint(&hasher, cp, @intCast(cluster));
-                continue;
-            }
-
-            // If we're a Kitty unicode placeholder then we add a blank.
-            if (cell.codepoint() == terminal.kitty.graphics.unicode.placeholder) {
-                try self.addCodepoint(&hasher, ' ', @intCast(cluster));
-                continue;
-            }
-
-            // Add all the codepoints for our grapheme
-            try self.addCodepoint(
-                &hasher,
-                if (cell.codepoint() == 0) ' ' else cell.codepoint(),
-                @intCast(cluster),
-            );
-            if (cell.hasGrapheme()) {
-                for (graphemes[j]) |cp| {
-                    // Do not send presentation modifiers
-                    if (cp == 0xFE0E or cp == 0xFE0F) continue;
-                    try self.addCodepoint(&hasher, cp, @intCast(cluster));
-                }
-            }
+        // Build bidi inputs from logical cells and derive visual runs in a
+        // paragraph that is always anchored LTR (terminal line model).
+        var bidi_codepoints = try alloc.alloc(u21, max);
+        defer alloc.free(bidi_codepoints);
+        for (cells[0..max], 0..) |cell, i| {
+            bidi_codepoints[i] = bidiCodepoint(cell);
         }
 
-        // Finalize our buffer
-        self.hooks.finalize();
+        var layout = try itijah.resolveVisualLayout(alloc, bidi_codepoints, .{
+            .base_dir = .ltr,
+        });
+        defer layout.deinit();
+        const visual_runs = layout.runs;
+        if (visual_runs.len == 0) return null;
 
-        // Add our length to the hash as an additional mechanism to avoid collisions
-        autoHash(&hasher, j - self.i);
+        // Invisible cells don't have any glyphs rendered, so we skip them.
+        while (self.i < max) {
+            const vr = findVisualRun(visual_runs, self.i) orelse break;
+            const logical_i: usize = @intCast(itijah.logicalIndexForVisual(vr, @intCast(self.i)));
+            if (!(cells[logical_i].hasStyling() and styles[logical_i].flags.invisible)) break;
+            self.i += 1;
+        }
+        if (self.i >= max) return null;
 
-        // Add our font index
-        autoHash(&hasher, current_font);
+        while (self.i < max) {
+            const bidi_run = findVisualRun(visual_runs, self.i) orelse return null;
+            const bidi_run_start: usize = @intCast(bidi_run.visual_start);
+            const bidi_run_end: usize = bidi_run_start + @as(usize, @intCast(bidi_run.len));
+            assert(self.i >= bidi_run_start and self.i < bidi_run_end);
 
-        // Move our cursor. Must defer since we use self.i below.
-        defer self.i = j;
+            // Track the font for our current run.
+            var current_font: font.Collection.Index = .{};
+            var have_font = false;
 
-        return .{
-            .hash = hasher.final(),
-            .offset = @intCast(self.i),
-            .cells = @intCast(j - self.i),
-            .grid = self.opts.grid,
-            .font_index = current_font,
-        };
+            const rtl = bidi_run.is_rtl;
+
+            // Style is anchored to the first visual cell in this candidate run.
+            const start_logical: usize = @intCast(itijah.logicalIndexForVisual(
+                bidi_run,
+                @intCast(self.i),
+            ));
+            const style: terminal.Style = if (cells[start_logical].hasStyling())
+                styles[start_logical]
+            else
+                .{};
+
+            // Find the run boundary in visual order.
+            var j: usize = self.i;
+            while (j < bidi_run_end) : (j += 1) {
+                const logical_j: usize = @intCast(itijah.logicalIndexForVisual(
+                    bidi_run,
+                    @intCast(j),
+                ));
+                const cell: *const terminal.page.Cell = &cells[logical_j];
+
+                // If we have a selection and we're at a boundary point, then
+                // we break the run here.
+                if (self.opts.selection) |bounds| {
+                    if (j > self.i) {
+                        if (bounds[0] > 0 and j == bounds[0]) break;
+                        if (bounds[1] > 0 and j == bounds[1] + 1) break;
+                    }
+                }
+
+                // If we're a spacer, then we ignore it.
+                switch (cell.wide) {
+                    .narrow, .wide => {},
+                    .spacer_head, .spacer_tail => continue,
+                }
+
+                // If our cell attributes are changing, then we split the run.
+                // This prevents a single glyph for ">=" to be rendered with
+                // one color when the two components have different styling.
+                if (j > self.i) style_change: {
+                    const prev_logical: usize = @intCast(itijah.logicalIndexForVisual(
+                        bidi_run,
+                        @intCast(j - 1),
+                    ));
+                    const prev_cell = cells[prev_logical];
+
+                    // If the prev cell and this cell are both plain
+                    // codepoints then we check if they are commonly "bad"
+                    // ligatures and split the run if they are.
+                    if (prev_cell.content_tag == .codepoint and
+                        cell.content_tag == .codepoint)
+                    {
+                        const prev_cp = prev_cell.codepoint();
+                        switch (prev_cp) {
+                            // fl, fi
+                            'f' => {
+                                const cp = cell.codepoint();
+                                if (cp == 'l' or cp == 'i') break;
+                            },
+
+                            // st
+                            's' => {
+                                const cp = cell.codepoint();
+                                if (cp == 't') break;
+                            },
+
+                            else => {},
+                        }
+                    }
+
+                    // If the style is exactly the change then fast path out.
+                    if (prev_cell.style_id == cell.style_id) break :style_change;
+
+                    // The style is different. We allow differing background
+                    // styles but any other change results in a new run.
+                    const c1 = comparableStyle(style);
+                    const c2 = comparableStyle(if (cell.hasStyling()) styles[logical_j] else .{});
+                    if (!c1.eql(c2)) break;
+                }
+
+                // Text runs break when font styles change so we need to get
+                // the proper style.
+                const font_style: font.Style = style_id: {
+                    if (style.flags.bold) {
+                        if (style.flags.italic) break :style_id .bold_italic;
+                        break :style_id .bold;
+                    }
+
+                    if (style.flags.italic) break :style_id .italic;
+                    break :style_id .regular;
+                };
+
+                // Determine the presentation format for this glyph.
+                const presentation: ?font.Presentation = if (cell.hasGrapheme()) p: {
+                    // We only check the FIRST codepoint because the
+                    // presentation format must be directly adjacent to
+                    // the codepoint.
+                    const cps = graphemes[logical_j];
+                    assert(cps.len > 0);
+                    if (cps[0] == 0xFE0E) break :p .text;
+                    if (cps[0] == 0xFE0F) break :p .emoji;
+                    break :p null;
+                } else null;
+
+                // If our cursor is on this line then we break the run around
+                // the cursor.
+                if (!cell.hasGrapheme()) {
+                    if (self.opts.cursor_x) |cursor_x| {
+                        if (self.i == cursor_x and j == self.i + 1) break;
+                        if (self.i < cursor_x and j == cursor_x) {
+                            assert(j > 0);
+                            break;
+                        }
+                    }
+                }
+
+                // We need to find a font that supports this character.
+                const font_info: struct {
+                    idx: font.Collection.Index,
+                    fallback: ?u32 = null,
+                } = font_info: {
+                    if (try self.indexForCell(
+                        alloc,
+                        cell,
+                        graphemes[logical_j],
+                        font_style,
+                        presentation,
+                    )) |idx| break :font_info .{ .idx = idx };
+
+                    // Otherwise we need a fallback character. Prefer the
+                    // official replacement character.
+                    if (try self.opts.grid.getIndex(
+                        alloc,
+                        0xFFFD, // replacement char
+                        font_style,
+                        presentation,
+                    )) |idx| break :font_info .{ .idx = idx, .fallback = 0xFFFD };
+
+                    // Fallback to space.
+                    if (try self.opts.grid.getIndex(
+                        alloc,
+                        ' ',
+                        font_style,
+                        presentation,
+                    )) |idx| break :font_info .{ .idx = idx, .fallback = ' ' };
+
+                    // We can't render at all. This is a bug, we should always
+                    // have a font that can render a space.
+                    unreachable;
+                };
+
+                if (!have_font) {
+                    current_font = font_info.idx;
+                    have_font = true;
+                }
+
+                // If our fonts are not equal, then we're done with our run —
+                // UNLESS the codepoint is neutral (space, punctuation) and
+                // the current run's font also supports it.
+                if (font_info.idx != current_font) {
+                    const cp = cell.codepoint();
+                    const is_neutral_in_current_font = cp != 0 and
+                        codepointIsRtl(cp) == null and
+                        self.opts.grid.hasCodepoint(current_font, cp, presentation);
+                    if (!is_neutral_in_current_font) break;
+                }
+            }
+
+            // Defensive: ensure forward progress.
+            if (j == self.i) {
+                self.i += 1;
+                continue;
+            }
+
+            // A run with only spacer cells can occur in edge cases; skip it.
+            if (!have_font) {
+                self.i = j;
+                continue;
+            }
+
+            const logical_range = itijah.logicalRangeForVisualSlice(
+                bidi_run,
+                @intCast(self.i),
+                @intCast(j),
+            );
+            const logical_start: usize = @intCast(logical_range.start);
+            const logical_end: usize = @intCast(logical_range.end);
+
+            // Prepare the shaping backend and build the run contents in LOGICAL
+            // order for shaping correctness.
+            self.hooks.prepare();
+            defer self.hooks.finalize();
+
+            var hasher = Hasher.init(0);
+            for (logical_start..logical_end) |logical_j| {
+                const visual_idx = itijah.visualIndexForLogical(bidi_run, @intCast(logical_j));
+                const cluster: u32 = visual_idx - @as(u32, @intCast(self.i));
+                const cell: *const terminal.page.Cell = &cells[logical_j];
+
+                switch (cell.wide) {
+                    .narrow, .wide => {},
+                    .spacer_head, .spacer_tail => continue,
+                }
+
+                const font_style: font.Style = style_id: {
+                    if (style.flags.bold) {
+                        if (style.flags.italic) break :style_id .bold_italic;
+                        break :style_id .bold;
+                    }
+
+                    if (style.flags.italic) break :style_id .italic;
+                    break :style_id .regular;
+                };
+
+                const presentation: ?font.Presentation = if (cell.hasGrapheme()) p: {
+                    const cps = graphemes[logical_j];
+                    assert(cps.len > 0);
+                    if (cps[0] == 0xFE0E) break :p .text;
+                    if (cps[0] == 0xFE0F) break :p .emoji;
+                    break :p null;
+                } else null;
+
+                const font_info: struct {
+                    idx: font.Collection.Index,
+                    fallback: ?u32 = null,
+                } = font_info: {
+                    if (try self.indexForCell(
+                        alloc,
+                        cell,
+                        graphemes[logical_j],
+                        font_style,
+                        presentation,
+                    )) |idx| break :font_info .{ .idx = idx };
+
+                    if (try self.opts.grid.getIndex(
+                        alloc,
+                        0xFFFD, // replacement char
+                        font_style,
+                        presentation,
+                    )) |idx| break :font_info .{ .idx = idx, .fallback = 0xFFFD };
+
+                    if (try self.opts.grid.getIndex(
+                        alloc,
+                        ' ',
+                        font_style,
+                        presentation,
+                    )) |idx| break :font_info .{ .idx = idx, .fallback = ' ' };
+
+                    unreachable;
+                };
+
+                if (font_info.idx != current_font) {
+                    const cp = cell.codepoint();
+                    const is_neutral_in_current_font = cp != 0 and
+                        codepointIsRtl(cp) == null and
+                        self.opts.grid.hasCodepoint(current_font, cp, presentation);
+                    if (!is_neutral_in_current_font) unreachable;
+                }
+
+                // If we're a fallback character and that fallback is in the
+                // current run font, add it directly.
+                if (font_info.fallback) |cp| {
+                    if (font_info.idx == current_font) {
+                        try self.addCodepoint(&hasher, cp, cluster);
+                        continue;
+                    }
+                }
+
+                // If we're a Kitty unicode placeholder then we add a blank.
+                if (cell.codepoint() == terminal.kitty.graphics.unicode.placeholder) {
+                    try self.addCodepoint(&hasher, ' ', cluster);
+                    continue;
+                }
+
+                // Add all the codepoints for our grapheme.
+                try self.addCodepoint(
+                    &hasher,
+                    if (cell.codepoint() == 0) ' ' else cell.codepoint(),
+                    cluster,
+                );
+                if (cell.hasGrapheme()) {
+                    for (graphemes[logical_j]) |cp| {
+                        // Do not send presentation modifiers.
+                        if (cp == 0xFE0E or cp == 0xFE0F) continue;
+                        try self.addCodepoint(&hasher, cp, cluster);
+                    }
+                }
+            }
+
+            // Add our length to the hash as an additional mechanism to avoid collisions.
+            autoHash(&hasher, j - self.i);
+            autoHash(&hasher, current_font);
+            autoHash(&hasher, rtl);
+
+            const run_offset = self.i;
+            self.i = j;
+
+            return .{
+                .hash = hasher.final(),
+                .offset = @intCast(run_offset),
+                .cells = @intCast(j - run_offset),
+                .grid = self.opts.grid,
+                .font_index = current_font,
+                .rtl = rtl,
+            };
+        }
+
+        return null;
     }
 
     fn addCodepoint(self: *RunIterator, hasher: anytype, cp: u32, cluster: u32) !void {
@@ -394,6 +516,21 @@ pub const RunIterator = struct {
         return null;
     }
 };
+
+fn bidiCodepoint(cell: terminal.page.Cell) u21 {
+    const cp = cell.codepoint();
+    return @intCast(if (cp == 0) ' ' else cp);
+}
+
+fn findVisualRun(visual_runs: []const VisualRun, visual_index: usize) ?VisualRun {
+    for (visual_runs) |run| {
+        const start: usize = @intCast(run.visual_start);
+        const end: usize = @intCast(run.visualEnd());
+        if (visual_index >= start and visual_index < end) return run;
+    }
+
+    return null;
+}
 
 /// Returns a style that when compared must be identical for a run to
 /// continue.

--- a/src/font/shaper/run.zig
+++ b/src/font/shaper/run.zig
@@ -59,6 +59,10 @@ pub const RunIterator = struct {
     opts: shape.RunOptions,
     // Visual cursor within the trimmed row.
     i: usize = 0,
+    // Cached row layout derived once per iterator.
+    layout_ready: bool = false,
+    max: usize = 0,
+    visual_runs: []const VisualRun = &.{},
 
     pub fn next(self: *RunIterator, alloc: Allocator) !?TextRun {
         const slice = &self.opts.cells;
@@ -66,51 +70,23 @@ pub const RunIterator = struct {
         const graphemes: []const []const u21 = slice.items(.grapheme);
         const styles: []const terminal.Style = slice.items(.style);
 
-        // Trim the right side of a row that might be empty
-        const max: usize = max: {
-            for (0..cells.len) |i| {
-                const rev_i = cells.len - i - 1;
-                if (!cells[rev_i].isEmpty()) break :max rev_i + 1;
-            }
-
-            break :max 0;
-        };
-
-        if (max == 0) return null;
+        if (!self.layout_ready) try self.resolveRowLayout(alloc, cells);
+        if (self.max == 0) return null;
 
         // We're over at the max.
-        if (self.i >= max) return null;
-
-        // Build bidi inputs from logical cells and derive visual runs in a
-        // paragraph that is always anchored LTR (terminal line model).
-        var bidi_codepoints = try alloc.alloc(u21, max);
-        defer alloc.free(bidi_codepoints);
-        for (cells[0..max], 0..) |cell, i| {
-            bidi_codepoints[i] = bidiCodepoint(cell);
-        }
-
-        const layout = try itijah.resolveVisualLayoutScratch(
-            alloc,
-            self.hooks.bidiLayoutScratch(),
-            bidi_codepoints,
-            .{
-                .base_dir = .ltr,
-            },
-        );
-        const visual_runs = layout.runs;
-        if (visual_runs.len == 0) return null;
+        if (self.i >= self.max) return null;
 
         // Invisible cells don't have any glyphs rendered, so we skip them.
-        while (self.i < max) {
-            const vr = findVisualRun(visual_runs, self.i) orelse break;
+        while (self.i < self.max) {
+            const vr = findVisualRun(self.visual_runs, self.i) orelse break;
             const logical_i: usize = @intCast(itijah.logicalIndexForVisual(vr, @intCast(self.i)));
             if (!(cells[logical_i].hasStyling() and styles[logical_i].flags.invisible)) break;
             self.i += 1;
         }
-        if (self.i >= max) return null;
+        if (self.i >= self.max) return null;
 
-        while (self.i < max) {
-            const bidi_run = findVisualRun(visual_runs, self.i) orelse return null;
+        while (self.i < self.max) {
+            const bidi_run = findVisualRun(self.visual_runs, self.i) orelse return null;
             const bidi_run_start: usize = @intCast(bidi_run.visual_start);
             const bidi_run_end: usize = bidi_run_start + @as(usize, @intCast(bidi_run.len));
             assert(self.i >= bidi_run_start and self.i < bidi_run_end);
@@ -130,6 +106,7 @@ pub const RunIterator = struct {
                 styles[start_logical]
             else
                 .{};
+            const run_font_style = fontStyleForStyle(style);
 
             // Find the run boundary in visual order.
             var j: usize = self.i;
@@ -199,29 +176,8 @@ pub const RunIterator = struct {
                     if (!c1.eql(c2)) break;
                 }
 
-                // Text runs break when font styles change so we need to get
-                // the proper style.
-                const font_style: font.Style = style_id: {
-                    if (style.flags.bold) {
-                        if (style.flags.italic) break :style_id .bold_italic;
-                        break :style_id .bold;
-                    }
-
-                    if (style.flags.italic) break :style_id .italic;
-                    break :style_id .regular;
-                };
-
                 // Determine the presentation format for this glyph.
-                const presentation: ?font.Presentation = if (cell.hasGrapheme()) p: {
-                    // We only check the FIRST codepoint because the
-                    // presentation format must be directly adjacent to
-                    // the codepoint.
-                    const cps = graphemes[logical_j];
-                    assert(cps.len > 0);
-                    if (cps[0] == 0xFE0E) break :p .text;
-                    if (cps[0] == 0xFE0F) break :p .emoji;
-                    break :p null;
-                } else null;
+                const presentation = presentationForCell(cell, graphemes[logical_j]);
 
                 // If our cursor is on this line then we break the run around
                 // the cursor.
@@ -244,7 +200,7 @@ pub const RunIterator = struct {
                         alloc,
                         cell,
                         graphemes[logical_j],
-                        font_style,
+                        run_font_style,
                         presentation,
                     )) |idx| break :font_info .{ .idx = idx };
 
@@ -253,7 +209,7 @@ pub const RunIterator = struct {
                     if (try self.opts.grid.getIndex(
                         alloc,
                         0xFFFD, // replacement char
-                        font_style,
+                        run_font_style,
                         presentation,
                     )) |idx| break :font_info .{ .idx = idx, .fallback = 0xFFFD };
 
@@ -261,7 +217,7 @@ pub const RunIterator = struct {
                     if (try self.opts.grid.getIndex(
                         alloc,
                         ' ',
-                        font_style,
+                        run_font_style,
                         presentation,
                     )) |idx| break :font_info .{ .idx = idx, .fallback = ' ' };
 
@@ -323,23 +279,7 @@ pub const RunIterator = struct {
                     .spacer_head, .spacer_tail => continue,
                 }
 
-                const font_style: font.Style = style_id: {
-                    if (style.flags.bold) {
-                        if (style.flags.italic) break :style_id .bold_italic;
-                        break :style_id .bold;
-                    }
-
-                    if (style.flags.italic) break :style_id .italic;
-                    break :style_id .regular;
-                };
-
-                const presentation: ?font.Presentation = if (cell.hasGrapheme()) p: {
-                    const cps = graphemes[logical_j];
-                    assert(cps.len > 0);
-                    if (cps[0] == 0xFE0E) break :p .text;
-                    if (cps[0] == 0xFE0F) break :p .emoji;
-                    break :p null;
-                } else null;
+                const presentation = presentationForCell(cell, graphemes[logical_j]);
 
                 const font_info: struct {
                     idx: font.Collection.Index,
@@ -349,21 +289,21 @@ pub const RunIterator = struct {
                         alloc,
                         cell,
                         graphemes[logical_j],
-                        font_style,
+                        run_font_style,
                         presentation,
                     )) |idx| break :font_info .{ .idx = idx };
 
                     if (try self.opts.grid.getIndex(
                         alloc,
                         0xFFFD, // replacement char
-                        font_style,
+                        run_font_style,
                         presentation,
                     )) |idx| break :font_info .{ .idx = idx, .fallback = 0xFFFD };
 
                     if (try self.opts.grid.getIndex(
                         alloc,
                         ' ',
-                        font_style,
+                        run_font_style,
                         presentation,
                     )) |idx| break :font_info .{ .idx = idx, .fallback = ' ' };
 
@@ -375,12 +315,13 @@ pub const RunIterator = struct {
                     const is_neutral_in_current_font = cp != 0 and
                         codepointIsRtl(cp) == null and
                         self.opts.grid.hasCodepoint(current_font, cp, presentation);
-                    if (!is_neutral_in_current_font) unreachable;
+                    if (!is_neutral_in_current_font) continue;
                 }
 
                 // If we're a fallback character and that fallback is in the
                 // current run font, add it directly.
                 if (font_info.fallback) |cp| {
+                    // Only use fallback glyph if it comes from the run font.
                     if (font_info.idx == current_font) {
                         try self.addCodepoint(&hasher, cp, cluster);
                         continue;
@@ -427,6 +368,42 @@ pub const RunIterator = struct {
         }
 
         return null;
+    }
+
+    fn resolveRowLayout(
+        self: *RunIterator,
+        alloc: Allocator,
+        cells: []const terminal.page.Cell,
+    ) !void {
+        self.layout_ready = true;
+        self.max = max: {
+            for (0..cells.len) |i| {
+                const rev_i = cells.len - i - 1;
+                if (!cells[rev_i].isEmpty()) break :max rev_i + 1;
+            }
+            break :max 0;
+        };
+
+        if (self.max == 0) {
+            self.visual_runs = &.{};
+            return;
+        }
+
+        // Build bidi inputs from logical cells and derive visual runs in a
+        // paragraph that is always anchored LTR (terminal line model).
+        var bidi_codepoints = try alloc.alloc(u21, self.max);
+        defer alloc.free(bidi_codepoints);
+        for (cells[0..self.max], 0..) |cell, i| {
+            bidi_codepoints[i] = bidiCodepoint(cell);
+        }
+
+        const layout = try itijah.resolveVisualLayoutScratch(
+            alloc,
+            self.hooks.bidiLayoutScratch(),
+            bidi_codepoints,
+            .{ .base_dir = .ltr },
+        );
+        self.visual_runs = layout.runs;
     }
 
     fn addCodepoint(self: *RunIterator, hasher: anytype, cp: u32, cluster: u32) !void {
@@ -524,6 +501,24 @@ pub const RunIterator = struct {
 fn bidiCodepoint(cell: terminal.page.Cell) u21 {
     const cp = cell.codepoint();
     return @intCast(if (cp == 0) ' ' else cp);
+}
+
+fn fontStyleForStyle(style: terminal.Style) font.Style {
+    if (style.flags.bold and style.flags.italic) return .bold_italic;
+    if (style.flags.bold) return .bold;
+    if (style.flags.italic) return .italic;
+    return .regular;
+}
+
+fn presentationForCell(cell: *const terminal.page.Cell, grapheme: []const u21) ?font.Presentation {
+    if (!cell.hasGrapheme() or grapheme.len == 0) return null;
+
+    // Presentation modifiers apply only when directly adjacent to the base.
+    return switch (grapheme[0]) {
+        0xFE0E => .text,
+        0xFE0F => .emoji,
+        else => null,
+    };
 }
 
 fn findVisualRun(visual_runs: []const VisualRun, visual_index: usize) ?VisualRun {

--- a/src/font/shaper/run.zig
+++ b/src/font/shaper/run.zig
@@ -89,10 +89,14 @@ pub const RunIterator = struct {
             bidi_codepoints[i] = bidiCodepoint(cell);
         }
 
-        var layout = try itijah.resolveVisualLayout(alloc, bidi_codepoints, .{
-            .base_dir = .ltr,
-        });
-        defer layout.deinit();
+        const layout = try itijah.resolveVisualLayoutScratch(
+            alloc,
+            self.hooks.bidiLayoutScratch(),
+            bidi_codepoints,
+            .{
+                .base_dir = .ltr,
+            },
+        );
         const visual_runs = layout.runs;
         if (visual_runs.len == 0) return null;
 

--- a/src/font/shaper/run.zig
+++ b/src/font/shaper/run.zig
@@ -343,8 +343,10 @@ pub const RunIterator = struct {
             return;
         }
 
-        // Build bidi inputs from logical cells and derive visual runs in a
-        // paragraph that is always anchored LTR (terminal line model).
+        // Build bidi inputs from logical cells and derive visual runs.
+        // Paragraph direction follows UAX #9 P2-P3 (first-strong detection):
+        // rows starting with LTR text stay LTR, rows starting with Hebrew/Arabic
+        // become RTL so trailing punctuation resolves correctly via N1/N2.
         var bidi_codepoints = try alloc.alloc(u21, self.max);
         defer alloc.free(bidi_codepoints);
         for (cells[0..self.max], 0..) |cell, i| {
@@ -355,7 +357,7 @@ pub const RunIterator = struct {
             alloc,
             self.hooks.bidiLayoutScratch(),
             bidi_codepoints,
-            .{ .base_dir = .ltr },
+            .{ .base_dir = .auto_ltr },
         );
         self.visual_runs = layout.runs;
     }

--- a/src/font/shaper/web_canvas.zig
+++ b/src/font/shaper/web_canvas.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const assert = @import("../../quirks.zig").inlineAssert;
 const Allocator = std.mem.Allocator;
+const itijah = @import("itijah");
 const font = @import("../main.zig");
 const terminal = @import("../../terminal/main.zig");
 const unicode = @import("../../unicode/main.zig");
@@ -36,6 +37,9 @@ pub const Shaper = struct {
     /// The shared memory used for storing information about a run.
     run_buf: RunBuf,
 
+    /// Scratch reused for terminal bidi layout resolution.
+    bidi_layout_scratch: itijah.VisualLayoutScratch = .{},
+
     /// The cell_buf argument is the buffer to use for storing shaped results.
     /// This should be at least the number of columns in the terminal.
     pub fn init(alloc: Allocator, opts: font.shape.Options) !Shaper {
@@ -50,6 +54,7 @@ pub const Shaper = struct {
 
     pub fn deinit(self: *Shaper) void {
         self.run_buf.deinit(self.alloc);
+        self.bidi_layout_scratch.deinit(self.alloc);
         self.* = undefined;
     }
 
@@ -224,6 +229,10 @@ pub const Shaper = struct {
 
         pub fn finalize(self: RunIteratorHook) !void {
             _ = self;
+        }
+
+        pub fn bidiLayoutScratch(self: RunIteratorHook) *itijah.VisualLayoutScratch {
+            return &self.shaper.bidi_layout_scratch;
         }
     };
 };


### PR DESCRIPTION
## ⚠️ Disclaimer

This PR was drafted by an AI agent (opencode) assisting @DiaaEddin's RTL work in #11079. I (@guysoft) will review everything below and remove this disclaimer once I've verified it. The `.auto_ltr` fix I tested locally — it does solve edge cases, with tests attached.

---

## What this PR is

This is @DiaaEddin's `bidi-support` branch (PR #11079) **rebased onto current `main`** plus a one-line paragraph-direction fix and a regression test. It's intended to be cherry-picked onto #11079 or reviewed as a standalone if #11079 stalls.

**Related:** #11079 (the main RTL PR), #1442, #1737

## Why

PR #11079 has been idle for ~2.5 months. It's `mergeable_state: dirty` (conflicts with main) and still marked `CHANGES_REQUESTED` despite all of @pluiedev's review feedback being addressed in commit `0d4ba38` on May 17. This PR:
1. Resolves the merge conflicts (rebase onto current `main`)
2. Fixes a trailing-punctuation rendering bug not covered by #11079
3. Adds a regression test that locks in the fix

## The fix: `.ltr` → `.auto_ltr` (`src/font/shaper/run.zig:360`)

The `LayoutOptions.base_dir` was hardcoded to `.ltr`, bypassing UAX #9 P2-P3 first-strong paragraph direction detection. This breaks trailing ASCII punctuation in RTL-leading rows.

**Example:** `"שלום, עולם! מה שלומך?"`

Under forced `.ltr` (base_level = 0):
- Trailing `?` is a neutral (Bidi_Class = ON) at the end of the row
- `computeSequenceSosEos` falls back to `succ_level = base_level = 0` → `eos = L`
- N1: `prev_type = R` (Hebrew on left), `next_type = eos = L` → **no match**
- N2: neutral adopts embedding direction → `L`
- `?` ends up at level 0 (LTR skeleton); `applyL2` doesn't reverse even-level runs
- **Result:** `?` appears at the visual-left, ahead of the Hebrew text ❌

Under `.auto_ltr` (P2-P3 picks RTL from first strong `ש`):
- `base_level = 1` (RTL paragraph)
- `eos = classFromLevel(max(1, 1)) = R`
- N1: `prev = R`, `next = R` → **match** → neutral resolves to `R`
- `?` stays at level 1 (RTL run); `applyL2` reverses odd-level runs
- **Result:** `?` appears at the visual-right (end of sentence) ✅

Rows starting with LTR text are byte-identical — P2-P3 detects `H` (L) → `base_level = 0`, same as before. Rows with no strong chars fall back to LTR (the "ltr" in `auto_ltr`). itijah passes Unicode conformance (BidiTest.txt, BidiCharacterTest.txt), so this is a one-line integration fix, not an algorithm change.

## The regression test (`src/font/shaper/harfbuzz.zig`)

Added `test "shape hebrew RTL with trailing punctuation at visual-right"` feeding `"שלום, עולם! מה שלומך?"` (21 cells) and asserting:
- Exactly **1** visual run (not split)
- The run is RTL
- `run.cells == 21` (the `?` is part of the same RTL run as the Hebrew)

Without this test, all existing hebrew/rtl/bidi/arabic tests pass under *both* `.ltr` and `.auto_ltr` because none of them feed trailing ASCII punctuation in an RTL-leading row — so the fix would be silently unlockable. I only added the test to `harfbuzz.zig` (Linux-testable); `coretext.zig` is intentionally untouched (I'm on Linux and can't test the CoreText backend).

## What I did NOT touch

- `src/font/shaper/coretext.zig` — intentionally left as DiaaEddin's original. The `try s.nextSlice` → `s.nextSlice` rebase compat for CoreText can be done by a macOS contributor.
- No new config options (no `text-direction` toggle). Minimal diff for review. A config option can be a follow-up if users need an escape hatch.

## Test results (Linux/x86_64, HarfBuzz 11.0.0, GTK 4.22.4)

All RTL shaper tests pass:
- `zig build test -Dtest-filter="hebrew"` → ✅
- `zig build test -Dtest-filter="rtl"` → ✅
- `zig build test -Dtest-filter="bidi"` → ✅
- `zig build test -Dtest-filter="arabic"` → ✅
- `zig build test -Dtest-filter="trailing punctuation"` → ✅ (new)

Full `shape` suite: 108/109 pass (1 pre-existing Chakma vowel test failure, unrelated to RTL — same on `fork/bidi-support`).

Build: `zig build -Dapp-runtime=gtk` succeeds.

## Commit structure

1. DiaaEddin's 9 commits from `bidi-support` (rebased onto `main`)
2. `font/shaper: fix trailing punctuation in RTL paragraphs + regression test` — the `.auto_ltr` fix + regression test + `try` removal in harfbuzz.zig
3. `revert coretext.zig to upstream, keep only RTL-relevant changes` — removed coretext.zig changes to minimize diff

## Credits

All RTL/bidi infrastructure (itijah integration, run iterator, Arabic/Hebrew shaping, 21 tests) is @DiaaEddin's work in #11079. This PR adds a one-line fix and one regression test on top.