### PR TITLE
core: avoid copying OSC 52 clipboard responses

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -5974,8 +5974,8 @@ fn completeClipboardReadOSC52(
     // This must hold the base64 encoded data PLUS the OSC code surrounding it.
     const enc = std.base64.standard.Encoder;
     const size = enc.calcSize(data.len);
-    var buf = try self.alloc.alloc(u8, size + 9); // const for OSC
-    defer self.alloc.free(buf);
+    const buf = try self.alloc.alloc(u8, size + 9); // const for OSC
+    errdefer self.alloc.free(buf);
 
     const kind: u8 = switch (clipboard_type) {
         .standard => 'c',
@@ -5993,10 +5993,10 @@ fn completeClipboardReadOSC52(
     const encoded = enc.encode(buf[prefix.len..], data);
     assert(encoded.len == size);
 
-    self.queueIo(try termio.Message.writeReq(
-        self.alloc,
-        buf,
-    ), .unlocked);
+    self.queueIo(.{ .write_alloc = .{
+        .alloc = self.alloc,
+        .data = buf,
+    } }, .unlocked);
 }
 
 fn showDesktopNotification(self: *Surface, title: [:0]const u8, body: [:0]const u8) !void {


### PR DESCRIPTION
OSC 52 clipboard reads built their response in an allocated buffer and then passed it through Message.writeReq, which allocated a second copy for large responses.

Instead, transfer the allocated response directly using .write_alloc.

Small responses now retain their initial allocation until the IO thread consumes them instead of being copied inline and freed immediately. Their allocation count is unchanged, while large responses improve from two allocations to one. Both cases avoid the additional copy.