### PR TITLE
renderer: reset terminal state cleanup counter

### DIFF
--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -1138,6 +1138,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             if (self.terminal_state_frame_count >= max_terminal_state_frame_count) {
                 self.terminal_state.deinit(self.alloc);
                 self.terminal_state = .empty;
+                self.terminal_state_frame_count = 0;
             }
             self.terminal_state_frame_count += 1;
 


### PR DESCRIPTION
Reset the frame counter whenever retained render state is cleared. Otherwise, every subsequent frame will be deinitialized and rebuilt.