### PR TITLE
config: clarify cursor-click-to-move's relation to shell-integration

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -908,10 +908,10 @@ palette: Palette = .{},
 /// Enables the ability to move the cursor at prompts by clicking on a
 /// location in the prompt text.
 ///
-/// This feature requires shell integration, specifically prompt marking
-/// via `OSC 133`. Some shells like Fish (v4) and Nu (0.111+) natively
-/// support this while others may require additional configuration or
-/// Ghostty's shell integration features to be enabled.
+/// This feature requires prompt marking via `OSC 133`. Some shells like Fish
+/// (v4.1+) and Nu (0.111+) natively support this while others may require
+/// additional configuration or Ghostty's shell integration features to be
+/// enabled.
 ///
 /// Depending on the shell, this works either by translating your click
 /// position into a series of synthetic arrow key movements or by sending


### PR DESCRIPTION
the original wording is a bit confusing; I thought cursor-click-to-move required shell-integration to be enabled, and was confused when the mouse was still moving my cursor in fish even with shell-integration=none.