### PR TITLE
feat(bidi): Add Unicode Bidirectional Text Support (UAX #9)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ glad.zip
 vgcore.*
 
 /sprite_face_test*
+
+# Bidi conformance data, fetched on demand.
+# See src/bidi/testdata/README.md
+/src/bidi/testdata/*.txt

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -25,6 +25,8 @@ const oni = @import("oniguruma");
 const crash = @import("crash/main.zig");
 const unicode = @import("unicode/main.zig");
 const rendererpkg = @import("renderer.zig");
+const rendererbidi = @import("renderer/bidi.zig");
+const bidipkg = @import("bidi/main.zig");
 const termio = @import("termio.zig");
 const font = @import("font/main.zig");
 const Command = @import("Command.zig");
@@ -96,6 +98,15 @@ renderer_thr: std.Thread,
 
 /// Mouse state.
 mouse: Mouse,
+
+/// Bidi resolution for pointer input.
+///
+/// The renderer has its own cache on its own thread. This one exists so
+/// that mapping a pointer position needs no shared state and no lock on
+/// the render thread: mouse events are user-paced, so resolving a single
+/// row on demand costs microseconds and the duplication is cheaper than
+/// coordinating between threads on an input path.
+bidi_cache: rendererbidi.BidiCache,
 
 /// Keyboard input state.
 keyboard: Keyboard,
@@ -298,6 +309,8 @@ const DerivedConfig = struct {
     original_font_size: f32,
     keybind: configpkg.Keybinds,
     abnormal_command_exit_runtime_ms: u32,
+    bidi: configpkg.Config.Bidi,
+    bidi_default_direction: configpkg.Config.BidiDefaultDirection,
     clipboard_read: configpkg.ClipboardAccess,
     clipboard_write: configpkg.ClipboardAccess,
     clipboard_trim_trailing_spaces: bool,
@@ -377,6 +390,8 @@ const DerivedConfig = struct {
             .original_font_size = config.@"font-size",
             .keybind = try config.keybind.clone(alloc),
             .abnormal_command_exit_runtime_ms = config.@"abnormal-command-exit-runtime",
+            .bidi = config.bidi,
+            .bidi_default_direction = config.@"bidi-default-direction",
             .clipboard_read = config.@"clipboard-read",
             .clipboard_write = config.@"clipboard-write",
             .clipboard_trim_trailing_spaces = config.@"clipboard-trim-trailing-spaces",
@@ -610,6 +625,7 @@ pub fn init(
         },
         .renderer_thr = undefined,
         .mouse = .{},
+        .bidi_cache = .init(alloc),
         .keyboard = .{},
         .io = undefined,
         .io_thread = io_thread,
@@ -795,6 +811,8 @@ pub fn init(
 }
 
 pub fn deinit(self: *Surface) void {
+    self.bidi_cache.deinit(self.alloc);
+
     // Stop search thread
     if (self.search) |*s| s.deinit();
 
@@ -1196,12 +1214,16 @@ fn selectionScrollTick(self: *Surface) !void {
     }
 
     const pos = try self.rt_surface.getCursorPos();
-    const pos_vp = self.posToViewport(pos.x, pos.y);
+    const pos_visual = self.posToViewport(pos.x, pos.y);
 
     // We need our locked state for the remainder
     self.renderer_state.mutex.lockUncancelable(global.io());
     defer self.renderer_state.mutex.unlock(global.io());
     const t: *terminal.Terminal = self.renderer_state.terminal;
+
+    // Reading the screen to map the column requires the lock, so this
+    // happens after it is taken rather than alongside posToViewport.
+    const pos_vp = self.viewportToLogical(pos_visual);
 
     const selection = self.mouse.selection_gesture.autoscrollTick(t, .{
         .viewport = pos_vp,
@@ -3972,7 +3994,9 @@ pub fn mouseButtonCallback(
 
         const pos = try self.rt_surface.getCursorPos();
         const pin = pin: {
-            const pt_viewport = self.posToViewport(pos.x, pos.y);
+            const pt_viewport = self.viewportToLogical(
+                self.posToViewport(pos.x, pos.y),
+            );
             const pin = screen.pages.pin(.{
                 .viewport = .{
                     .x = pt_viewport.x,
@@ -4078,7 +4102,9 @@ pub fn mouseButtonCallback(
         const screen: *terminal.Screen = self.renderer_state.terminal.screens.active;
         const pos = try self.rt_surface.getCursorPos();
         const pin = pin: {
-            const pt_viewport = self.posToViewport(pos.x, pos.y);
+            const pt_viewport = self.viewportToLogical(
+                self.posToViewport(pos.x, pos.y),
+            );
             const pin = screen.pages.pin(.{
                 .viewport = .{
                     .x = pt_viewport.x,
@@ -4751,6 +4777,55 @@ pub fn posToViewport(self: Surface, xpos: f64, ypos: f64) terminal.point.Coordin
     const coord: rendererpkg.Coordinate = .{ .surface = .{ .x = xpos, .y = ypos } };
     const grid = coord.convert(.grid, self.size).grid;
     return .{ .x = grid.x, .y = grid.y };
+}
+
+/// Map a viewport coordinate from the visual column the pointer is over
+/// to the logical column stored there.
+///
+/// A pointer position is inherently visual: it says where on the glass
+/// the mouse is. Everything downstream of it, mouse reporting, selection
+/// and link hits, works in logical columns, because that is the space
+/// the running program and the screen buffer use. On a row that was
+/// reordered the two differ, and reporting the visual column would make
+/// every click land somewhere else in a program showing right-to-left
+/// text.
+///
+/// The caller must hold the renderer state mutex, since this reads the
+/// screen.
+fn viewportToLogical(
+    self: *Surface,
+    vp: terminal.point.Coordinate,
+) terminal.point.Coordinate {
+    // Nothing can reorder, so the two spaces coincide.
+    if (comptime bidipkg.options.backend == .noop) return vp;
+    if (self.config.bidi == .never) return vp;
+
+    const screen: *terminal.Screen = self.renderer_state.terminal.screens.active;
+    const pin = screen.pages.pin(.{ .viewport = .{ .x = 0, .y = vp.y } }) orelse
+        return vp;
+
+    const cells = pin.cells(.all);
+    const cols: u16 = @intCast(cells.len);
+    if (vp.x >= cols) return vp;
+
+    const row_bidi = self.bidi_cache.resolve(
+        self.alloc,
+        cells,
+        cols,
+        .{ .direction = switch (self.config.bidi_default_direction) {
+            .auto => .auto,
+            .ltr => .ltr,
+            .rtl => .rtl,
+        } },
+    ) catch |err| {
+        log.warn("error resolving bidi for pointer row err={}", .{err});
+        return vp;
+    };
+
+    return .{
+        .x = @intCast(row_bidi.hitTest(.from(vp.x)).int()),
+        .y = vp.y,
+    };
 }
 
 /// Scroll to the bottom of the viewport.

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1225,7 +1225,12 @@ fn selectionScrollTick(self: *Surface) !void {
 
     // Reading the screen to map the column requires the lock, so this
     // happens after it is taken rather than alongside posToViewport.
-    const pos_vp = self.viewportToLogical(pos_visual);
+    // A rectangular selection keeps visual coordinates; see the note at
+    // the click sites.
+    const pos_vp = if (SurfaceMouse.isRectangleSelectState(self.mouse.mods))
+        pos_visual
+    else
+        self.viewportToLogical(pos_visual);
 
     const selection = self.mouse.selection_gesture.autoscrollTick(t, .{
         .viewport = pos_vp,
@@ -2250,6 +2255,144 @@ fn clipboardWrite(self: *const Surface, data: []const u8, loc: apprt.Clipboard) 
     };
 }
 
+/// Extract a rectangular selection whose rows have been reordered.
+///
+/// Returns null when this does not apply, which is any selection that is
+/// not rectangular, any build without reordering, and any rectangle over
+/// rows that were not reordered. The caller then takes its usual path,
+/// so ordinary rectangle copies are untouched.
+///
+/// A rectangle's corners are visual, because taking a column out of
+/// something laid out in columns is a geometric operation. The text it
+/// covers is not: on a reordered row the visual span maps to a set of
+/// logical columns, which is generally several disjoint ranges rather
+/// than one. Each is emitted separately and in logical order, so the
+/// copied text reads the way the program wrote it, as everything else
+/// on the clipboard does.
+///
+/// This lives here rather than in Screen because the mapping needs the
+/// bidi cache, and src/terminal deliberately depends on neither the
+/// renderer nor the font package. The surface already owns a cache for
+/// pointer hit-testing.
+/// The widest row a reordered rectangle copy handles. Beyond this it
+/// falls back to the normal path rather than dropping columns.
+const max_rect_cols = 1024;
+
+fn rectangleBidiText(
+    self: *Surface,
+    alloc: Allocator,
+    sel: terminal.Selection,
+    opts: terminal.formatter.Options,
+) !?[:0]const u8 {
+    if (!sel.rectangle) return null;
+    if (comptime bidipkg.options.backend == .noop) return null;
+    if (self.config.bidi == .never) return null;
+
+    const screen: *terminal.Screen = self.io.terminal.screens.active;
+    const tl = sel.topLeft(screen);
+    const br = sel.bottomRight(screen);
+
+    const tl_pt = screen.pages.pointFromPin(.viewport, tl) orelse return null;
+    const br_pt = screen.pages.pointFromPin(.viewport, br) orelse return null;
+
+    const vx0 = @min(tl_pt.viewport.x, br_pt.viewport.x);
+    const vx1 = @max(tl_pt.viewport.x, br_pt.viewport.x);
+
+    // Resolve every row first. If not one of them reordered then the
+    // visual and logical spans are identical everywhere and the normal
+    // path produces the same bytes, so hand it back.
+    var any_reordered = false;
+    {
+        var y = tl_pt.viewport.y;
+        while (y <= br_pt.viewport.y) : (y += 1) {
+            const pin = screen.pages.pin(.{ .viewport = .{ .x = 0, .y = y } }) orelse continue;
+            const cells = pin.cells(.all);
+            const row = self.bidi_cache.resolve(
+                self.alloc,
+                cells,
+                @intCast(cells.len),
+                .{ .direction = switch (self.config.bidi_default_direction) {
+                    .auto => .auto,
+                    .ltr => .ltr,
+                    .rtl => .rtl,
+                } },
+            ) catch return null;
+            if (!row.identity) {
+                any_reordered = true;
+                break;
+            }
+        }
+    }
+    if (!any_reordered) return null;
+
+    var aw: std.Io.Writer.Allocating = .init(alloc);
+
+    var y = tl_pt.viewport.y;
+    while (y <= br_pt.viewport.y) : (y += 1) {
+        if (y > tl_pt.viewport.y) try aw.writer.writeByte('\n');
+
+        const row_pin = screen.pages.pin(.{ .viewport = .{ .x = 0, .y = y } }) orelse continue;
+        const cells = row_pin.cells(.all);
+        const cols: u16 = @intCast(cells.len);
+        if (cols == 0) continue;
+
+        const row = self.bidi_cache.resolve(
+            self.alloc,
+            cells,
+            cols,
+            .{ .direction = switch (self.config.bidi_default_direction) {
+                .auto => .auto,
+                .ltr => .ltr,
+                .rtl => .rtl,
+            } },
+        ) catch continue;
+
+        // Which logical columns this row's visual span covers. Walking
+        // the span and marking what it displays gives the answer
+        // directly, and a run of marked columns is one range to emit.
+        //
+        // A row wider than the buffer would have to drop columns, and
+        // silently copying less than was selected is worse than copying
+        // it in the wrong order, so fall back instead.
+        var covered: [max_rect_cols]bool = @splat(false);
+        if (cols > covered.len) return null;
+
+        var v = vx0;
+        while (v <= vx1 and v < cols) : (v += 1) {
+            const l = row.logicalCol(.from(v)).int();
+            covered[l] = true;
+        }
+
+        var l: u16 = 0;
+        while (l < cols) {
+            if (!covered[l]) {
+                l += 1;
+                continue;
+            }
+
+            var end = l;
+            while (end + 1 < cols and covered[end + 1]) end += 1;
+
+            const start_pin = screen.pages.pin(.{
+                .viewport = .{ .x = l, .y = y },
+            }) orelse break;
+            const end_pin = screen.pages.pin(.{
+                .viewport = .{ .x = end, .y = y },
+            }) orelse break;
+
+            var seg_opts = opts;
+            seg_opts.unwrap = false;
+            var formatter: terminal.formatter.ScreenFormatter = .init(screen, seg_opts);
+            formatter.content = .{ .selection = .init(start_pin, end_pin, false) };
+            try formatter.format(&aw.writer);
+
+            l = end + 1;
+        }
+    }
+
+    return try aw.toOwnedSliceSentinel(0);
+}
+
 fn copySelectionToClipboards(
     self: *Surface,
     sel: terminal.Selection,
@@ -2279,13 +2422,20 @@ fn copySelectionToClipboards(
     var contents: std.ArrayList(apprt.ClipboardContent) = .empty;
     switch (format) {
         .plain => {
-            var formatter: ScreenFormatter = .init(self.io.terminal.screens.active, opts);
-            formatter.content = .{ .selection = sel };
-            try formatter.format(&aw.writer);
-            try contents.append(alloc, .{
-                .mime = "text/plain",
-                .data = try aw.toOwnedSliceSentinel(0),
-            });
+            if (try self.rectangleBidiText(alloc, sel, opts)) |text| {
+                try contents.append(alloc, .{
+                    .mime = "text/plain",
+                    .data = text,
+                });
+            } else {
+                var formatter: ScreenFormatter = .init(self.io.terminal.screens.active, opts);
+                formatter.content = .{ .selection = sel };
+                try formatter.format(&aw.writer);
+                try contents.append(alloc, .{
+                    .mime = "text/plain",
+                    .data = try aw.toOwnedSliceSentinel(0),
+                });
+            }
         },
 
         .vt => {
@@ -4013,9 +4163,17 @@ pub fn mouseButtonCallback(
 
         const pos = try self.rt_surface.getCursorPos();
         const pin = pin: {
-            const pt_viewport = self.viewportToLogical(
-                self.posToViewport(pos.x, pos.y),
-            );
+            // A rectangular selection is a geometric operation on the
+            // grid: the point of it is to take a column out of something
+            // laid out in columns, so its corners are visual and are
+            // left unmapped. Every other selection anchors on a
+            // character, so its coordinates are mapped to the logical
+            // column that character lives at.
+            const visual = self.posToViewport(pos.x, pos.y);
+            const pt_viewport = if (SurfaceMouse.isRectangleSelectState(self.mouse.mods))
+                visual
+            else
+                self.viewportToLogical(visual);
             const pin = screen.pages.pin(.{
                 .viewport = .{
                     .x = pt_viewport.x,
@@ -4121,9 +4279,17 @@ pub fn mouseButtonCallback(
         const screen: *terminal.Screen = self.renderer_state.terminal.screens.active;
         const pos = try self.rt_surface.getCursorPos();
         const pin = pin: {
-            const pt_viewport = self.viewportToLogical(
-                self.posToViewport(pos.x, pos.y),
-            );
+            // A rectangular selection is a geometric operation on the
+            // grid: the point of it is to take a column out of something
+            // laid out in columns, so its corners are visual and are
+            // left unmapped. Every other selection anchors on a
+            // character, so its coordinates are mapped to the logical
+            // column that character lives at.
+            const visual = self.posToViewport(pos.x, pos.y);
+            const pt_viewport = if (SurfaceMouse.isRectangleSelectState(self.mouse.mods))
+                visual
+            else
+                self.viewportToLogical(visual);
             const pin = screen.pages.pin(.{
                 .viewport = .{
                     .x = pt_viewport.x,

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -3738,10 +3738,26 @@ fn mouseReport(
 
     var data: termio.Message.WriteReq.Small.Array = undefined;
     var writer: std.Io.Writer = .fixed(&data);
+    // The pointer position gives the visual column. A program tracking
+    // the mouse addresses the screen logically, so on a reordered row
+    // the two differ and the click has to be reported where the
+    // character actually lives. This reads the io terminal directly, as
+    // the rest of this function already does.
+    const logical_x: ?u16 = logical: {
+        if (comptime bidipkg.options.backend == .noop) break :logical null;
+        if (self.config.bidi == .never) break :logical null;
+        const vp = self.posToViewport(pos.x, pos.y);
+        break :logical self.logicalColFor(
+            self.io.terminal.screens.active,
+            vp,
+        );
+    };
+
     input.mouse_encode.encode(&writer, .{
         .button = button,
         .action = action,
         .mods = mods,
+        .logical_x = logical_x,
         .pos = .{
             .x = pos.x,
             .y = pos.y,
@@ -4796,17 +4812,37 @@ fn viewportToLogical(
     self: *Surface,
     vp: terminal.point.Coordinate,
 ) terminal.point.Coordinate {
-    // Nothing can reorder, so the two spaces coincide.
-    if (comptime bidipkg.options.backend == .noop) return vp;
-    if (self.config.bidi == .never) return vp;
+    return .{
+        .x = self.logicalColFor(
+            self.renderer_state.terminal.screens.active,
+            vp,
+        ),
+        .y = vp.y,
+    };
+}
 
-    const screen: *terminal.Screen = self.renderer_state.terminal.screens.active;
+/// The logical column displayed at a viewport coordinate on the given
+/// screen.
+///
+/// The screen is passed explicitly because the two callers reach it
+/// differently: selection goes through the renderer state under its
+/// mutex, while mouse reporting reads the io terminal directly, as the
+/// rest of that function already does.
+fn logicalColFor(
+    self: *Surface,
+    screen: *terminal.Screen,
+    vp: terminal.point.Coordinate,
+) terminal.size.CellCountInt {
+    // Nothing can reorder, so the two spaces coincide.
+    if (comptime bidipkg.options.backend == .noop) return vp.x;
+    if (self.config.bidi == .never) return vp.x;
+
     const pin = screen.pages.pin(.{ .viewport = .{ .x = 0, .y = vp.y } }) orelse
-        return vp;
+        return vp.x;
 
     const cells = pin.cells(.all);
     const cols: u16 = @intCast(cells.len);
-    if (vp.x >= cols) return vp;
+    if (vp.x >= cols) return vp.x;
 
     const row_bidi = self.bidi_cache.resolve(
         self.alloc,
@@ -4819,13 +4855,10 @@ fn viewportToLogical(
         } },
     ) catch |err| {
         log.warn("error resolving bidi for pointer row err={}", .{err});
-        return vp;
+        return vp.x;
     };
 
-    return .{
-        .x = @intCast(row_bidi.hitTest(.from(vp.x)).int()),
-        .y = vp.y,
-    };
+    return @intCast(row_bidi.hitTest(.from(vp.x)).int());
 }
 
 /// Scroll to the bottom of the viewport.

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -317,6 +317,7 @@ const DerivedConfig = struct {
     clipboard_paste_protection: bool,
     clipboard_paste_bracketed_safe: bool,
     clipboard_codepoint_map: configpkg.Config.RepeatableClipboardCodepointMap,
+    clipboard_bidi_controls: configpkg.Config.ClipboardBidiControls,
     copy_on_select: configpkg.CopyOnSelect,
     right_click_action: configpkg.RightClickAction,
     middle_click_action: configpkg.MiddleClickAction,
@@ -398,6 +399,7 @@ const DerivedConfig = struct {
             .clipboard_paste_protection = config.@"clipboard-paste-protection",
             .clipboard_paste_bracketed_safe = config.@"clipboard-paste-bracketed-safe",
             .clipboard_codepoint_map = try config.@"clipboard-codepoint-map".clone(alloc),
+            .clipboard_bidi_controls = config.@"clipboard-bidi-controls",
             .copy_on_select = config.@"copy-on-select",
             .right_click_action = config.@"right-click-action",
             .middle_click_action = config.@"middle-click-action",
@@ -2266,6 +2268,7 @@ fn copySelectionToClipboards(
         .unwrap = true,
         .trim = self.config.clipboard_trim_trailing_spaces,
         .codepoint_map = self.config.clipboard_codepoint_map.map.list,
+        .strip_bidi_controls = self.config.clipboard_bidi_controls == .strip,
         .background = self.io.terminal.colors.background.get(),
         .foreground = self.io.terminal.colors.foreground.get(),
         .palette = &self.io.terminal.colors.palette.current,
@@ -6004,6 +6007,24 @@ fn completeClipboardPaste(
             // If we're allowed to paste unsafe data then we always allow the paste.
             // This is set during confirmation usually.
             if (allow_unsafe) break :unsafe false;
+
+            // A bidi directional override is checked before anything
+            // else, and deliberately before the bracketed paste
+            // shortcuts below.
+            //
+            // Bracketing makes a paste safe in the sense that the
+            // terminal cannot be tricked into interpreting it as input.
+            // It does nothing about text that a human then reads and
+            // runs, which is precisely the Trojan Source problem: the
+            // line on screen and the bytes underneath say different
+            // things. Framing the paste does not change that.
+            if (input.paste.hasBidiOverride(data)) {
+                log.info(
+                    "paste contains a bidi directional override, requesting confirmation",
+                    .{},
+                );
+                break :unsafe true;
+            }
 
             if (opts.bracketed) {
                 // If we're bracketed and the paste contains and ending

--- a/src/benchmark/BidiResolve.zig
+++ b/src/benchmark/BidiResolve.zig
@@ -24,13 +24,21 @@ const global = @import("../global.zig");
 
 const log = std.log.scoped(.@"bidi-resolve-bench");
 
+/// The maximum corpus size we will read into memory.
+const max_corpus_size = 1 * 1024 * 1024 * 1024;
+
 opts: Options,
 
 /// The allocator used for the resolver and line buffer.
 alloc: Allocator,
 
-/// The file, opened in the setup function.
-data_f: ?std.Io.File = null,
+/// The corpus, read fully into memory during setup.
+///
+/// This is read up front rather than streamed per step so that a step can
+/// be run repeatedly, which `--duration` requires: a step that consumed a
+/// file handle would read nothing after its first invocation and report an
+/// enormous iteration count. It also keeps file I/O out of the measurement.
+data: []const u8 = &.{},
 
 /// The resolver under test. Created in setup so its buffers are warm for
 /// the whole run rather than being reallocated per step.
@@ -86,18 +94,29 @@ pub fn benchmark(self: *BidiResolve) Benchmark {
 fn setup(ptr: *anyopaque) Benchmark.Error!void {
     const self: *BidiResolve = @ptrCast(@alignCast(ptr));
 
-    assert(self.data_f == null);
-    self.data_f = options.dataFile(self.opts.data) catch |err| {
+    assert(self.data.len == 0);
+    const f = options.dataFile(self.opts.data) catch |err| {
         log.warn("error opening data file err={}", .{err});
+        return error.BenchmarkFailed;
+    } orelse return;
+    defer f.close(global.io());
+
+    var read_buf: [4096]u8 = undefined;
+    var f_reader = f.reader(global.io(), &read_buf);
+    self.data = f_reader.interface.allocRemaining(
+        self.alloc,
+        .limited(max_corpus_size),
+    ) catch |err| {
+        log.warn("error reading data file err={}", .{err});
         return error.BenchmarkFailed;
     };
 }
 
 fn teardown(ptr: *anyopaque) void {
     const self: *BidiResolve = @ptrCast(@alignCast(ptr));
-    if (self.data_f) |f| {
-        f.close(global.io());
-        self.data_f = null;
+    if (self.data.len > 0) {
+        self.alloc.free(self.data);
+        self.data = &.{};
     }
     self.line.deinit(self.alloc);
     self.line = .empty;
@@ -116,41 +135,27 @@ fn stepResolve(ptr: *anyopaque) Benchmark.Error!void {
 }
 
 fn run(self: *BidiResolve, comptime do_resolve: bool) Benchmark.Error!void {
-    const f = self.data_f orelse return;
-    var read_buf: [4096]u8 align(std.atomic.cache_line) = undefined;
-    var f_reader = f.reader(global.io(), &read_buf);
-    var r = &f_reader.interface;
-
     self.line.clearRetainingCapacity();
 
     var d: UTF8Decoder = .{};
-    var buf: [4096]u8 align(std.atomic.cache_line) = undefined;
-    while (true) {
-        const n = r.readSliceShort(&buf) catch {
-            log.warn("error reading data file err={?}", .{f_reader.err});
-            return error.BenchmarkFailed;
-        };
-        if (n == 0) break; // EOF reached
+    for (self.data) |c| {
+        const cp_, const consumed = d.next(c);
+        assert(consumed);
+        const cp = cp_ orelse continue;
 
-        for (buf[0..n]) |c| {
-            const cp_, const consumed = d.next(c);
-            assert(consumed);
-            const cp = cp_ orelse continue;
-
-            if (cp != '\n') {
-                // Rows are bounded by the terminal width in practice; the
-                // resolver's index type is a u16 so we cap defensively.
-                if (self.line.items.len < std.math.maxInt(u16)) {
-                    self.line.append(self.alloc, cp) catch {
-                        log.warn("out of memory buffering line", .{});
-                        return error.BenchmarkFailed;
-                    };
-                }
-                continue;
+        if (cp != '\n') {
+            // Rows are bounded by the terminal width in practice; the
+            // resolver's index type is a u16 so we cap defensively.
+            if (self.line.items.len < std.math.maxInt(u16)) {
+                self.line.append(self.alloc, cp) catch {
+                    log.warn("out of memory buffering line", .{});
+                    return error.BenchmarkFailed;
+                };
             }
-
-            try self.flush(do_resolve);
+            continue;
         }
+
+        try self.flush(do_resolve);
     }
 
     // Trailing line without a newline.

--- a/src/benchmark/BidiResolve.zig
+++ b/src/benchmark/BidiResolve.zig
@@ -1,0 +1,194 @@
+//! This benchmark measures the throughput of bidi resolution over a
+//! corpus, one line at a time.
+//!
+//! The number that matters most here is the `ascii` corpus. Bidi support
+//! must not measurably slow down plain left-to-right output, which is the
+//! overwhelming majority of what a terminal renders, so the `resolve` mode
+//! on an ASCII corpus is the regression gate for the whole feature. The
+//! `decode` mode isolates the UTF-8 decoding cost so the resolver's own
+//! contribution can be read off the difference rather than guessed at.
+//!
+//! Generate corpora with `ghostty-gen bidi --profile=<profile> --seed=<n>`
+//! and reuse the exact same file across revisions. See
+//! `src/benchmark/AGENTS.md`.
+const BidiResolve = @This();
+
+const std = @import("std");
+const assert = std.debug.assert;
+const Allocator = std.mem.Allocator;
+const Benchmark = @import("Benchmark.zig");
+const options = @import("options.zig");
+const bidi = @import("../bidi/main.zig");
+const UTF8Decoder = @import("../terminal/UTF8Decoder.zig");
+const global = @import("../global.zig");
+
+const log = std.log.scoped(.@"bidi-resolve-bench");
+
+opts: Options,
+
+/// The allocator used for the resolver and line buffer.
+alloc: Allocator,
+
+/// The file, opened in the setup function.
+data_f: ?std.Io.File = null,
+
+/// The resolver under test. Created in setup so its buffers are warm for
+/// the whole run rather than being reallocated per step.
+resolver: bidi.Resolver = .empty,
+
+/// Codepoints of the line currently being accumulated.
+line: std.ArrayList(u21) = .empty,
+
+pub const Options = struct {
+    /// The type of work to perform.
+    mode: Mode = .decode,
+
+    /// The data to read as a filepath. If this is "-" then we will read
+    /// stdin. If this is unset, then we will do nothing (benchmark is a
+    /// noop).
+    data: ?[]const u8 = null,
+};
+
+pub const Mode = enum {
+    /// Decode UTF-8 and split into lines, but resolve nothing. This is
+    /// the baseline: subtract it from `resolve` to get the resolver cost.
+    decode,
+
+    /// Decode and run each line through the bidi resolver.
+    resolve,
+};
+
+pub fn create(
+    alloc: Allocator,
+    opts: Options,
+) !*BidiResolve {
+    const ptr = try alloc.create(BidiResolve);
+    errdefer alloc.destroy(ptr);
+    ptr.* = .{ .opts = opts, .alloc = alloc };
+    return ptr;
+}
+
+pub fn destroy(self: *BidiResolve, alloc: Allocator) void {
+    alloc.destroy(self);
+}
+
+pub fn benchmark(self: *BidiResolve) Benchmark {
+    return .init(self, .{
+        .stepFn = switch (self.opts.mode) {
+            .decode => stepDecode,
+            .resolve => stepResolve,
+        },
+        .setupFn = setup,
+        .teardownFn = teardown,
+    });
+}
+
+fn setup(ptr: *anyopaque) Benchmark.Error!void {
+    const self: *BidiResolve = @ptrCast(@alignCast(ptr));
+
+    assert(self.data_f == null);
+    self.data_f = options.dataFile(self.opts.data) catch |err| {
+        log.warn("error opening data file err={}", .{err});
+        return error.BenchmarkFailed;
+    };
+}
+
+fn teardown(ptr: *anyopaque) void {
+    const self: *BidiResolve = @ptrCast(@alignCast(ptr));
+    if (self.data_f) |f| {
+        f.close(global.io());
+        self.data_f = null;
+    }
+    self.line.deinit(self.alloc);
+    self.line = .empty;
+    self.resolver.deinit(self.alloc);
+    self.resolver = .empty;
+}
+
+fn stepDecode(ptr: *anyopaque) Benchmark.Error!void {
+    const self: *BidiResolve = @ptrCast(@alignCast(ptr));
+    try self.run(false);
+}
+
+fn stepResolve(ptr: *anyopaque) Benchmark.Error!void {
+    const self: *BidiResolve = @ptrCast(@alignCast(ptr));
+    try self.run(true);
+}
+
+fn run(self: *BidiResolve, comptime do_resolve: bool) Benchmark.Error!void {
+    const f = self.data_f orelse return;
+    var read_buf: [4096]u8 align(std.atomic.cache_line) = undefined;
+    var f_reader = f.reader(global.io(), &read_buf);
+    var r = &f_reader.interface;
+
+    self.line.clearRetainingCapacity();
+
+    var d: UTF8Decoder = .{};
+    var buf: [4096]u8 align(std.atomic.cache_line) = undefined;
+    while (true) {
+        const n = r.readSliceShort(&buf) catch {
+            log.warn("error reading data file err={?}", .{f_reader.err});
+            return error.BenchmarkFailed;
+        };
+        if (n == 0) break; // EOF reached
+
+        for (buf[0..n]) |c| {
+            const cp_, const consumed = d.next(c);
+            assert(consumed);
+            const cp = cp_ orelse continue;
+
+            if (cp != '\n') {
+                // Rows are bounded by the terminal width in practice; the
+                // resolver's index type is a u16 so we cap defensively.
+                if (self.line.items.len < std.math.maxInt(u16)) {
+                    self.line.append(self.alloc, cp) catch {
+                        log.warn("out of memory buffering line", .{});
+                        return error.BenchmarkFailed;
+                    };
+                }
+                continue;
+            }
+
+            try self.flush(do_resolve);
+        }
+    }
+
+    // Trailing line without a newline.
+    try self.flush(do_resolve);
+}
+
+fn flush(self: *BidiResolve, comptime do_resolve: bool) Benchmark.Error!void {
+    if (self.line.items.len == 0) return;
+
+    if (do_resolve) {
+        const result = self.resolver.resolve(
+            self.alloc,
+            self.line.items,
+            .{},
+        ) catch {
+            log.warn("out of memory resolving line", .{});
+            return error.BenchmarkFailed;
+        };
+
+        // Consume the result so the resolve can't be optimized away.
+        std.mem.doNotOptimizeAway(result.identity);
+        std.mem.doNotOptimizeAway(result.runs.len);
+    } else {
+        std.mem.doNotOptimizeAway(self.line.items.len);
+    }
+
+    self.line.clearRetainingCapacity();
+}
+
+test BidiResolve {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    inline for (&.{ Mode.decode, Mode.resolve }) |mode| {
+        const impl: *BidiResolve = try .create(alloc, .{ .mode = mode });
+        defer impl.destroy(alloc);
+
+        const bench = impl.benchmark();
+        _ = try bench.run(.once);
+    }
+}

--- a/src/benchmark/cli.zig
+++ b/src/benchmark/cli.zig
@@ -8,6 +8,7 @@ const global = @import("../global.zig");
 /// named files.
 pub const Action = enum {
     @"apc-parser",
+    @"bidi-resolve",
     @"codepoint-width",
     @"grapheme-break",
     @"hyperlink-map",
@@ -31,6 +32,7 @@ pub const Action = enum {
     pub fn Struct(comptime action: Action) type {
         return switch (action) {
             .@"apc-parser" => @import("ApcParser.zig"),
+            .@"bidi-resolve" => @import("BidiResolve.zig"),
             .@"hyperlink-map" => @import("HyperlinkMap.zig"),
             .@"screen-clone" => @import("ScreenClone.zig"),
             .@"page-compression" => @import("PageCompression.zig"),

--- a/src/benchmark/cli.zig
+++ b/src/benchmark/cli.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 const cli = @import("../cli.zig");
 const global = @import("../global.zig");
+const Benchmark = @import("Benchmark.zig");
 
 /// The available actions for the CLI. This is the list of available
 /// benchmarks. View docs for each individual one in the predictably
@@ -79,6 +80,66 @@ pub fn mainAction(
     }
 }
 
+/// Options understood by every benchmark, independent of which one is
+/// being run. These are filtered out of the argument list before the
+/// benchmark-specific options are parsed, so an individual benchmark's
+/// `Options` struct never has to know about them.
+pub const CommonOptions = struct {
+    /// Run the benchmark repeatedly for this many milliseconds and report
+    /// the iteration count, instead of running a single step and reporting
+    /// nothing.
+    ///
+    /// Timing the process from the outside (with hyperfine, say) measures
+    /// process startup, file I/O, and scheduler noise along with the work
+    /// under test. On a shared machine that noise floor is several percent,
+    /// which is larger than the regressions worth catching. Sampling many
+    /// iterations inside one process and dividing gives a figure that is
+    /// stable enough to gate on.
+    ///
+    /// A benchmark must be able to run its step more than once for this to
+    /// be meaningful. A step that consumes a file handle to exhaustion will
+    /// report an enormous iteration count and measure nothing; benchmarks
+    /// that read input should load it in `setup` instead.
+    duration: ?u64 = null,
+
+    /// Consume `arg` if it is a common option. Returns true if it was
+    /// consumed and should not be passed to the benchmark's own parser.
+    fn consume(self: *CommonOptions, arg: []const u8) !bool {
+        const prefix = "--duration=";
+        if (!std.mem.startsWith(u8, arg, prefix)) return false;
+        self.duration = std.fmt.parseInt(
+            u64,
+            arg[prefix.len..],
+            10,
+        ) catch return cli.args.Error.InvalidValue;
+        return true;
+    }
+};
+
+/// Wraps an argument iterator, pulling out the common options as it goes
+/// and yielding only the arguments the benchmark itself should see.
+fn CommonFilter(comptime Iter: type) type {
+    return struct {
+        inner: *Iter,
+        common: *CommonOptions,
+        err: ?anyerror = null,
+
+        pub fn next(self: *@This()) ?[]const u8 {
+            while (self.inner.next()) |arg| {
+                const consumed = self.common.consume(arg) catch |err| {
+                    // The parse loop has no way to surface an error from
+                    // the iterator, so stash it and stop yielding.
+                    self.err = err;
+                    return null;
+                };
+                if (consumed) continue;
+                return arg;
+            }
+            return null;
+        }
+    };
+}
+
 fn mainActionImpl(
     comptime BenchmarkImpl: type,
     alloc: Allocator,
@@ -87,12 +148,18 @@ fn mainActionImpl(
     // First, parse our CLI options.
     const Options = BenchmarkImpl.Options;
     var opts: Options = .{};
+    var common: CommonOptions = .{};
     defer if (@hasDecl(Options, "deinit")) opts.deinit();
     switch (args) {
         .cli => |process_args| {
             var iter = try cli.args.argsIterator(alloc, process_args);
             defer iter.deinit();
-            try cli.args.parse(Options, alloc, &opts, &iter);
+            var filter: CommonFilter(@TypeOf(iter)) = .{
+                .inner = &iter,
+                .common = &common,
+            };
+            try cli.args.parse(Options, alloc, &opts, &filter);
+            if (filter.err) |err| return err;
         },
         .string => |str| {
             var iter = try std.process.Args.IteratorGeneral(.{}).init(
@@ -100,7 +167,12 @@ fn mainActionImpl(
                 str,
             );
             defer iter.deinit();
-            try cli.args.parse(Options, alloc, &opts, &iter);
+            var filter: CommonFilter(@TypeOf(iter)) = .{
+                .inner = &iter,
+                .common = &common,
+            };
+            try cli.args.parse(Options, alloc, &opts, &filter);
+            if (filter.err) |err| return err;
         },
     }
 
@@ -110,5 +182,74 @@ fn mainActionImpl(
 
     // Initialize our benchmark
     const b = impl.benchmark();
-    _ = try b.run(.once);
+
+    const duration_ms = common.duration orelse {
+        // Preserve the historical behavior exactly when no duration is
+        // requested: run once, print nothing, let the caller time the
+        // process.
+        _ = try b.run(.once);
+        return;
+    };
+
+    const result = try b.run(.{ .duration = duration_ms * std.time.ns_per_ms });
+    try reportResult(result);
+}
+
+/// Print a duration-mode result in a form that is easy to both read and
+/// grep out of CI logs.
+fn reportResult(result: Benchmark.RunResult) !void {
+    var buf: [256]u8 = undefined;
+    var stdout = std.Io.File.stdout().writer(global.io(), &buf);
+    const w = &stdout.interface;
+
+    const ns_per_iter: u64 = if (result.iterations > 0)
+        result.duration / result.iterations
+    else
+        0;
+
+    try w.print(
+        "iterations={d} duration_ns={d} ns_per_iteration={d}\n",
+        .{ result.iterations, result.duration, ns_per_iter },
+    );
+    try w.flush();
+}
+
+test "CommonOptions: consumes duration" {
+    const testing = std.testing;
+
+    var common: CommonOptions = .{};
+    try testing.expect(try common.consume("--duration=250"));
+    try testing.expectEqual(@as(?u64, 250), common.duration);
+
+    // Anything else is left for the benchmark's own parser.
+    try testing.expect(!try common.consume("--mode=resolve"));
+    try testing.expect(!try common.consume("--duration"));
+    try testing.expect(!try common.consume("+bidi-resolve"));
+
+    try testing.expectError(
+        cli.args.Error.InvalidValue,
+        common.consume("--duration=abc"),
+    );
+}
+
+test "CommonFilter: hides common options from the inner parser" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var iter = try std.process.Args.IteratorGeneral(.{}).init(
+        alloc,
+        "--mode=resolve --duration=500 --data=x.txt",
+    );
+    defer iter.deinit();
+
+    var common: CommonOptions = .{};
+    var filter: CommonFilter(@TypeOf(iter)) = .{
+        .inner = &iter,
+        .common = &common,
+    };
+
+    try testing.expectEqualStrings("--mode=resolve", filter.next().?);
+    try testing.expectEqualStrings("--data=x.txt", filter.next().?);
+    try testing.expectEqual(@as(?[]const u8, null), filter.next());
+    try testing.expectEqual(@as(?u64, 500), common.duration);
 }

--- a/src/benchmark/main.zig
+++ b/src/benchmark/main.zig
@@ -1,5 +1,6 @@
 pub const cli = @import("cli.zig");
 pub const Benchmark = @import("Benchmark.zig");
+pub const BidiResolve = @import("BidiResolve.zig");
 pub const CApi = @import("CApi.zig");
 pub const TerminalStream = @import("TerminalStream.zig");
 pub const CodepointWidth = @import("CodepointWidth.zig");

--- a/src/bidi/backend.zig
+++ b/src/bidi/backend.zig
@@ -17,6 +17,11 @@ pub const Backend = enum {
     /// bidi implementation and costs a single branch per resolve call.
     noop,
 
+    /// The native Zig implementation of UAX #9 in `zig.zig`. No third
+    /// party library is involved, so there is no licensing question and
+    /// nothing extra to cross-compile.
+    zig,
+
     pub fn default(target: std.Target) Backend {
         _ = target;
 

--- a/src/bidi/backend.zig
+++ b/src/bidi/backend.zig
@@ -25,9 +25,16 @@ pub const Backend = enum {
     pub fn default(target: std.Target) Backend {
         _ = target;
 
-        // Bidi is not enabled by default yet. The rendering pipeline that
-        // consumes it does not exist, so anything other than `noop` would
-        // only add cost. This flips once the phases that integrate it land.
+        // The pipeline that consumes bidi results is complete, and the
+        // `bidi` config option now defaults to reordering. This still
+        // returns `noop`, so a default build compiles no resolver and
+        // the option has nothing to drive: reordering requires
+        // `-Dbidi-backend=zig`.
+        //
+        // That is deliberate. Turning this on is what exposes every user
+        // to the feature, and it is gated on review by people who read
+        // the scripts involved, which no amount of passing tests
+        // substitutes for.
         return .noop;
     }
 };

--- a/src/bidi/backend.zig
+++ b/src/bidi/backend.zig
@@ -1,0 +1,28 @@
+const std = @import("std");
+
+/// Possible bidi implementations, used for build options.
+///
+/// The backend is a comptime interface in the same spirit as
+/// `font.Shaper` in `src/font/shape.zig`: every backend exposes the same
+/// `Resolver` API and the same result vocabulary from `types.zig`, so
+/// swapping one for another cannot change behavior outside this package.
+///
+/// This seam exists deliberately. Ghostty is MIT licensed, and the obvious
+/// off-the-shelf bidi implementation (FriBidi) is LGPL, which is awkward to
+/// statically link into a distributed binary. Keeping the backend swappable
+/// means that choice is never load-bearing.
+pub const Backend = enum {
+    /// No reordering at all. Every row resolves to the identity mapping at
+    /// left-to-right. This is the "bidi compiled out" state: it links no
+    /// bidi implementation and costs a single branch per resolve call.
+    noop,
+
+    pub fn default(target: std.Target) Backend {
+        _ = target;
+
+        // Bidi is not enabled by default yet. The rendering pipeline that
+        // consumes it does not exist, so anything other than `noop` would
+        // only add cost. This flips once the phases that integrate it land.
+        return .noop;
+    }
+};

--- a/src/bidi/conformance_test.zig
+++ b/src/bidi/conformance_test.zig
@@ -1,0 +1,364 @@
+//! Conformance tests against the Unicode Character Database's own bidi
+//! test suites, `BidiTest.txt` and `BidiCharacterTest.txt`.
+//!
+//! Together these are roughly 600,000 cases covering every combination of
+//! rules the algorithm has. They are the only way to claim UAX #9
+//! conformance honestly: hand-written tests check the cases an author
+//! thought of, which are by definition the ones they did not get wrong.
+//!
+//! The data files are ~15 MB combined, which is more than is reasonable
+//! to vendor into the repository without a deliberate decision by the
+//! maintainers, so these tests read them from `src/bidi/testdata/` and
+//! skip (loudly) when they are absent:
+//!
+//!     curl -o src/bidi/testdata/BidiTest.txt \
+//!       https://www.unicode.org/Public/UCD/latest/ucd/BidiTest.txt
+//!     curl -o src/bidi/testdata/BidiCharacterTest.txt \
+//!       https://www.unicode.org/Public/UCD/latest/ucd/BidiCharacterTest.txt
+//!     zig build test -Dtest-filter="bidi conformance"
+//!
+//! The UCD version must match the one the tables in `src/unicode` were
+//! generated from, which is whatever uucode vendors.
+
+const std = @import("std");
+const testing = std.testing;
+const unicode = @import("../unicode/main.zig");
+const types = @import("types.zig");
+const zig_backend = @import("zig.zig");
+
+const BidiClass = unicode.BidiClass;
+const Level = types.Level;
+
+/// A representative codepoint for each Bidi_Class.
+///
+/// `BidiTest.txt` specifies inputs as class names rather than characters,
+/// so a conforming implementation has to pick a character per class. Every
+/// one of these is verified against our own tables in a test below, so a
+/// wrong choice fails loudly instead of silently testing the wrong thing.
+pub fn sampleCodepoint(c: BidiClass) u21 {
+    return switch (c) {
+        .l => 0x0061, // LATIN SMALL LETTER A
+        .r => 0x05D0, // HEBREW LETTER ALEF
+        .al => 0x0627, // ARABIC LETTER ALEF
+        .en => 0x0030, // DIGIT ZERO
+        .es => 0x002B, // PLUS SIGN
+        .et => 0x0023, // NUMBER SIGN
+        .an => 0x0660, // ARABIC-INDIC DIGIT ZERO
+        .cs => 0x002C, // COMMA
+        .nsm => 0x0300, // COMBINING GRAVE ACCENT
+        .bn => 0x00AD, // SOFT HYPHEN
+        .b => 0x2029, // PARAGRAPH SEPARATOR
+        .s => 0x0009, // CHARACTER TABULATION
+        .ws => 0x0020, // SPACE
+        .on => 0x0021, // EXCLAMATION MARK
+        .lre => 0x202A,
+        .rle => 0x202B,
+        .pdf => 0x202C,
+        .lro => 0x202D,
+        .rlo => 0x202E,
+        .lri => 0x2066,
+        .rli => 0x2067,
+        .fsi => 0x2068,
+        .pdi => 0x2069,
+    };
+}
+
+fn classFromName(name: []const u8) ?BidiClass {
+    const map = .{
+        .{ "L", BidiClass.l },     .{ "R", BidiClass.r },
+        .{ "AL", BidiClass.al },   .{ "EN", BidiClass.en },
+        .{ "ES", BidiClass.es },   .{ "ET", BidiClass.et },
+        .{ "AN", BidiClass.an },   .{ "CS", BidiClass.cs },
+        .{ "NSM", BidiClass.nsm }, .{ "BN", BidiClass.bn },
+        .{ "B", BidiClass.b },     .{ "S", BidiClass.s },
+        .{ "WS", BidiClass.ws },   .{ "ON", BidiClass.on },
+        .{ "LRE", BidiClass.lre }, .{ "RLE", BidiClass.rle },
+        .{ "LRO", BidiClass.lro }, .{ "RLO", BidiClass.rlo },
+        .{ "PDF", BidiClass.pdf }, .{ "LRI", BidiClass.lri },
+        .{ "RLI", BidiClass.rli }, .{ "FSI", BidiClass.fsi },
+        .{ "PDI", BidiClass.pdi },
+    };
+    inline for (map) |entry| {
+        if (std.mem.eql(u8, name, entry[0])) return entry[1];
+    }
+    return null;
+}
+
+/// Expected levels, where null means "implementation dependent" (the `x`
+/// marker used for characters removed by X9).
+const Expected = struct {
+    levels: std.ArrayList(?Level) = .empty,
+    reorder: std.ArrayList(u16) = .empty,
+
+    fn deinit(self: *Expected, alloc: std.mem.Allocator) void {
+        self.levels.deinit(alloc);
+        self.reorder.deinit(alloc);
+    }
+};
+
+/// Check one case: resolve `cps` and compare against the expected levels
+/// and visual order. Returns null on success or a description on failure.
+pub fn checkCase(
+    alloc: std.mem.Allocator,
+    resolver: *zig_backend.Resolver,
+    cps: []const u21,
+    direction: types.ParagraphDirection,
+    expected: *const Expected,
+) !bool {
+    const result = try resolver.resolve(alloc, cps, .{ .direction = direction });
+
+    // Levels, skipping the entries the suite marks as don't-care.
+    if (expected.levels.items.len != cps.len) return false;
+    for (expected.levels.items, 0..) |want_, i| {
+        const want = want_ orelse continue;
+        if (result.level(i) != want) return false;
+    }
+
+    // Visual order, omitting the characters the suite treats as removed.
+    var got: std.ArrayList(u16) = .empty;
+    defer got.deinit(alloc);
+    for (0..cps.len) |v| {
+        const logical = result.logicalIndex(v);
+        if (expected.levels.items[logical] == null) continue;
+        try got.append(alloc, @intCast(logical));
+    }
+
+    if (got.items.len != expected.reorder.items.len) return false;
+    for (got.items, expected.reorder.items) |a, b| {
+        if (a != b) return false;
+    }
+
+    return true;
+}
+
+fn parseLevels(
+    alloc: std.mem.Allocator,
+    out: *std.ArrayList(?Level),
+    spec: []const u8,
+) !void {
+    out.clearRetainingCapacity();
+    var it = std.mem.tokenizeAny(u8, spec, " \t");
+    while (it.next()) |tok| {
+        if (std.mem.eql(u8, tok, "x")) {
+            try out.append(alloc, null);
+        } else {
+            try out.append(alloc, try std.fmt.parseInt(Level, tok, 10));
+        }
+    }
+}
+
+fn parseReorder(
+    alloc: std.mem.Allocator,
+    out: *std.ArrayList(u16),
+    spec: []const u8,
+) !void {
+    out.clearRetainingCapacity();
+    var it = std.mem.tokenizeAny(u8, spec, " \t");
+    while (it.next()) |tok| {
+        try out.append(alloc, try std.fmt.parseInt(u16, tok, 10));
+    }
+}
+
+/// Read a UCD test file from `src/bidi/testdata`, or return null if it
+/// has not been downloaded.
+fn openUcd(alloc: std.mem.Allocator, comptime name: []const u8) !?[]u8 {
+    const path = "src/bidi/testdata/" ++ name;
+    return std.Io.Dir.cwd().readFileAlloc(
+        testing.io,
+        path,
+        alloc,
+        .unlimited,
+    ) catch |err| switch (err) {
+        error.FileNotFound => {
+            std.log.warn(
+                "skipping bidi conformance: {s} not present. " ++
+                    "See the comment at the top of conformance_test.zig.",
+                .{path},
+            );
+            return null;
+        },
+        else => return err,
+    };
+}
+
+test "bidi conformance: BidiTest.txt" {
+    const alloc = testing.allocator;
+
+    const content = (try openUcd(alloc, "BidiTest.txt")) orelse
+        return error.SkipZigTest;
+    defer alloc.free(content);
+
+    var resolver: zig_backend.Resolver = .empty;
+    defer resolver.deinit(alloc);
+
+    var expected: Expected = .{};
+    defer expected.deinit(alloc);
+
+    var cps: std.ArrayList(u21) = .empty;
+    defer cps.deinit(alloc);
+
+    var total: usize = 0;
+    var failed: usize = 0;
+    var first_failure: [256]u8 = undefined;
+    var first_failure_len: usize = 0;
+
+    var lines = std.mem.splitScalar(u8, content, '\n');
+    while (lines.next()) |raw| {
+        const line = std.mem.trim(u8, raw, " \t\r");
+        if (line.len == 0 or line[0] == '#') continue;
+
+        if (std.mem.startsWith(u8, line, "@Levels:")) {
+            try parseLevels(alloc, &expected.levels, line["@Levels:".len..]);
+            continue;
+        }
+        if (std.mem.startsWith(u8, line, "@Reorder:")) {
+            try parseReorder(alloc, &expected.reorder, line["@Reorder:".len..]);
+            continue;
+        }
+
+        // A data line: "<class> <class> ...; <bitset>"
+        const semi = std.mem.indexOfScalar(u8, line, ';') orelse continue;
+        const classes = line[0..semi];
+        const bitset = try std.fmt.parseInt(u8, std.mem.trim(u8, line[semi + 1 ..], " \t"), 10);
+
+        cps.clearRetainingCapacity();
+        var ok = true;
+        var it = std.mem.tokenizeAny(u8, classes, " \t");
+        while (it.next()) |name| {
+            const c = classFromName(name) orelse {
+                ok = false;
+                break;
+            };
+            try cps.append(alloc, sampleCodepoint(c));
+        }
+        if (!ok) continue;
+
+        // Bit 1 is auto, bit 2 is LTR, bit 4 is RTL.
+        const dirs = [_]struct { mask: u8, dir: types.ParagraphDirection }{
+            .{ .mask = 1, .dir = .auto },
+            .{ .mask = 2, .dir = .ltr },
+            .{ .mask = 4, .dir = .rtl },
+        };
+        for (dirs) |d| {
+            if (bitset & d.mask == 0) continue;
+            total += 1;
+            const pass = try checkCase(alloc, &resolver, cps.items, d.dir, &expected);
+            if (!pass) {
+                failed += 1;
+                if (first_failure_len == 0) {
+                    if (std.fmt.bufPrint(
+                        &first_failure,
+                        "classes=[{s}] dir={s}",
+                        .{ std.mem.trim(u8, classes, " \t"), @tagName(d.dir) },
+                    )) |msg| {
+                        first_failure_len = msg.len;
+                    } else |_| {}
+                }
+            }
+        }
+    }
+
+    std.log.warn("BidiTest.txt: {d} cases, {d} failed", .{ total, failed });
+    if (failed > 0) {
+        std.log.warn("first failure: {s}", .{first_failure[0..first_failure_len]});
+    }
+    try testing.expect(total > 0);
+    try testing.expectEqual(@as(usize, 0), failed);
+}
+
+test "bidi conformance: BidiCharacterTest.txt" {
+    const alloc = testing.allocator;
+
+    const content = (try openUcd(alloc, "BidiCharacterTest.txt")) orelse
+        return error.SkipZigTest;
+    defer alloc.free(content);
+
+    var resolver: zig_backend.Resolver = .empty;
+    defer resolver.deinit(alloc);
+
+    var expected: Expected = .{};
+    defer expected.deinit(alloc);
+
+    var cps: std.ArrayList(u21) = .empty;
+    defer cps.deinit(alloc);
+
+    var total: usize = 0;
+    var failed: usize = 0;
+    var first_failure: [512]u8 = undefined;
+    var first_failure_len: usize = 0;
+
+    var lines = std.mem.splitScalar(u8, content, '\n');
+    while (lines.next()) |raw| {
+        const line = std.mem.trim(u8, raw, " \t\r");
+        if (line.len == 0 or line[0] == '#') continue;
+
+        // <codepoints>;<direction>;<para level>;<levels>;<reorder>
+        var fields = std.mem.splitScalar(u8, line, ';');
+        const cps_str = fields.next() orelse continue;
+        const dir_str = fields.next() orelse continue;
+        const para_str = fields.next() orelse continue;
+        const levels_str = fields.next() orelse continue;
+        const reorder_str = fields.next() orelse continue;
+
+        cps.clearRetainingCapacity();
+        var it = std.mem.tokenizeAny(u8, cps_str, " \t");
+        while (it.next()) |tok| {
+            try cps.append(alloc, try std.fmt.parseInt(u21, tok, 16));
+        }
+        if (cps.items.len == 0) continue;
+
+        const dir: types.ParagraphDirection = switch (try std.fmt.parseInt(u8, dir_str, 10)) {
+            0 => .ltr,
+            1 => .rtl,
+            2 => .auto,
+            else => continue,
+        };
+
+        try parseLevels(alloc, &expected.levels, levels_str);
+        try parseReorder(alloc, &expected.reorder, reorder_str);
+
+        total += 1;
+
+        // The suite also states the resolved paragraph level.
+        const want_para = try std.fmt.parseInt(Level, para_str, 10);
+        const result = try resolver.resolve(alloc, cps.items, .{ .direction = dir });
+        const got_para: Level = switch (result.direction) {
+            .ltr => 0,
+            .rtl => 1,
+        };
+
+        const pass = got_para == want_para and
+            try checkCase(alloc, &resolver, cps.items, dir, &expected);
+
+        if (!pass) {
+            failed += 1;
+            if (first_failure_len == 0) {
+                if (std.fmt.bufPrint(
+                    &first_failure,
+                    "cps=[{s}] dir={s}",
+                    .{ std.mem.trim(u8, cps_str, " \t"), @tagName(dir) },
+                )) |msg| {
+                    first_failure_len = msg.len;
+                } else |_| {}
+            }
+        }
+    }
+
+    std.log.warn("BidiCharacterTest.txt: {d} cases, {d} failed", .{ total, failed });
+    if (failed > 0) {
+        std.log.warn("first failure: {s}", .{first_failure[0..first_failure_len]});
+    }
+    try testing.expect(total > 0);
+    try testing.expectEqual(@as(usize, 0), failed);
+}
+
+test "conformance: sample codepoints have the class they claim" {
+    // If any of these drifted, BidiTest.txt would be silently exercising
+    // the wrong characters and could pass while the implementation is
+    // wrong. BN is the exception: several classes have no single
+    // canonical representative, so we assert on the class we looked up.
+    for (std.enums.values(BidiClass)) |c| {
+        const cp = sampleCodepoint(c);
+        try testing.expectEqual(c, unicode.bidiClass(cp));
+    }
+}

--- a/src/bidi/main.zig
+++ b/src/bidi/main.zig
@@ -32,6 +32,7 @@ const builtin = @import("builtin");
 const build_config = @import("../build_config.zig");
 
 pub const noop = @import("noop.zig");
+pub const scan = @import("scan.zig");
 pub const types = @import("types.zig");
 pub const zig = @import("zig.zig");
 
@@ -74,6 +75,7 @@ test {
     // same way `src/font/shape.zig` always tests its noop shaper. The
     // conformance suite in particular must run on every build.
     _ = noop;
+    _ = scan;
     _ = zig;
     _ = @import("conformance_test.zig");
 }

--- a/src/bidi/main.zig
+++ b/src/bidi/main.zig
@@ -33,6 +33,7 @@ const build_config = @import("../build_config.zig");
 
 pub const noop = @import("noop.zig");
 pub const types = @import("types.zig");
+pub const zig = @import("zig.zig");
 
 pub const Backend = @import("backend.zig").Backend;
 pub const Direction = types.Direction;
@@ -63,15 +64,18 @@ pub const options: struct {
 /// next `resolve` call.
 pub const Resolver = switch (options.backend) {
     .noop => noop.Resolver,
+    .zig => zig.Resolver,
 };
 
 test {
     _ = types;
-    _ = noop;
 
-    // Always test the noop backend regardless of what we're built with,
-    // the same way `src/font/shape.zig` always tests its noop shaper.
-    _ = noop.Resolver;
+    // Always test every backend regardless of what we're built with, the
+    // same way `src/font/shape.zig` always tests its noop shaper. The
+    // conformance suite in particular must run on every build.
+    _ = noop;
+    _ = zig;
+    _ = @import("conformance_test.zig");
 }
 
 test "Resolver: round trips through the selected backend" {

--- a/src/bidi/main.zig
+++ b/src/bidi/main.zig
@@ -1,0 +1,97 @@
+//! Unicode Bidirectional Algorithm (UAX #9) support.
+//!
+//! This package turns a paragraph of codepoints in *logical* order into the
+//! information needed to display it in *visual* order: an embedding level
+//! per element, a permutation between the two orders, and the level runs a
+//! shaper needs to hand correctly-directioned text to HarfBuzz.
+//!
+//! ## What this package does not do
+//!
+//! It knows nothing about terminals. It operates on a flat array of
+//! codepoints and returns flat index mappings. Adapting a row of terminal
+//! cells (wide-character spacers, grapheme continuations, styles) into that
+//! array, and caching the result per row, belongs to the caller. Keeping
+//! the boundary here means the algorithm can be tested against the Unicode
+//! conformance suites without a terminal in the picture.
+//!
+//! It also never mutates anything. Logical order remains authoritative
+//! everywhere in Ghostty; visual order is derived for display and thrown
+//! away. See `src/terminal/point.zig` for the types that keep the two
+//! coordinate spaces apart at compile time.
+//!
+//! ## Backends
+//!
+//! The implementation is selected at comptime via `-Dbidi-backend`, in the
+//! same style as the font shaper in `src/font/shape.zig`. Only the identity
+//! `noop` backend exists today; a native Zig implementation of UAX #9 lands
+//! behind this same interface, at which point selecting it is a one-word
+//! build-flag change and nothing outside this package moves.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const build_config = @import("../build_config.zig");
+
+pub const noop = @import("noop.zig");
+pub const types = @import("types.zig");
+
+pub const Backend = @import("backend.zig").Backend;
+pub const Direction = types.Direction;
+pub const Level = types.Level;
+pub const LevelRun = types.LevelRun;
+pub const Options = types.Options;
+pub const ParagraphDirection = types.ParagraphDirection;
+pub const Result = types.Result;
+pub const levelDirection = types.levelDirection;
+pub const max_depth = types.max_depth;
+
+/// Build options.
+pub const options: struct {
+    backend: Backend,
+} = .{
+    .backend = build_config.bidi_backend,
+};
+
+/// The resolver implementation for our build options.
+///
+/// Every backend exposes the same API:
+///
+///     var resolver: Resolver = .empty;
+///     defer resolver.deinit(alloc);
+///     const result = try resolver.resolve(alloc, codepoints, .{});
+///
+/// The result borrows the resolver's buffers and is valid only until the
+/// next `resolve` call.
+pub const Resolver = switch (options.backend) {
+    .noop => noop.Resolver,
+};
+
+test {
+    _ = types;
+    _ = noop;
+
+    // Always test the noop backend regardless of what we're built with,
+    // the same way `src/font/shape.zig` always tests its noop shaper.
+    _ = noop.Resolver;
+}
+
+test "Resolver: round trips through the selected backend" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var resolver: Resolver = .empty;
+    defer resolver.deinit(alloc);
+
+    const cps = [_]u21{ 'a', 'b', 'c' };
+    const result = try resolver.resolve(alloc, &cps, .{});
+    try testing.expectEqual(@as(usize, 3), result.len);
+
+    // Whatever the backend, visual and logical indices must round trip.
+    for (0..result.len) |i| {
+        try testing.expectEqual(i, result.logicalIndex(result.visualIndex(i)));
+    }
+
+    // And the level runs must cover every element exactly once.
+    var covered: usize = 0;
+    for (result.runs) |run| covered += run.len;
+    try testing.expectEqual(result.len, covered);
+}

--- a/src/bidi/noop.zig
+++ b/src/bidi/noop.zig
@@ -1,0 +1,182 @@
+//! The identity bidi backend.
+//!
+//! This resolves every paragraph to left-to-right with visual order equal
+//! to logical order. It is what Ghostty ships with until the rendering
+//! pipeline that consumes real bidi results exists, and it remains the
+//! escape hatch for builds that want bidi compiled out entirely.
+//!
+//! It is not a stub: it implements the full `Resolver` API and produces
+//! well-formed results, so every consumer can be written and tested against
+//! it before a real backend arrives.
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const types = @import("types.zig");
+
+const Level = types.Level;
+const LevelRun = types.LevelRun;
+const Options = types.Options;
+const Result = types.Result;
+
+pub const Resolver = struct {
+    /// The single synthesized level run. Kept in the resolver rather than
+    /// returned by value so that `Result.runs` has the same lifetime rules
+    /// for every backend.
+    runs: std.ArrayList(LevelRun) = .empty,
+
+    pub const empty: Resolver = .{};
+
+    pub fn deinit(self: *Resolver, alloc: Allocator) void {
+        self.runs.deinit(alloc);
+        self.* = undefined;
+    }
+
+    /// Resolve one paragraph.
+    ///
+    /// The returned slices borrow this resolver's buffers and are valid
+    /// until the next call. `opts` is accepted for API parity and ignored:
+    /// a backend that performs no reordering has no meaningful response to
+    /// a forced paragraph direction, and pretending otherwise would report
+    /// a direction inconsistent with the identity mapping it returns.
+    pub fn resolve(
+        self: *Resolver,
+        alloc: Allocator,
+        codepoints: []const u21,
+        opts: Options,
+    ) Allocator.Error!Result {
+        _ = opts;
+
+        std.debug.assert(codepoints.len <= std.math.maxInt(u16));
+        if (codepoints.len == 0) return .empty;
+
+        // Retains capacity, so this is allocation-free after the first
+        // call for any row length seen so far.
+        self.runs.clearRetainingCapacity();
+        try self.runs.append(alloc, .{
+            .visual_start = 0,
+            .len = @intCast(codepoints.len),
+            .logical_start = 0,
+            .level = 0,
+        });
+
+        return .{
+            .direction = .ltr,
+            .len = codepoints.len,
+            .identity = true,
+            .levels = &.{},
+            .v2l = &.{},
+            .l2v = &.{},
+            .runs = self.runs.items,
+        };
+    }
+};
+
+test "noop: empty input" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var r: Resolver = .empty;
+    defer r.deinit(alloc);
+
+    const result = try r.resolve(alloc, &.{}, .{});
+    try testing.expectEqual(@as(usize, 0), result.len);
+    try testing.expect(result.identity);
+    try testing.expectEqual(@as(usize, 0), result.runs.len);
+}
+
+test "noop: ascii resolves to identity" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var r: Resolver = .empty;
+    defer r.deinit(alloc);
+
+    const cps = [_]u21{ 'h', 'e', 'l', 'l', 'o' };
+    const result = try r.resolve(alloc, &cps, .{});
+
+    try testing.expectEqual(types.Direction.ltr, result.direction);
+    try testing.expectEqual(@as(usize, 5), result.len);
+    try testing.expect(result.identity);
+    try testing.expectEqual(@as(usize, 0), result.levels.len);
+    try testing.expectEqual(@as(usize, 0), result.v2l.len);
+    try testing.expectEqual(@as(usize, 0), result.l2v.len);
+
+    for (0..5) |i| {
+        try testing.expectEqual(i, result.logicalIndex(i));
+        try testing.expectEqual(i, result.visualIndex(i));
+        try testing.expectEqual(@as(Level, 0), result.level(i));
+    }
+}
+
+test "noop: rtl input still resolves to identity" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var r: Resolver = .empty;
+    defer r.deinit(alloc);
+
+    // Hebrew alef-bet-gimel. A real backend reverses these; noop must not,
+    // because "no reordering" is exactly its contract.
+    const cps = [_]u21{ 0x05D0, 0x05D1, 0x05D2 };
+    const result = try r.resolve(alloc, &cps, .{});
+
+    try testing.expect(result.identity);
+    try testing.expectEqual(types.Direction.ltr, result.direction);
+    for (0..3) |i| try testing.expectEqual(i, result.logicalIndex(i));
+}
+
+test "noop: forced direction is ignored" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var r: Resolver = .empty;
+    defer r.deinit(alloc);
+
+    const cps = [_]u21{ 'a', 'b' };
+    const result = try r.resolve(alloc, &cps, .{ .direction = .rtl });
+
+    // Reporting .rtl here would contradict the identity mapping we return.
+    try testing.expectEqual(types.Direction.ltr, result.direction);
+    try testing.expect(result.identity);
+}
+
+test "noop: produces exactly one level run" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var r: Resolver = .empty;
+    defer r.deinit(alloc);
+
+    const cps = [_]u21{ 'a', 'b', 'c', 'd' };
+    const result = try r.resolve(alloc, &cps, .{});
+
+    try testing.expectEqual(@as(usize, 1), result.runs.len);
+    const run = result.runs[0];
+    try testing.expectEqual(@as(u16, 0), run.visual_start);
+    try testing.expectEqual(@as(u16, 4), run.len);
+    try testing.expectEqual(@as(u16, 0), run.logical_start);
+    try testing.expectEqual(@as(Level, 0), run.level);
+    try testing.expectEqual(types.Direction.ltr, run.direction());
+}
+
+test "noop: steady state performs no allocations" {
+    const testing = std.testing;
+
+    var counting: std.testing.FailingAllocator = .init(testing.allocator, .{
+        .fail_index = std.math.maxInt(usize),
+    });
+    const alloc = counting.allocator();
+
+    var r: Resolver = .empty;
+    defer r.deinit(alloc);
+
+    const cps = [_]u21{ 'a', 'b', 'c' };
+
+    // Warm up: this one is allowed to allocate the run buffer.
+    _ = try r.resolve(alloc, &cps, .{});
+    const after_warmup = counting.allocations;
+
+    // Every subsequent call must reuse the retained capacity.
+    for (0..64) |_| _ = try r.resolve(alloc, &cps, .{});
+    try testing.expectEqual(after_warmup, counting.allocations);
+}

--- a/src/bidi/scan.zig
+++ b/src/bidi/scan.zig
@@ -1,0 +1,155 @@
+//! The bidi fast-path scan.
+//!
+//! Deciding that a paragraph cannot be affected by the bidirectional
+//! algorithm is worth far more than making the algorithm fast, because
+//! the overwhelming majority of what a terminal renders is plain
+//! left-to-right text. This scan is what keeps that text out of the
+//! resolver entirely.
+//!
+//! ## Why a single threshold is sufficient
+//!
+//! `U+0590` is the first codepoint of the Hebrew block and the start of
+//! the first right-to-left range in Unicode. Below it there is no
+//! character with Bidi_Class R, AL, or AN, and none of the explicit
+//! formatting characters (LRM, RLM, ALM, the embeddings, overrides, and
+//! isolates all live at U+200E and above).
+//!
+//! That is not quite enough on its own, because European Numbers are
+//! raised two levels by rule I1 even at an even embedding level. What
+//! saves us is W7: with a paragraph level of 0 the sequence's start-of-
+//! sequence type is L, so every EN resolves to L before I1 runs and no
+//! level is ever raised. A paragraph forced to right-to-left breaks that
+//! reasoning, so the caller must not use this scan in that case.
+//!
+//! The soundness of all of the above is not left to argument: a test
+//! below runs the full resolver over every codepoint this scan accepts
+//! and over randomized strings built from them, and asserts the result
+//! really is the identity.
+//!
+//! ## Asymmetry of failure
+//!
+//! A false positive here renders text backwards. A false negative only
+//! costs time. The scan is therefore written to be conservative, and the
+//! vectorized and scalar forms are checked against each other.
+
+const std = @import("std");
+const simd = @import("../simd/main.zig");
+
+/// The first codepoint that can influence bidi resolution.
+pub const threshold: u21 = 0x0590;
+
+/// True if no codepoint in `codepoints` can influence bidi resolution,
+/// meaning visual order is guaranteed to equal logical order.
+///
+/// Only valid when the paragraph direction is left-to-right or is being
+/// derived from the content (rules P2/P3). A caller forcing a
+/// right-to-left paragraph must not use this.
+pub fn isTriviallyLtr(codepoints: []const u21) bool {
+    var i: usize = 0;
+
+    // Manually vectorized: this is an early-exit search that LLVM will
+    // not auto-vectorize, and the all-accept case dominates real input,
+    // so it is worth scanning several codepoints per iteration. Same
+    // idiom as the printable-run scan in `terminal/stream.zig`.
+    if (simd.lanes(u21)) |lanes| {
+        const V = @Vector(lanes, u21);
+        const limit: V = @splat(threshold);
+        while (i + lanes <= codepoints.len) : (i += lanes) {
+            const v: V = codepoints[i..][0..lanes].*;
+            if (@reduce(.Or, v >= limit)) return false;
+        }
+    }
+
+    // Tail, and the whole scan on targets without usable SIMD.
+    while (i < codepoints.len) : (i += 1) {
+        if (codepoints[i] >= threshold) return false;
+    }
+
+    return true;
+}
+
+/// The scalar reference implementation, kept so the vectorized form can
+/// be differentially tested against something obviously correct.
+fn isTriviallyLtrScalar(codepoints: []const u21) bool {
+    for (codepoints) |cp| {
+        if (cp >= threshold) return false;
+    }
+    return true;
+}
+
+test "scan: basic acceptance and rejection" {
+    const testing = std.testing;
+
+    try testing.expect(isTriviallyLtr(&.{}));
+    try testing.expect(isTriviallyLtr(&.{ 'h', 'e', 'l', 'l', 'o' }));
+    try testing.expect(isTriviallyLtr(&.{ '1', '2', '3', '.', '4' }));
+
+    // Greek and Cyrillic are below the threshold and left-to-right.
+    try testing.expect(isTriviallyLtr(&.{ 0x03B1, 0x0416 }));
+
+    // Hebrew, Arabic, and the formatting characters are all rejected.
+    try testing.expect(!isTriviallyLtr(&.{0x05D0}));
+    try testing.expect(!isTriviallyLtr(&.{0x0627}));
+    try testing.expect(!isTriviallyLtr(&.{0x200F})); // RLM
+    try testing.expect(!isTriviallyLtr(&.{0x202E})); // RLO
+    try testing.expect(!isTriviallyLtr(&.{0x2067})); // RLI
+    try testing.expect(!isTriviallyLtr(&.{0x0590})); // exactly the threshold
+}
+
+test "scan: rejection at every position and length" {
+    const testing = std.testing;
+
+    // A rejecting codepoint must be found wherever it sits, including in
+    // the vector tail. Lengths are swept past several vector widths so
+    // the tail handling is covered for any lane count.
+    var buf: [67]u21 = undefined;
+    for (1..buf.len + 1) |len| {
+        for (0..len) |pos| {
+            @memset(buf[0..len], 'a');
+            buf[pos] = 0x05D0;
+            try testing.expect(!isTriviallyLtr(buf[0..len]));
+
+            buf[pos] = 'a';
+            try testing.expect(isTriviallyLtr(buf[0..len]));
+        }
+    }
+}
+
+test "scan: vectorized agrees with scalar" {
+    const testing = std.testing;
+
+    var prng = std.Random.DefaultPrng.init(0x5E5E);
+    const rand = prng.random();
+
+    var buf: [512]u21 = undefined;
+    for (0..2000) |_| {
+        const len = rand.uintLessThan(usize, buf.len);
+        for (buf[0..len]) |*cp| {
+            // Weighted toward the accepting range so both outcomes occur
+            // frequently and neither branch dominates the sample.
+            cp.* = if (rand.float(f32) < 0.98)
+                rand.uintLessThan(u21, threshold)
+            else
+                rand.intRangeAtMost(u21, threshold, 0x10FFFF);
+        }
+
+        try testing.expectEqual(
+            isTriviallyLtrScalar(buf[0..len]),
+            isTriviallyLtr(buf[0..len]),
+        );
+    }
+}
+
+test "scan: exhaustive over every codepoint" {
+    const testing = std.testing;
+
+    // Every codepoint, checked one at a time against the scalar
+    // reference. This is the cheap half of the soundness argument; the
+    // expensive half (that accepted input really resolves to the
+    // identity) lives in `zig.zig` where the resolver is available.
+    for (0..std.math.maxInt(u21) + 1) |i| {
+        const cp: u21 = @intCast(i);
+        const one = [_]u21{cp};
+        try testing.expectEqual(cp < threshold, isTriviallyLtr(&one));
+    }
+}

--- a/src/bidi/testdata/README.md
+++ b/src/bidi/testdata/README.md
@@ -1,0 +1,41 @@
+# Bidi conformance test data
+
+The tests in `../conformance_test.zig` run against the Unicode Character
+Database's own bidi test suites. Those two files total roughly 15 MB, which
+is a large thing to add to the repository, so they are **not** checked in
+and this directory ignores them.
+
+Download them before running the conformance tests:
+
+```sh
+curl -o src/bidi/testdata/BidiTest.txt \
+  https://www.unicode.org/Public/UCD/latest/ucd/BidiTest.txt
+curl -o src/bidi/testdata/BidiCharacterTest.txt \
+  https://www.unicode.org/Public/UCD/latest/ucd/BidiCharacterTest.txt
+
+zig build test -Dtest-filter="bidi conformance"
+```
+
+Without them the conformance tests skip with a warning. Everything else in
+`src/bidi` is covered by hand-written tests that always run.
+
+## Version
+
+The files must come from the same Unicode version that the property tables
+in `src/unicode` were generated from, which is whatever `uucode` vendors
+(Unicode 17.0.0 at the time of writing). Mixing versions produces failures
+that look like algorithm bugs but are really data mismatches. The version
+is in the first line of each file.
+
+## Coverage
+
+The two suites are complementary and both are needed:
+
+- `BidiTest.txt` specifies inputs as Bidi_Class names, so a conforming
+  implementation picks a representative character per class. It covers the
+  rule combinations exhaustively but cannot express paired brackets,
+  because bracket-ness is a property of specific characters rather than of
+  a class.
+- `BidiCharacterTest.txt` specifies real codepoints, and is what actually
+  exercises rule N0. Disabling bracket resolution fails ~14,500 cases here
+  and zero in `BidiTest.txt`.

--- a/src/bidi/types.zig
+++ b/src/bidi/types.zig
@@ -1,0 +1,220 @@
+//! Vocabulary types shared by every bidi backend.
+//!
+//! These are deliberately backend-agnostic: they describe the *result* of
+//! running the Unicode Bidirectional Algorithm (UAX #9), not how it was
+//! computed. Swapping the backend must never change these.
+
+const std = @import("std");
+
+/// A resolved direction. Levels are even for left-to-right and odd for
+/// right-to-left (UAX #9, rules I1/I2).
+pub const Direction = enum(u1) {
+    ltr,
+    rtl,
+};
+
+/// An embedding level. UAX #9 caps the maximum depth at 125 (BD2), so this
+/// always fits in a u8 with room to spare.
+pub const Level = u8;
+
+/// The maximum explicit embedding depth (UAX #9, BD2).
+pub const max_depth: Level = 125;
+
+/// The direction implied by an embedding level: even is LTR, odd is RTL.
+pub fn levelDirection(level: Level) Direction {
+    return if (level & 1 == 0) .ltr else .rtl;
+}
+
+/// How to determine the paragraph embedding level.
+pub const ParagraphDirection = enum {
+    /// Derive it from the first strong character (UAX #9, rules P2/P3),
+    /// defaulting to left-to-right if there is none.
+    auto,
+
+    /// Force a left-to-right paragraph, skipping P2/P3.
+    ltr,
+
+    /// Force a right-to-left paragraph, skipping P2/P3.
+    rtl,
+};
+
+/// A maximal run of elements sharing one embedding level, in visual order.
+///
+/// Rule L2 reverses contiguous level runs, which means a run is contiguous
+/// in both logical and visual order. That is what lets a shaper treat a run
+/// as a plain logical substring plus a direction.
+pub const LevelRun = struct {
+    /// The first visual index covered by this run.
+    visual_start: u16,
+
+    /// The number of elements in the run.
+    len: u16,
+
+    /// The lowest logical index covered by this run. For a right-to-left
+    /// run the logical indices descend as the visual indices ascend, so
+    /// this is the logical index of the run's *last* visual element.
+    logical_start: u16,
+
+    /// The resolved embedding level of every element in the run.
+    level: Level,
+
+    pub fn direction(self: LevelRun) Direction {
+        return levelDirection(self.level);
+    }
+};
+
+/// Options for a single resolve call.
+pub const Options = struct {
+    /// How to determine the paragraph embedding level.
+    direction: ParagraphDirection = .auto,
+};
+
+/// The result of resolving one paragraph.
+///
+/// The slices borrow the resolver's internal buffers and are only valid
+/// until the next call to `resolve` on that resolver. Callers that need to
+/// retain the mapping must copy it (the renderer's row cache does exactly
+/// this in a later phase).
+///
+/// ## The identity fast path
+///
+/// When `identity` is true, visual order equals logical order and
+/// `levels`, `v2l`, and `l2v` are left empty rather than being filled with
+/// a trivial 0..n mapping. This is the whole point of the fast path: a row
+/// of pure left-to-right text costs no allocation and no table writes. Use
+/// the accessors below rather than indexing the slices directly so this
+/// stays transparent.
+pub const Result = struct {
+    /// The resolved paragraph direction.
+    direction: Direction,
+
+    /// The number of elements this result describes.
+    len: usize,
+
+    /// True when visual order equals logical order. See above.
+    identity: bool,
+
+    /// Resolved embedding level per logical index. Empty when `identity`.
+    levels: []const Level,
+
+    /// Visual index to logical index. Empty when `identity`.
+    v2l: []const u16,
+
+    /// Logical index to visual index. Empty when `identity`.
+    l2v: []const u16,
+
+    /// Level runs in visual order. Always populated, including for the
+    /// identity case, so run iteration needs no special casing.
+    runs: []const LevelRun,
+
+    /// The logical index displayed at the given visual index.
+    pub inline fn logicalIndex(self: Result, visual: usize) usize {
+        std.debug.assert(visual < self.len);
+        return if (self.identity) visual else self.v2l[visual];
+    }
+
+    /// The visual index at which the given logical index is displayed.
+    pub inline fn visualIndex(self: Result, logical: usize) usize {
+        std.debug.assert(logical < self.len);
+        return if (self.identity) logical else self.l2v[logical];
+    }
+
+    /// The resolved embedding level of the given logical index.
+    pub inline fn level(self: Result, logical: usize) Level {
+        std.debug.assert(logical < self.len);
+        return if (self.identity) 0 else self.levels[logical];
+    }
+
+    /// An empty result, for zero-length input.
+    pub const empty: Result = .{
+        .direction = .ltr,
+        .len = 0,
+        .identity = true,
+        .levels = &.{},
+        .v2l = &.{},
+        .l2v = &.{},
+        .runs = &.{},
+    };
+};
+
+test "levelDirection" {
+    const testing = std.testing;
+    try testing.expectEqual(Direction.ltr, levelDirection(0));
+    try testing.expectEqual(Direction.rtl, levelDirection(1));
+    try testing.expectEqual(Direction.ltr, levelDirection(2));
+    try testing.expectEqual(Direction.rtl, levelDirection(125));
+}
+
+test "LevelRun direction" {
+    const testing = std.testing;
+    const ltr: LevelRun = .{
+        .visual_start = 0,
+        .len = 3,
+        .logical_start = 0,
+        .level = 0,
+    };
+    const rtl: LevelRun = .{
+        .visual_start = 3,
+        .len = 3,
+        .logical_start = 3,
+        .level = 1,
+    };
+    try testing.expectEqual(Direction.ltr, ltr.direction());
+    try testing.expectEqual(Direction.rtl, rtl.direction());
+}
+
+test "Result: identity accessors need no tables" {
+    const testing = std.testing;
+
+    const r: Result = .{
+        .direction = .ltr,
+        .len = 4,
+        .identity = true,
+        .levels = &.{},
+        .v2l = &.{},
+        .l2v = &.{},
+        .runs = &.{},
+    };
+
+    for (0..4) |i| {
+        try testing.expectEqual(i, r.logicalIndex(i));
+        try testing.expectEqual(i, r.visualIndex(i));
+        try testing.expectEqual(@as(Level, 0), r.level(i));
+    }
+}
+
+test "Result: non-identity accessors read the tables" {
+    const testing = std.testing;
+
+    // Logical "abcABC" where ABC is RTL: visual order is abcCBA.
+    const levels = [_]Level{ 0, 0, 0, 1, 1, 1 };
+    const v2l = [_]u16{ 0, 1, 2, 5, 4, 3 };
+    const l2v = [_]u16{ 0, 1, 2, 5, 4, 3 };
+
+    const r: Result = .{
+        .direction = .ltr,
+        .len = 6,
+        .identity = false,
+        .levels = &levels,
+        .v2l = &v2l,
+        .l2v = &l2v,
+        .runs = &.{},
+    };
+
+    try testing.expectEqual(@as(usize, 5), r.logicalIndex(3));
+    try testing.expectEqual(@as(usize, 3), r.visualIndex(5));
+    try testing.expectEqual(@as(Level, 1), r.level(4));
+    try testing.expectEqual(@as(Level, 0), r.level(0));
+
+    // v2l and l2v must be inverse permutations of each other.
+    for (0..6) |i| {
+        try testing.expectEqual(i, r.logicalIndex(r.visualIndex(i)));
+    }
+}
+
+test "Result.empty" {
+    const testing = std.testing;
+    try testing.expectEqual(@as(usize, 0), Result.empty.len);
+    try testing.expect(Result.empty.identity);
+    try testing.expectEqual(@as(usize, 0), Result.empty.runs.len);
+}

--- a/src/bidi/zig.zig
+++ b/src/bidi/zig.zig
@@ -18,6 +18,7 @@
 const std = @import("std");
 const assert = std.debug.assert;
 const Allocator = std.mem.Allocator;
+const scan = @import("scan.zig");
 const unicode = @import("../unicode/main.zig");
 const types = @import("types.zig");
 
@@ -132,12 +133,9 @@ pub const Resolver = struct {
         // Fast path: text that cannot be affected by the algorithm at all
         // resolves to the identity without touching any of the machinery
         // below. This is the overwhelmingly common case in a terminal.
-        //
-        // A SIMD version of this scan is a separate change; the scalar
-        // form here already keeps plain left-to-right rows off the slow
-        // path, which is what matters for correctness of the fast path
-        // being *sound* rather than merely fast.
-        if (opts.direction != .rtl and isTriviallyLtr(codepoints)) {
+        // See `scan.zig` for why one threshold suffices and why a forced
+        // right-to-left paragraph has to skip it.
+        if (opts.direction != .rtl and scan.isTriviallyLtr(codepoints)) {
             self.runs.clearRetainingCapacity();
             try self.runs.append(alloc, .{
                 .visual_start = 0,
@@ -156,6 +154,18 @@ pub const Resolver = struct {
             };
         }
 
+        return self.resolveFull(alloc, codepoints, opts);
+    }
+
+    /// The algorithm proper, with the fast path skipped. Split out so
+    /// that tests can assert the fast path agrees with it.
+    fn resolveFull(
+        self: *Resolver,
+        alloc: Allocator,
+        codepoints: []const u21,
+        opts: Options,
+    ) Allocator.Error!Result {
+        const n: u16 = @intCast(codepoints.len);
         try self.prepare(alloc, codepoints);
 
         // P2-P3: determine the paragraph embedding level.
@@ -180,21 +190,6 @@ pub const Resolver = struct {
             .l2v = self.l2v.items,
             .runs = self.runs.items,
         };
-    }
-
-    /// True if no codepoint in the input can influence bidi resolution,
-    /// meaning visual order is guaranteed to equal logical order.
-    ///
-    /// This must never produce a false negative. A false positive would
-    /// merely cost performance; a false negative renders text backwards.
-    /// Everything below U+0590 is left-to-right or neutral, which covers
-    /// Latin, Greek, Cyrillic, and all of ASCII.
-    fn isTriviallyLtr(codepoints: []const u21) bool {
-        for (codepoints) |cp| {
-            if (cp < 0x0590) continue;
-            return false;
-        }
-        return true;
     }
 
     /// Populate the per-element arrays and compute matching PDIs.
@@ -1337,5 +1332,82 @@ test "uba: empty and single element input" {
         try testing.expectEqual(@as(usize, 1), result.len);
         try testing.expectEqual(Direction.rtl, result.direction);
         try testing.expectEqual(@as(usize, 0), result.logicalIndex(0));
+    }
+}
+
+test "uba: the fast path never lies" {
+    const alloc = testing.allocator;
+    var r: Resolver = .empty;
+    defer r.deinit(alloc);
+
+    // The fast path claims that any input it accepts resolves to the
+    // identity. That claim is the one place where being wrong renders
+    // text backwards, so it is checked against the full algorithm rather
+    // than argued from the properties involved.
+    //
+    // First: every single codepoint the scan accepts.
+    var one: [1]u21 = undefined;
+    for (0..scan.threshold) |i| {
+        one[0] = @intCast(i);
+        if (!scan.isTriviallyLtr(&one)) continue;
+
+        const full = try r.resolveFull(alloc, &one, .{});
+        try testing.expectEqual(Direction.ltr, full.direction);
+        try testing.expectEqual(@as(Level, 0), full.level(0));
+        try testing.expectEqual(@as(usize, 0), full.logicalIndex(0));
+    }
+
+    // Second: randomized strings built from the accepted range, since
+    // resolution depends on context and single characters cannot show
+    // an interaction between them.
+    var prng = std.Random.DefaultPrng.init(0xFA57);
+    const rand = prng.random();
+
+    var buf: [128]u21 = undefined;
+    for (0..3000) |_| {
+        const len = rand.intRangeAtMost(usize, 1, buf.len);
+        for (buf[0..len]) |*cp| cp.* = rand.uintLessThan(u21, scan.threshold);
+
+        const cps = buf[0..len];
+        try testing.expect(scan.isTriviallyLtr(cps));
+
+        const full = try r.resolveFull(alloc, cps, .{});
+        try testing.expectEqual(Direction.ltr, full.direction);
+        for (0..len) |i| {
+            try testing.expectEqual(@as(Level, 0), full.level(i));
+            try testing.expectEqual(i, full.logicalIndex(i));
+        }
+    }
+}
+
+test "uba: fast path and full path agree on accepted input" {
+    const alloc = testing.allocator;
+    var r: Resolver = .empty;
+    defer r.deinit(alloc);
+
+    var prng = std.Random.DefaultPrng.init(0xC0FFEE);
+    const rand = prng.random();
+
+    var buf: [64]u21 = undefined;
+    for (0..1000) |_| {
+        const len = rand.intRangeAtMost(usize, 1, buf.len);
+        for (buf[0..len]) |*cp| cp.* = rand.uintLessThan(u21, scan.threshold);
+        const cps = buf[0..len];
+
+        // Take the fast path, copy what it produced, then take the slow
+        // path over the same input and compare. The result borrows the
+        // resolver's buffers, so the visual order has to be copied out
+        // before the second call overwrites them.
+        var fast_visual: [64]usize = undefined;
+        {
+            const fast = try r.resolve(alloc, cps, .{});
+            try testing.expect(fast.identity);
+            for (0..len) |i| fast_visual[i] = fast.logicalIndex(i);
+        }
+
+        const full = try r.resolveFull(alloc, cps, .{});
+        for (0..len) |i| {
+            try testing.expectEqual(fast_visual[i], full.logicalIndex(i));
+        }
     }
 }

--- a/src/bidi/zig.zig
+++ b/src/bidi/zig.zig
@@ -1,0 +1,1341 @@
+//! A native Zig implementation of the Unicode Bidirectional Algorithm
+//! (UAX #9).
+//!
+//! This implements the full algorithm: paragraph level detection (P2-P3),
+//! explicit embeddings and isolates (X1-X8), isolating run sequences (X10),
+//! weak type resolution (W1-W7), paired brackets (N0/BD16), neutral
+//! resolution (N1-N2), implicit levels (I1-I2), and reordering (L1-L2).
+//!
+//! Rule numbers from the specification appear in comments throughout.
+//! They are not decoration: the rules are subtle, frequently reordered
+//! between revisions, and the only practical way to review this code is
+//! side by side with the spec, so every block says which rule it is.
+//!
+//! Character properties come from the build-time tables in `src/unicode`,
+//! which derive them from the UCD via uucode. Nothing here parses Unicode
+//! data at runtime and no third-party bidi library is linked.
+
+const std = @import("std");
+const assert = std.debug.assert;
+const Allocator = std.mem.Allocator;
+const unicode = @import("../unicode/main.zig");
+const types = @import("types.zig");
+
+const BidiClass = unicode.BidiClass;
+const Direction = types.Direction;
+const Level = types.Level;
+const LevelRun = types.LevelRun;
+const Options = types.Options;
+const Result = types.Result;
+const max_depth = types.max_depth;
+
+/// The maximum number of bracket pairs we track per isolating run
+/// sequence (BD16). The spec fixes this at 63 and requires that
+/// processing stop, not fail, once it is exceeded.
+const max_bracket_pairs = 63;
+
+/// A directional override status (X1).
+const Override = enum { neutral, ltr, rtl };
+
+/// One entry on the directional status stack (X1).
+const Status = struct {
+    level: Level,
+    override: Override,
+    isolate: bool,
+};
+
+/// A bracket pair discovered by BD16, in sequence-relative positions.
+const BracketPair = struct {
+    open: u16,
+    close: u16,
+};
+
+pub const Resolver = struct {
+    /// The input, borrowed for the duration of a resolve call so N0 can
+    /// look up bracket properties without copying.
+    codepoints: []const u21 = &.{},
+
+    /// Original Bidi_Class per input element, never mutated after setup.
+    /// L1 needs the original classes, not the resolved ones.
+    orig: std.ArrayList(BidiClass) = .empty,
+
+    /// Working classes, mutated by the W, N, and X override rules.
+    class: std.ArrayList(BidiClass) = .empty,
+
+    /// Resolved embedding level per input element.
+    levels: std.ArrayList(Level) = .empty,
+
+    /// Indices of elements not removed by X9, in logical order. All of
+    /// X10 through I2 operate on this subsequence.
+    keep: std.ArrayList(u16) = .empty,
+
+    /// For each element, the index of its matching PDI (BD9), or the
+    /// input length if it has none. Only meaningful for isolate
+    /// initiators.
+    matching_pdi: std.ArrayList(u16) = .empty,
+
+    /// True for each PDI that matches an earlier isolate initiator.
+    /// Precomputed so X10 does not have to rescan.
+    matched_pdi: std.ArrayList(bool) = .empty,
+
+    /// Positions (indices into `keep`) of the current isolating run
+    /// sequence, built fresh for each sequence in X10.
+    seq: std.ArrayList(u16) = .empty,
+
+    /// The directional status stack (X1).
+    stack: std.ArrayList(Status) = .empty,
+
+    /// Scratch index stack, used for BD9 isolate matching.
+    stack_u16: std.ArrayList(u16) = .empty,
+
+    /// Bracket pair scratch for N0.
+    bracket_stack: std.ArrayList(struct { cp: u21, pos: u16 }) = .empty,
+    bracket_pairs: std.ArrayList(BracketPair) = .empty,
+
+    /// Output permutations.
+    v2l: std.ArrayList(u16) = .empty,
+    l2v: std.ArrayList(u16) = .empty,
+    runs: std.ArrayList(LevelRun) = .empty,
+
+    pub const empty: Resolver = .{};
+
+    pub fn deinit(self: *Resolver, alloc: Allocator) void {
+        self.orig.deinit(alloc);
+        self.class.deinit(alloc);
+        self.levels.deinit(alloc);
+        self.keep.deinit(alloc);
+        self.matching_pdi.deinit(alloc);
+        self.matched_pdi.deinit(alloc);
+        self.seq.deinit(alloc);
+        self.stack.deinit(alloc);
+        self.stack_u16.deinit(alloc);
+        self.bracket_stack.deinit(alloc);
+        self.bracket_pairs.deinit(alloc);
+        self.v2l.deinit(alloc);
+        self.l2v.deinit(alloc);
+        self.runs.deinit(alloc);
+        self.* = undefined;
+    }
+
+    /// Resolve one paragraph. See `types.Result` for the lifetime of the
+    /// returned slices.
+    pub fn resolve(
+        self: *Resolver,
+        alloc: Allocator,
+        codepoints: []const u21,
+        opts: Options,
+    ) Allocator.Error!Result {
+        assert(codepoints.len <= std.math.maxInt(u16));
+        if (codepoints.len == 0) return .empty;
+        const n: u16 = @intCast(codepoints.len);
+
+        // Fast path: text that cannot be affected by the algorithm at all
+        // resolves to the identity without touching any of the machinery
+        // below. This is the overwhelmingly common case in a terminal.
+        //
+        // A SIMD version of this scan is a separate change; the scalar
+        // form here already keeps plain left-to-right rows off the slow
+        // path, which is what matters for correctness of the fast path
+        // being *sound* rather than merely fast.
+        if (opts.direction != .rtl and isTriviallyLtr(codepoints)) {
+            self.runs.clearRetainingCapacity();
+            try self.runs.append(alloc, .{
+                .visual_start = 0,
+                .len = n,
+                .logical_start = 0,
+                .level = 0,
+            });
+            return .{
+                .direction = .ltr,
+                .len = n,
+                .identity = true,
+                .levels = &.{},
+                .v2l = &.{},
+                .l2v = &.{},
+                .runs = self.runs.items,
+            };
+        }
+
+        try self.prepare(alloc, codepoints);
+
+        // P2-P3: determine the paragraph embedding level.
+        const para_level: Level = switch (opts.direction) {
+            .ltr => 0,
+            .rtl => 1,
+            .auto => self.paragraphLevel(0, n),
+        };
+
+        try self.resolveExplicit(alloc, para_level);
+        try self.resolveSequences(alloc, para_level);
+        self.resolveImplicitLevels(para_level);
+        self.applyL1(para_level);
+        try self.reorder(alloc);
+
+        return .{
+            .direction = types.levelDirection(para_level),
+            .len = n,
+            .identity = false,
+            .levels = self.levels.items,
+            .v2l = self.v2l.items,
+            .l2v = self.l2v.items,
+            .runs = self.runs.items,
+        };
+    }
+
+    /// True if no codepoint in the input can influence bidi resolution,
+    /// meaning visual order is guaranteed to equal logical order.
+    ///
+    /// This must never produce a false negative. A false positive would
+    /// merely cost performance; a false negative renders text backwards.
+    /// Everything below U+0590 is left-to-right or neutral, which covers
+    /// Latin, Greek, Cyrillic, and all of ASCII.
+    fn isTriviallyLtr(codepoints: []const u21) bool {
+        for (codepoints) |cp| {
+            if (cp < 0x0590) continue;
+            return false;
+        }
+        return true;
+    }
+
+    /// Populate the per-element arrays and compute matching PDIs.
+    fn prepare(
+        self: *Resolver,
+        alloc: Allocator,
+        codepoints: []const u21,
+    ) Allocator.Error!void {
+        const n: u16 = @intCast(codepoints.len);
+        self.codepoints = codepoints;
+
+        self.orig.clearRetainingCapacity();
+        self.class.clearRetainingCapacity();
+        self.levels.clearRetainingCapacity();
+        self.matching_pdi.clearRetainingCapacity();
+        self.matched_pdi.clearRetainingCapacity();
+
+        try self.orig.ensureTotalCapacity(alloc, n);
+        try self.class.ensureTotalCapacity(alloc, n);
+        try self.levels.ensureTotalCapacity(alloc, n);
+        try self.matching_pdi.ensureTotalCapacity(alloc, n);
+        try self.matched_pdi.ensureTotalCapacity(alloc, n);
+
+        for (codepoints) |cp| {
+            const c = unicode.bidiClass(cp);
+            self.orig.appendAssumeCapacity(c);
+            self.class.appendAssumeCapacity(c);
+            self.levels.appendAssumeCapacity(0);
+            self.matching_pdi.appendAssumeCapacity(n);
+            self.matched_pdi.appendAssumeCapacity(false);
+        }
+
+        // BD9: match each isolate initiator with its PDI.
+        //
+        // A stack gives this in one pass. The naive form -- scanning
+        // forward from every initiator counting depth -- is quadratic on
+        // input consisting mostly of isolate initiators, and a terminal
+        // has to assume the program on the other end of the pty can print
+        // exactly that.
+        const classes = self.orig.items;
+        self.stack_u16.clearRetainingCapacity();
+        for (classes, 0..) |c, i| {
+            if (c.isIsolateInitiator()) {
+                try self.stack_u16.append(alloc, @intCast(i));
+                continue;
+            }
+            if (c != .pdi) continue;
+
+            // The PDI matches the most recent unmatched initiator, which
+            // is the one on top of the stack.
+            const open = self.stack_u16.pop() orelse continue;
+            self.matching_pdi.items[open] = @intCast(i);
+            self.matched_pdi.items[i] = true;
+        }
+        // Initiators still on the stack have no matching PDI and keep the
+        // sentinel value of `n` assigned above.
+    }
+
+    /// P2-P3 over the range [start, end): the paragraph level is derived
+    /// from the first strong character, skipping over isolate runs.
+    fn paragraphLevel(self: *Resolver, start: u16, end: u16) Level {
+        const classes = self.orig.items;
+        var i = start;
+        while (i < end) : (i += 1) {
+            switch (classes[i]) {
+                // P2: skip characters between an isolate initiator and
+                // its matching PDI entirely.
+                .lri, .rli, .fsi => {
+                    i = self.matching_pdi.items[i];
+                    if (i >= end) break;
+                },
+
+                // P3: L gives level 0, R and AL give level 1.
+                .l => return 0,
+                .r, .al => return 1,
+
+                else => {},
+            }
+        }
+        return 0;
+    }
+
+    /// X1-X8: compute explicit embedding levels and apply overrides.
+    fn resolveExplicit(
+        self: *Resolver,
+        alloc: Allocator,
+        para_level: Level,
+    ) Allocator.Error!void {
+        const n: u16 = @intCast(self.orig.items.len);
+
+        self.stack.clearRetainingCapacity();
+        try self.stack.append(alloc, .{
+            .level = para_level,
+            .override = .neutral,
+            .isolate = false,
+        });
+
+        var overflow_isolate: usize = 0;
+        var overflow_embedding: usize = 0;
+        var valid_isolate: usize = 0;
+
+        var i: u16 = 0;
+        while (i < n) : (i += 1) {
+            const c = self.orig.items[i];
+            switch (c) {
+                // X2-X5: explicit embeddings and overrides.
+                .rle, .lre, .rlo, .lro => {
+                    const top = self.stack.items[self.stack.items.len - 1];
+                    self.levels.items[i] = top.level;
+
+                    const rtl = c == .rle or c == .rlo;
+                    const new_level = nextLevel(top.level, rtl);
+
+                    if (new_level <= max_depth and
+                        overflow_isolate == 0 and
+                        overflow_embedding == 0)
+                    {
+                        try self.stack.append(alloc, .{
+                            .level = new_level,
+                            .override = switch (c) {
+                                .rlo => .rtl,
+                                .lro => .ltr,
+                                else => .neutral,
+                            },
+                            .isolate = false,
+                        });
+                    } else if (overflow_isolate == 0) {
+                        overflow_embedding += 1;
+                    }
+                },
+
+                // X5a-X5c: isolate initiators.
+                .rli, .lri, .fsi => {
+                    // X5c: FSI behaves as RLI or LRI depending on the
+                    // first strong character inside the isolate.
+                    const rtl = switch (c) {
+                        .rli => true,
+                        .lri => false,
+                        .fsi => self.paragraphLevel(
+                            i + 1,
+                            self.matching_pdi.items[i],
+                        ) == 1,
+                        else => unreachable,
+                    };
+
+                    const top = self.stack.items[self.stack.items.len - 1];
+
+                    // The initiator itself takes the level in effect
+                    // before the isolate is entered, and is subject to the
+                    // current override.
+                    self.levels.items[i] = top.level;
+                    switch (top.override) {
+                        .neutral => {},
+                        .ltr => self.class.items[i] = .l,
+                        .rtl => self.class.items[i] = .r,
+                    }
+
+                    const new_level = nextLevel(top.level, rtl);
+                    if (new_level <= max_depth and
+                        overflow_isolate == 0 and
+                        overflow_embedding == 0)
+                    {
+                        valid_isolate += 1;
+                        try self.stack.append(alloc, .{
+                            .level = new_level,
+                            .override = .neutral,
+                            .isolate = true,
+                        });
+                    } else {
+                        overflow_isolate += 1;
+                    }
+                },
+
+                // X6a: pop directional isolate status.
+                .pdi => {
+                    if (overflow_isolate > 0) {
+                        overflow_isolate -= 1;
+                    } else if (valid_isolate > 0) {
+                        overflow_embedding = 0;
+                        while (!self.stack.items[self.stack.items.len - 1].isolate) {
+                            _ = self.stack.pop();
+                        }
+                        _ = self.stack.pop();
+                        valid_isolate -= 1;
+                    }
+
+                    // The PDI takes the level and override of whatever is
+                    // on top of the stack *after* the pops above.
+                    const top = self.stack.items[self.stack.items.len - 1];
+                    self.levels.items[i] = top.level;
+                    switch (top.override) {
+                        .neutral => {},
+                        .ltr => self.class.items[i] = .l,
+                        .rtl => self.class.items[i] = .r,
+                    }
+                },
+
+                // X7: pop directional format status.
+                .pdf => {
+                    self.levels.items[i] =
+                        self.stack.items[self.stack.items.len - 1].level;
+
+                    if (overflow_isolate > 0) {
+                        // An overflowing isolate takes precedence.
+                    } else if (overflow_embedding > 0) {
+                        overflow_embedding -= 1;
+                    } else if (!self.stack.items[self.stack.items.len - 1].isolate and
+                        self.stack.items.len >= 2)
+                    {
+                        _ = self.stack.pop();
+                    }
+                },
+
+                // X8: paragraph separators reset to the paragraph level.
+                .b => self.levels.items[i] = para_level,
+
+                // Boundary neutrals are removed by X9 but still need a
+                // level so that later phases can index uniformly.
+                .bn => self.levels.items[i] =
+                    self.stack.items[self.stack.items.len - 1].level,
+
+                // X6: everything else.
+                else => {
+                    const top = self.stack.items[self.stack.items.len - 1];
+                    self.levels.items[i] = top.level;
+                    switch (top.override) {
+                        .neutral => {},
+                        .ltr => self.class.items[i] = .l,
+                        .rtl => self.class.items[i] = .r,
+                    }
+                },
+            }
+        }
+
+        // X9: build the list of characters that survive. Rather than
+        // physically removing the embedding and override formatting
+        // characters we skip them, which keeps a level for every input
+        // element so callers can map results back one to one.
+        self.keep.clearRetainingCapacity();
+        try self.keep.ensureTotalCapacity(alloc, n);
+        for (self.orig.items, 0..) |c, idx| {
+            if (c.isRemovedByX9()) continue;
+            self.keep.appendAssumeCapacity(@intCast(idx));
+        }
+    }
+
+    /// X10 plus W1-W7, N0-N2: split into isolating run sequences and
+    /// resolve weak and neutral types within each.
+    fn resolveSequences(
+        self: *Resolver,
+        alloc: Allocator,
+        para_level: Level,
+    ) Allocator.Error!void {
+        const keep = self.keep.items;
+        if (keep.len == 0) return;
+
+        // Walk level runs over the retained subsequence. A level run is a
+        // maximal range with the same resolved level.
+        var run_start: usize = 0;
+        while (run_start < keep.len) {
+            const level = self.levels.items[keep[run_start]];
+            var run_end = run_start + 1;
+            while (run_end < keep.len and
+                self.levels.items[keep[run_end]] == level) run_end += 1;
+
+            // X10: a level run begins an isolating run sequence unless it
+            // starts with a PDI that matches an earlier isolate
+            // initiator, in which case it was already consumed by the
+            // sequence containing that initiator.
+            const first = keep[run_start];
+            const starts_sequence = self.orig.items[first] != .pdi or
+                !self.matched_pdi.items[first];
+
+            if (starts_sequence) {
+                try self.buildSequence(alloc, run_start, run_end);
+                try self.resolveSequence(alloc, para_level);
+            }
+
+            run_start = run_end;
+        }
+    }
+
+    /// Collect the level runs making up one isolating run sequence (X10),
+    /// storing positions into `keep` in `self.seq`.
+    fn buildSequence(
+        self: *Resolver,
+        alloc: Allocator,
+        run_start: usize,
+        run_end: usize,
+    ) Allocator.Error!void {
+        const keep = self.keep.items;
+        self.seq.clearRetainingCapacity();
+
+        var start = run_start;
+        var end = run_end;
+        while (true) {
+            var i = start;
+            while (i < end) : (i += 1) try self.seq.append(alloc, @intCast(i));
+
+            // If this run ends with an isolate initiator that has a
+            // matching PDI, the run containing that PDI continues the
+            // same sequence.
+            const last = keep[end - 1];
+            if (!self.orig.items[last].isIsolateInitiator()) break;
+            const pdi = self.matching_pdi.items[last];
+            if (pdi >= self.orig.items.len) break;
+
+            // Find the PDI's position in `keep` and the level run that
+            // starts there.
+            const pos = self.keepIndexOf(pdi) orelse break;
+            const level = self.levels.items[keep[pos]];
+            var next_end = pos + 1;
+            while (next_end < keep.len and
+                self.levels.items[keep[next_end]] == level) next_end += 1;
+
+            start = pos;
+            end = next_end;
+        }
+    }
+
+    fn keepIndexOf(self: *Resolver, idx: u16) ?usize {
+        // `keep` is sorted, so this is a binary search.
+        var lo: usize = 0;
+        var hi: usize = self.keep.items.len;
+        while (lo < hi) {
+            const mid = lo + (hi - lo) / 2;
+            const v = self.keep.items[mid];
+            if (v == idx) return mid;
+            if (v < idx) lo = mid + 1 else hi = mid;
+        }
+        return null;
+    }
+
+    /// Apply W1-W7, N0-N2 to the isolating run sequence in `self.seq`.
+    fn resolveSequence(
+        self: *Resolver,
+        alloc: Allocator,
+        para_level: Level,
+    ) Allocator.Error!void {
+        const seq = self.seq.items;
+        if (seq.len == 0) return;
+
+        const keep = self.keep.items;
+        const level = self.levels.items[keep[seq[0]]];
+        const e: BidiClass = if (level & 1 == 0) .l else .r;
+
+        // X10: compute sos and eos, the assumed types before and after
+        // the sequence, from the higher of the sequence's level and the
+        // level of the adjacent text.
+        const sos = boundaryClass(level, blk: {
+            const first = seq[0];
+            break :blk if (first == 0)
+                para_level
+            else
+                self.levels.items[keep[first - 1]];
+        });
+
+        const eos = boundaryClass(level, blk: {
+            const last = seq[seq.len - 1];
+            const last_idx = keep[last];
+            // An isolate initiator with no matching PDI runs to the end
+            // of the paragraph, so its eos uses the paragraph level.
+            if (self.orig.items[last_idx].isIsolateInitiator() and
+                self.matching_pdi.items[last_idx] >= self.orig.items.len)
+            {
+                break :blk para_level;
+            }
+            break :blk if (last + 1 >= keep.len)
+                para_level
+            else
+                self.levels.items[keep[last + 1]];
+        });
+
+        // W1: NSM takes the type of the previous character; at the start
+        // of the sequence it takes sos. After an isolate initiator or
+        // PDI it becomes ON.
+        {
+            var prev = sos;
+            for (seq) |p| {
+                const idx = keep[p];
+                const c = self.class.items[idx];
+                if (c == .nsm) {
+                    self.class.items[idx] = if (prev.isIsolateInitiator() or prev == .pdi)
+                        .on
+                    else
+                        prev;
+                }
+                prev = self.class.items[idx];
+            }
+        }
+
+        // W2: EN becomes AN when the last strong type before it is AL.
+        {
+            var strong = sos;
+            for (seq) |p| {
+                const idx = keep[p];
+                switch (self.class.items[idx]) {
+                    .l, .r, .al => strong = self.class.items[idx],
+                    .en => if (strong == .al) {
+                        self.class.items[idx] = .an;
+                    },
+                    else => {},
+                }
+            }
+        }
+
+        // W3: AL becomes R.
+        for (seq) |p| {
+            const idx = keep[p];
+            if (self.class.items[idx] == .al) self.class.items[idx] = .r;
+        }
+
+        // W4: a single ES between two EN becomes EN; a single CS between
+        // two numbers of the same type becomes that type.
+        if (seq.len >= 3) {
+            var i: usize = 1;
+            while (i + 1 < seq.len) : (i += 1) {
+                const idx = keep[seq[i]];
+                const c = self.class.items[idx];
+                if (c != .es and c != .cs) continue;
+                const prev = self.class.items[keep[seq[i - 1]]];
+                const next = self.class.items[keep[seq[i + 1]]];
+                if (prev == .en and next == .en) {
+                    self.class.items[idx] = .en;
+                } else if (c == .cs and prev == .an and next == .an) {
+                    self.class.items[idx] = .an;
+                }
+            }
+        }
+
+        // W5: a sequence of ET adjacent to EN becomes EN.
+        {
+            var i: usize = 0;
+            while (i < seq.len) {
+                if (self.class.items[keep[seq[i]]] != .et) {
+                    i += 1;
+                    continue;
+                }
+
+                var j = i;
+                while (j < seq.len and
+                    self.class.items[keep[seq[j]]] == .et) j += 1;
+
+                const before_en = i > 0 and
+                    self.class.items[keep[seq[i - 1]]] == .en;
+                const after_en = j < seq.len and
+                    self.class.items[keep[seq[j]]] == .en;
+
+                if (before_en or after_en) {
+                    var k = i;
+                    while (k < j) : (k += 1) {
+                        self.class.items[keep[seq[k]]] = .en;
+                    }
+                }
+
+                i = j;
+            }
+        }
+
+        // W6: any remaining separators and terminators become ON.
+        for (seq) |p| {
+            const idx = keep[p];
+            switch (self.class.items[idx]) {
+                .et, .es, .cs => self.class.items[idx] = .on,
+                else => {},
+            }
+        }
+
+        // W7: EN becomes L when the last strong type before it is L.
+        {
+            var strong = sos;
+            for (seq) |p| {
+                const idx = keep[p];
+                switch (self.class.items[idx]) {
+                    .l, .r => strong = self.class.items[idx],
+                    .en => if (strong == .l) {
+                        self.class.items[idx] = .l;
+                    },
+                    else => {},
+                }
+            }
+        }
+
+        try self.resolveBrackets(alloc, e, sos);
+        self.resolveNeutrals(e, sos, eos);
+    }
+
+    /// N0 with BD16: resolve paired brackets.
+    fn resolveBrackets(
+        self: *Resolver,
+        alloc: Allocator,
+        e: BidiClass,
+        sos: BidiClass,
+    ) Allocator.Error!void {
+        const seq = self.seq.items;
+        const keep = self.keep.items;
+
+        // BD16: locate bracket pairs with a stack, capped at 63 entries.
+        // Exceeding the cap stops pair processing rather than failing.
+        self.bracket_stack.clearRetainingCapacity();
+        self.bracket_pairs.clearRetainingCapacity();
+
+        for (seq, 0..) |p, i| {
+            const idx = keep[p];
+
+            // Only characters that are still ON participate.
+            if (self.class.items[idx] != .on) continue;
+
+            const cp = self.codepoints[idx];
+            switch (unicode.bidiPairedBracketType(cp)) {
+                .none => {},
+
+                .open => {
+                    if (self.bracket_stack.items.len >= max_bracket_pairs) {
+                        // BD16: stop processing entirely on overflow.
+                        self.bracket_pairs.clearRetainingCapacity();
+                        return;
+                    }
+                    // Remember the closing bracket we are looking for, so
+                    // matching is a single comparison below.
+                    const want = unicode.bidiPairedBracket(cp) orelse continue;
+                    try self.bracket_stack.append(alloc, .{
+                        .cp = canonicalBracket(want),
+                        .pos = @intCast(i),
+                    });
+                },
+
+                .close => {
+                    const have = canonicalBracket(cp);
+                    var k = self.bracket_stack.items.len;
+                    while (k > 0) {
+                        k -= 1;
+                        if (self.bracket_stack.items[k].cp != have) continue;
+
+                        try self.bracket_pairs.append(alloc, .{
+                            .open = self.bracket_stack.items[k].pos,
+                            .close = @intCast(i),
+                        });
+
+                        // BD16: discard the matched opening bracket and
+                        // everything pushed after it.
+                        self.bracket_stack.shrinkRetainingCapacity(k);
+                        break;
+                    }
+                },
+            }
+        }
+
+        // Pairs must be processed in order of their opening bracket.
+        std.mem.sort(BracketPair, self.bracket_pairs.items, {}, struct {
+            fn lessThan(_: void, a: BracketPair, b: BracketPair) bool {
+                return a.open < b.open;
+            }
+        }.lessThan);
+
+        const o: BidiClass = if (e == .l) .r else .l;
+
+        for (self.bracket_pairs.items) |pair| {
+            // N0 b/c: look for a strong type inside the pair. EN and AN
+            // count as R for this purpose.
+            var found_e = false;
+            var found_o = false;
+            var i = pair.open + 1;
+            while (i < pair.close) : (i += 1) {
+                const s = strongClass(self.class.items[keep[seq[i]]]) orelse continue;
+                if (s == e) found_e = true else found_o = true;
+            }
+
+            const new_class: ?BidiClass = if (found_e)
+                // N0 b: a strong type matching the embedding direction
+                // sets both brackets to that direction.
+                e
+            else if (found_o) blk: {
+                // N0 c: only the opposite direction appears inside.
+                // Check the preceding context.
+                var prev: BidiClass = sos;
+                var j = pair.open;
+                while (j > 0) {
+                    j -= 1;
+                    if (strongClass(self.class.items[keep[seq[j]]])) |s| {
+                        prev = s;
+                        break;
+                    }
+                }
+                // N0 c1: context matches the opposite direction, so use
+                // it. N0 c2: otherwise fall back to the embedding
+                // direction.
+                break :blk if (prev == o) o else e;
+            } else
+                // N0 d: no strong type inside, leave the brackets alone.
+                null;
+
+            const nc = new_class orelse continue;
+            self.class.items[keep[seq[pair.open]]] = nc;
+            self.class.items[keep[seq[pair.close]]] = nc;
+
+            // N0 note: any NSM following a paired bracket whose type
+            // changed takes the same type. The original class is what
+            // matters here, since W1 has already rewritten the working
+            // class.
+            self.applyBracketNsm(pair.open, nc);
+            self.applyBracketNsm(pair.close, nc);
+        }
+    }
+
+    fn applyBracketNsm(self: *Resolver, pos: u16, nc: BidiClass) void {
+        const seq = self.seq.items;
+        const keep = self.keep.items;
+        var i: usize = pos + 1;
+        while (i < seq.len) : (i += 1) {
+            const idx = keep[seq[i]];
+            if (self.orig.items[idx] != .nsm) break;
+            self.class.items[idx] = nc;
+        }
+    }
+
+    /// N1-N2: resolve remaining neutral and isolate formatting types.
+    fn resolveNeutrals(
+        self: *Resolver,
+        e: BidiClass,
+        sos: BidiClass,
+        eos: BidiClass,
+    ) void {
+        const seq = self.seq.items;
+        const keep = self.keep.items;
+
+        var i: usize = 0;
+        while (i < seq.len) {
+            if (!isNI(self.class.items[keep[seq[i]]])) {
+                i += 1;
+                continue;
+            }
+
+            var j = i;
+            while (j < seq.len and isNI(self.class.items[keep[seq[j]]])) j += 1;
+
+            // The types bracketing this run of neutrals, with numbers
+            // counting as R.
+            const before: BidiClass = if (i == 0)
+                sos
+            else
+                strongOrNumber(self.class.items[keep[seq[i - 1]]]);
+
+            const after: BidiClass = if (j >= seq.len)
+                eos
+            else
+                strongOrNumber(self.class.items[keep[seq[j]]]);
+
+            // N1: neutrals between two matching directions take that
+            // direction. N2: otherwise they take the embedding direction.
+            const resolved: BidiClass = if (before == after and
+                (before == .l or before == .r)) before else e;
+
+            var k = i;
+            while (k < j) : (k += 1) {
+                self.class.items[keep[seq[k]]] = resolved;
+            }
+
+            i = j;
+        }
+    }
+
+    /// I1-I2: raise levels according to the resolved types.
+    fn resolveImplicitLevels(self: *Resolver, para_level: Level) void {
+        for (self.keep.items) |idx| {
+            const level = self.levels.items[idx];
+            const c = self.class.items[idx];
+            if (level & 1 == 0) {
+                // I1: at an even level, R goes up one, AN and EN go up
+                // two.
+                self.levels.items[idx] = switch (c) {
+                    .r => level + 1,
+                    .an, .en => level + 2,
+                    else => level,
+                };
+            } else {
+                // I2: at an odd level, L, EN, and AN all go up one.
+                self.levels.items[idx] = switch (c) {
+                    .l, .en, .an => level + 1,
+                    else => level,
+                };
+            }
+        }
+
+        // Characters removed by X9 never received an implicit level.
+        // Give them the level of the preceding retained character so they
+        // do not split a level run, which is the behavior recommended for
+        // implementations that retain the formatting characters.
+        var last: Level = para_level;
+        for (self.orig.items, 0..) |c, i| {
+            if (!c.isRemovedByX9()) {
+                last = self.levels.items[i];
+                continue;
+            }
+            self.levels.items[i] = last;
+        }
+    }
+
+    /// L1: reset separators and trailing whitespace to the paragraph
+    /// level. This uses the *original* classes, not the resolved ones.
+    fn applyL1(self: *Resolver, para_level: Level) void {
+        const orig = self.orig.items;
+        const n = orig.len;
+
+        var i: usize = 0;
+        var reset_from: ?usize = 0;
+        while (i < n) : (i += 1) {
+            switch (orig[i]) {
+                // L1 items 1 and 2: segment and paragraph separators go
+                // to the paragraph level, along with any run of
+                // whitespace or isolate formatting characters before
+                // them.
+                .b, .s => {
+                    self.levels.items[i] = para_level;
+                    if (reset_from) |from| {
+                        var k = from;
+                        while (k < i) : (k += 1) self.levels.items[k] = para_level;
+                    }
+                    reset_from = i + 1;
+                },
+
+                // L1 items 3 and 4: whitespace and isolate formatting
+                // characters are candidates for resetting if they run to
+                // the end of the line or up to a separator. Characters
+                // removed by X9 are transparent here.
+                .ws, .lri, .rli, .fsi, .pdi => {
+                    if (reset_from == null) reset_from = i;
+                },
+
+                .rle, .lre, .rlo, .lro, .pdf, .bn => {},
+
+                else => reset_from = null,
+            }
+        }
+
+        // L1 item 4: a trailing run reaching the end of the line.
+        if (reset_from) |from| {
+            var k = from;
+            while (k < n) : (k += 1) self.levels.items[k] = para_level;
+        }
+    }
+
+    /// L2 plus level run extraction: reverse contiguous runs from the
+    /// highest level down to the lowest odd level.
+    fn reorder(self: *Resolver, alloc: Allocator) Allocator.Error!void {
+        const n: u16 = @intCast(self.levels.items.len);
+        const levels = self.levels.items;
+
+        self.v2l.clearRetainingCapacity();
+        self.l2v.clearRetainingCapacity();
+        try self.v2l.resize(alloc, n);
+        try self.l2v.resize(alloc, n);
+
+        for (self.v2l.items, 0..) |*v, i| v.* = @intCast(i);
+
+        // Find the highest level and the lowest odd level.
+        var highest: Level = 0;
+        var lowest_odd: Level = max_depth + 1;
+        for (levels) |l| {
+            if (l > highest) highest = l;
+            if (l & 1 == 1 and l < lowest_odd) lowest_odd = l;
+        }
+
+        // L2: for each level from the highest down to the lowest odd,
+        // reverse every contiguous run of characters at or above it.
+        if (lowest_odd <= highest) {
+            var level = highest;
+            while (level >= lowest_odd) : (level -= 1) {
+                var i: usize = 0;
+                while (i < n) {
+                    if (levels[self.v2l.items[i]] < level) {
+                        i += 1;
+                        continue;
+                    }
+                    var j = i;
+                    while (j < n and levels[self.v2l.items[j]] >= level) j += 1;
+                    std.mem.reverse(u16, self.v2l.items[i..j]);
+                    i = j;
+                }
+
+                // Level is unsigned; stop before it wraps.
+                if (level == 0) break;
+            }
+        }
+
+        // The inverse permutation.
+        for (self.v2l.items, 0..) |logical, visual| {
+            self.l2v.items[logical] = @intCast(visual);
+        }
+
+        // Extract level runs in visual order.
+        self.runs.clearRetainingCapacity();
+        var i: usize = 0;
+        while (i < n) {
+            const level = levels[self.v2l.items[i]];
+            var j = i + 1;
+            while (j < n and levels[self.v2l.items[j]] == level) j += 1;
+
+            // The lowest logical index in the run. For an RTL run the
+            // logical indices descend as the visual indices ascend.
+            var lo: u16 = self.v2l.items[i];
+            for (self.v2l.items[i..j]) |idx| lo = @min(lo, idx);
+
+            try self.runs.append(alloc, .{
+                .visual_start = @intCast(i),
+                .len = @intCast(j - i),
+                .logical_start = lo,
+                .level = level,
+            });
+
+            i = j;
+        }
+    }
+};
+
+/// The next embedding level above `level` in the given direction (X2-X5).
+fn nextLevel(level: Level, rtl: bool) Level {
+    return if (rtl)
+        (level + 1) | 1
+    else
+        (level + 2) & ~@as(Level, 1);
+}
+
+/// X10: the assumed type at a sequence boundary, from the higher of the
+/// two adjacent levels.
+fn boundaryClass(seq_level: Level, adjacent_level: Level) BidiClass {
+    const level = @max(seq_level, adjacent_level);
+    return if (level & 1 == 0) .l else .r;
+}
+
+/// True for the "neutral or isolate formatting" types (BD13 note, N1).
+fn isNI(c: BidiClass) bool {
+    return switch (c) {
+        .b, .s, .ws, .on, .fsi, .lri, .rli, .pdi => true,
+        else => false,
+    };
+}
+
+/// The strong direction a class contributes for N0, where numbers count
+/// as R. Returns null for classes that are not strong.
+fn strongClass(c: BidiClass) ?BidiClass {
+    return switch (c) {
+        .l => .l,
+        .r, .en, .an => .r,
+        else => null,
+    };
+}
+
+/// Like `strongClass` but total, mapping non-strong types to themselves.
+/// Used by N1 where the neighbours are already resolved.
+fn strongOrNumber(c: BidiClass) BidiClass {
+    return switch (c) {
+        .l => .l,
+        .r, .en, .an => .r,
+        else => c,
+    };
+}
+
+/// BD16 requires canonical equivalence when matching brackets, which in
+/// practice means the two CJK angle bracket pairs that are singleton
+/// decompositions of the mathematical ones.
+fn canonicalBracket(cp: u21) u21 {
+    return switch (cp) {
+        0x3008 => 0x2329,
+        0x3009 => 0x232A,
+        else => cp,
+    };
+}
+
+// -- Tests --------------------------------------------------------------
+//
+// The UCD conformance suites in `conformance_test.zig` are the
+// authoritative check and cover ~862,000 cases. The tests below are
+// deliberately small and readable: they document what the algorithm is
+// supposed to do for the cases a terminal actually hits, and they run on
+// every build without needing the 15 MB of UCD data downloaded.
+
+const testing = std.testing;
+
+/// Resolve a string of codepoints and return the visual order as a string
+/// of the same codepoints, for tests that are easier to read as text.
+fn testVisual(
+    alloc: Allocator,
+    resolver: *Resolver,
+    cps: []const u21,
+    dir: types.ParagraphDirection,
+    out: []u21,
+) ![]u21 {
+    const result = try resolver.resolve(alloc, cps, .{ .direction = dir });
+    for (0..cps.len) |v| out[v] = cps[result.logicalIndex(v)];
+    return out[0..cps.len];
+}
+
+test "uba: pure ascii takes the identity fast path" {
+    const alloc = testing.allocator;
+    var r: Resolver = .empty;
+    defer r.deinit(alloc);
+
+    const cps = [_]u21{ 'h', 'e', 'l', 'l', 'o' };
+    const result = try r.resolve(alloc, &cps, .{});
+
+    try testing.expect(result.identity);
+    try testing.expectEqual(Direction.ltr, result.direction);
+    try testing.expectEqual(@as(usize, 0), result.levels.len);
+    for (0..cps.len) |i| try testing.expectEqual(i, result.logicalIndex(i));
+}
+
+test "uba: hebrew reverses" {
+    const alloc = testing.allocator;
+    var r: Resolver = .empty;
+    defer r.deinit(alloc);
+
+    // Alef, bet, gimel. Logical order is alef-bet-gimel; on screen the
+    // alef must appear rightmost.
+    const cps = [_]u21{ 0x05D0, 0x05D1, 0x05D2 };
+    var buf: [3]u21 = undefined;
+    const visual = try testVisual(alloc, &r, &cps, .auto, &buf);
+
+    try testing.expectEqualSlices(u21, &.{ 0x05D2, 0x05D1, 0x05D0 }, visual);
+
+    // P2/P3: the first strong character is R, so the paragraph is RTL.
+    const result = try r.resolve(alloc, &cps, .{});
+    try testing.expectEqual(Direction.rtl, result.direction);
+    try testing.expect(!result.identity);
+}
+
+test "uba: mixed latin and hebrew reverses only the hebrew" {
+    const alloc = testing.allocator;
+    var r: Resolver = .empty;
+    defer r.deinit(alloc);
+
+    // "abc" + space + hebrew alef/bet/gimel, in an LTR paragraph.
+    const cps = [_]u21{ 'a', 'b', 'c', ' ', 0x05D0, 0x05D1, 0x05D2 };
+    var buf: [7]u21 = undefined;
+    const visual = try testVisual(alloc, &r, &cps, .auto, &buf);
+
+    try testing.expectEqualSlices(
+        u21,
+        &.{ 'a', 'b', 'c', ' ', 0x05D2, 0x05D1, 0x05D0 },
+        visual,
+    );
+}
+
+test "uba: numbers stay left to right inside rtl" {
+    const alloc = testing.allocator;
+    var r: Resolver = .empty;
+    defer r.deinit(alloc);
+
+    // Hebrew followed by "123". The Hebrew reverses; the digits must not.
+    // Getting this wrong is how phone numbers and versions end up
+    // silently backwards.
+    const cps = [_]u21{ 0x05D0, 0x05D1, ' ', '1', '2', '3' };
+    var buf: [6]u21 = undefined;
+    const visual = try testVisual(alloc, &r, &cps, .auto, &buf);
+
+    try testing.expectEqualSlices(
+        u21,
+        &.{ '1', '2', '3', ' ', 0x05D1, 0x05D0 },
+        visual,
+    );
+}
+
+test "uba: arabic-indic digits are AN, extended ones are EN" {
+    const alloc = testing.allocator;
+    var r: Resolver = .empty;
+    defer r.deinit(alloc);
+
+    // Both digit runs render left to right within themselves. This is the
+    // Persian-versus-Arabic distinction that P0.1's tables encode; here we
+    // just confirm neither run gets internally reversed.
+    inline for (.{
+        [_]u21{ 0x05D0, 0x0660, 0x0661, 0x0662 },
+        [_]u21{ 0x05D0, 0x06F0, 0x06F1, 0x06F2 },
+    }) |cps| {
+        var buf: [4]u21 = undefined;
+        const visual = try testVisual(alloc, &r, &cps, .auto, &buf);
+        try testing.expectEqualSlices(
+            u21,
+            &.{ cps[1], cps[2], cps[3], 0x05D0 },
+            visual,
+        );
+    }
+}
+
+test "uba: brackets mirror position in rtl (N0)" {
+    const alloc = testing.allocator;
+    var r: Resolver = .empty;
+    defer r.deinit(alloc);
+
+    // Hebrew with a parenthesized Hebrew word. The parentheses must swap
+    // places so they still enclose. Note the codepoints are unchanged;
+    // substituting the mirrored glyph is a rendering step (rule L4), not
+    // a reordering one.
+    const cps = [_]u21{ 0x05D0, ' ', '(', 0x05D1, 0x05D2, ')' };
+    var buf: [6]u21 = undefined;
+    const visual = try testVisual(alloc, &r, &cps, .auto, &buf);
+
+    try testing.expectEqualSlices(
+        u21,
+        &.{ ')', 0x05D2, 0x05D1, '(', ' ', 0x05D0 },
+        visual,
+    );
+}
+
+test "uba: forced paragraph direction overrides P2/P3" {
+    const alloc = testing.allocator;
+    var r: Resolver = .empty;
+    defer r.deinit(alloc);
+
+    const cps = [_]u21{ 'a', 'b', ' ', 0x05D0, 0x05D1 };
+
+    // Auto: first strong is L, so LTR.
+    {
+        const result = try r.resolve(alloc, &cps, .{ .direction = .auto });
+        try testing.expectEqual(Direction.ltr, result.direction);
+    }
+
+    // Forced RTL moves the Latin run to the right of the Hebrew.
+    {
+        var buf: [5]u21 = undefined;
+        const visual = try testVisual(alloc, &r, &cps, .rtl, &buf);
+        try testing.expectEqualSlices(
+            u21,
+            &.{ 0x05D1, 0x05D0, ' ', 'a', 'b' },
+            visual,
+        );
+    }
+}
+
+test "uba: isolates confine their contents" {
+    const alloc = testing.allocator;
+    var r: Resolver = .empty;
+    defer r.deinit(alloc);
+
+    // "a" RLI hebrew PDI "b". The isolate keeps the Hebrew from
+    // interacting with the surrounding Latin, so "a" and "b" stay put.
+    const cps = [_]u21{ 'a', 0x2067, 0x05D0, 0x05D1, 0x2069, 'b' };
+    const result = try r.resolve(alloc, &cps, .{});
+
+    try testing.expectEqual(Direction.ltr, result.direction);
+    try testing.expectEqual(@as(usize, 0), result.visualIndex(0)); // 'a'
+    try testing.expectEqual(@as(usize, 5), result.visualIndex(5)); // 'b'
+
+    // Inside the isolate the Hebrew is reversed.
+    try testing.expect(result.visualIndex(2) > result.visualIndex(3));
+}
+
+test "uba: overrides force direction (RLO)" {
+    const alloc = testing.allocator;
+    var r: Resolver = .empty;
+    defer r.deinit(alloc);
+
+    // RLO makes even Latin letters resolve as RTL, which is exactly the
+    // Trojan Source vector. The algorithm must honor it; the defense is a
+    // paste-time warning, not silently ignoring the character.
+    const cps = [_]u21{ 0x202E, 'a', 'b', 'c', 0x202C };
+    const result = try r.resolve(alloc, &cps, .{});
+
+    try testing.expect(result.visualIndex(1) > result.visualIndex(3));
+}
+
+test "uba: trailing whitespace resets to paragraph level (L1)" {
+    const alloc = testing.allocator;
+    var r: Resolver = .empty;
+    defer r.deinit(alloc);
+
+    // In an RTL paragraph, trailing spaces belong at the paragraph level
+    // so they do not drag to the wrong edge.
+    const cps = [_]u21{ 0x05D0, 0x05D1, ' ', ' ' };
+    const result = try r.resolve(alloc, &cps, .{});
+
+    try testing.expectEqual(Direction.rtl, result.direction);
+    try testing.expectEqual(@as(Level, 1), result.level(2));
+    try testing.expectEqual(@as(Level, 1), result.level(3));
+}
+
+test "uba: level runs cover every element exactly once" {
+    const alloc = testing.allocator;
+    var r: Resolver = .empty;
+    defer r.deinit(alloc);
+
+    const inputs = [_][]const u21{
+        &.{ 'a', 'b', 'c' },
+        &.{ 0x05D0, 0x05D1 },
+        &.{ 'a', ' ', 0x05D0, ' ', '1', '2' },
+        &.{ 'a', 0x2067, 0x05D0, 0x2069, 'b' },
+        &.{ 0x202E, 'a', 0x05D0, 0x202C, '!' },
+    };
+
+    for (inputs) |cps| {
+        const result = try r.resolve(alloc, cps, .{});
+
+        var covered: usize = 0;
+        var expect_start: u16 = 0;
+        for (result.runs) |run| {
+            try testing.expectEqual(expect_start, run.visual_start);
+            covered += run.len;
+            expect_start += run.len;
+        }
+        try testing.expectEqual(result.len, covered);
+
+        // The two permutations must be mutual inverses.
+        for (0..result.len) |i| {
+            try testing.expectEqual(i, result.logicalIndex(result.visualIndex(i)));
+            try testing.expectEqual(i, result.visualIndex(result.logicalIndex(i)));
+        }
+    }
+}
+
+test "uba: steady state performs no allocations" {
+    var counting: std.testing.FailingAllocator = .init(testing.allocator, .{
+        .fail_index = std.math.maxInt(usize),
+    });
+    const alloc = counting.allocator();
+
+    var r: Resolver = .empty;
+    defer r.deinit(alloc);
+
+    const cps = [_]u21{ 'a', ' ', 0x05D0, 0x05D1, ' ', '4', '2' };
+
+    // Warm up: these calls are allowed to grow the scratch buffers.
+    for (0..4) |_| _ = try r.resolve(alloc, &cps, .{});
+    const after_warmup = counting.allocations;
+
+    for (0..128) |_| _ = try r.resolve(alloc, &cps, .{});
+    try testing.expectEqual(after_warmup, counting.allocations);
+}
+
+test "uba: empty and single element input" {
+    const alloc = testing.allocator;
+    var r: Resolver = .empty;
+    defer r.deinit(alloc);
+
+    {
+        const result = try r.resolve(alloc, &.{}, .{});
+        try testing.expectEqual(@as(usize, 0), result.len);
+    }
+    {
+        const result = try r.resolve(alloc, &.{0x05D0}, .{});
+        try testing.expectEqual(@as(usize, 1), result.len);
+        try testing.expectEqual(Direction.rtl, result.direction);
+        try testing.expectEqual(@as(usize, 0), result.logicalIndex(0));
+    }
+}

--- a/src/build/Config.zig
+++ b/src/build/Config.zig
@@ -6,6 +6,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 
 const ApprtRuntime = @import("../apprt/runtime.zig").Runtime;
+const BidiBackend = @import("../bidi/backend.zig").Backend;
 const FontBackend = @import("../font/backend.zig").Backend;
 const RendererBackend = @import("../renderer/backend.zig").Backend;
 const TerminalBuildOptions = @import("../terminal/build_options.zig").Options;
@@ -26,6 +27,7 @@ wasm_target: WasmTarget,
 app_runtime: ApprtRuntime = .none,
 renderer: RendererBackend = .opengl,
 font_backend: FontBackend = .freetype,
+bidi_backend: BidiBackend = .noop,
 
 /// Feature flags
 x11: bool = false,
@@ -163,6 +165,12 @@ pub fn init(b: *std.Build, appVersion: []const u8, libVersion: []const u8) !Conf
         "renderer",
         "The app runtime to use. Not all values supported on all platforms.",
     ) orelse RendererBackend.default(target.result, wasm_target);
+
+    config.bidi_backend = b.option(
+        BidiBackend,
+        "bidi-backend",
+        "The Unicode bidirectional algorithm implementation to use.",
+    ) orelse BidiBackend.default(target.result);
 
     //---------------------------------------------------------------
     // Feature Flags
@@ -571,6 +579,7 @@ pub fn addOptions(self: *const Config, step: *std.Build.Step.Options) !void {
     step.addOption(ApprtRuntime, "app_runtime", self.app_runtime);
     step.addOption(FontBackend, "font_backend", self.font_backend);
     step.addOption(RendererBackend, "renderer", self.renderer);
+    step.addOption(BidiBackend, "bidi_backend", self.bidi_backend);
     step.addOption(ExeEntrypoint, "exe_entrypoint", self.exe_entrypoint);
     step.addOption(WasmTarget, "wasm_target", self.wasm_target);
     step.addOption(bool, "wasm_shared", self.wasm_shared);
@@ -661,6 +670,7 @@ pub fn fromOptions() Config {
         .app_runtime = std.meta.stringToEnum(ApprtRuntime, @tagName(options.app_runtime)).?,
         .font_backend = std.meta.stringToEnum(FontBackend, @tagName(options.font_backend)).?,
         .renderer = std.meta.stringToEnum(RendererBackend, @tagName(options.renderer)).?,
+        .bidi_backend = std.meta.stringToEnum(BidiBackend, @tagName(options.bidi_backend)).?,
         .snap = options.snap,
         .exe_entrypoint = std.meta.stringToEnum(ExeEntrypoint, @tagName(options.exe_entrypoint)).?,
         .wasm_target = std.meta.stringToEnum(WasmTarget, @tagName(options.wasm_target)).?,

--- a/src/build/UnicodeTables.zig
+++ b/src/build/UnicodeTables.zig
@@ -5,10 +5,12 @@ const std = @import("std");
 /// The exe.
 props_exe: *std.Build.Step.Compile,
 symbols_exe: *std.Build.Step.Compile,
+bidi_exe: *std.Build.Step.Compile,
 
 /// The output path for the unicode tables
 props_output: std.Build.LazyPath,
 symbols_output: std.Build.LazyPath,
+bidi_output: std.Build.LazyPath,
 
 pub fn init(b: *std.Build, uucode_tables: std.Build.LazyPath) !UnicodeTables {
     const props_exe = b.addExecutable(.{
@@ -39,29 +41,47 @@ pub fn init(b: *std.Build, uucode_tables: std.Build.LazyPath) !UnicodeTables {
         .use_llvm = true,
     });
 
+    const bidi_exe = b.addExecutable(.{
+        .name = "bidi-unigen",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/unicode/bidi_uucode.zig"),
+            .target = b.graph.host,
+            .strip = false,
+            .omit_frame_pointer = false,
+            .unwind_tables = .sync,
+        }),
+
+        // TODO: x86_64 self-hosted crashes
+        .use_llvm = true,
+    });
+
     if (b.lazyDependency("uucode", .{
         .target = b.graph.host,
         .tables_path = uucode_tables,
         .build_config_path = b.path("src/build/uucode_config.zig"),
     })) |dep| {
-        inline for (&.{ props_exe, symbols_exe }) |exe| {
+        inline for (&.{ props_exe, symbols_exe, bidi_exe }) |exe| {
             exe.root_module.addImport("uucode", dep.module("uucode"));
         }
     }
 
     const props_run = b.addRunArtifact(props_exe);
     const symbols_run = b.addRunArtifact(symbols_exe);
+    const bidi_run = b.addRunArtifact(bidi_exe);
 
     // Generated Zig files have to end with .zig
     const wf = b.addWriteFiles();
     const props_output = wf.addCopyFile(props_run.captureStdOut(.{}), "props.zig");
     const symbols_output = wf.addCopyFile(symbols_run.captureStdOut(.{}), "symbols.zig");
+    const bidi_output = wf.addCopyFile(bidi_run.captureStdOut(.{}), "bidi.zig");
 
     return .{
         .props_exe = props_exe,
         .symbols_exe = symbols_exe,
+        .bidi_exe = bidi_exe,
         .props_output = props_output,
         .symbols_output = symbols_output,
+        .bidi_output = bidi_output,
     };
 }
 
@@ -69,6 +89,7 @@ pub fn init(b: *std.Build, uucode_tables: std.Build.LazyPath) !UnicodeTables {
 pub fn addImport(self: *const UnicodeTables, step: *std.Build.Step.Compile) void {
     self.props_output.addStepDependencies(&step.step);
     self.symbols_output.addStepDependencies(&step.step);
+    self.bidi_output.addStepDependencies(&step.step);
     self.addModuleImport(step.root_module);
 }
 
@@ -83,10 +104,14 @@ pub fn addModuleImport(
     module.addAnonymousImport("symbols_tables", .{
         .root_source_file = self.symbols_output,
     });
+    module.addAnonymousImport("bidi_tables", .{
+        .root_source_file = self.bidi_output,
+    });
 }
 
 /// Install the exe
 pub fn install(self: *const UnicodeTables, b: *std.Build) void {
     b.installArtifact(self.props_exe);
     b.installArtifact(self.symbols_exe);
+    b.installArtifact(self.bidi_exe);
 }

--- a/src/build/uucode_config.zig
+++ b/src/build/uucode_config.zig
@@ -54,6 +54,15 @@ pub const tables = [_]config.Table{
             "grapheme_break_no_control",
             "is_symbol",
             "is_emoji_vs_base",
+
+            // Bidi (UAX #9) properties. These are only read by the
+            // build-time table generator in `src/unicode/bidi_uucode.zig`;
+            // the shipped binary reads the generated table instead, so
+            // none of this ends up in the runtime image.
+            "bidi_class",
+            "bidi_paired_bracket",
+            "bidi_mirroring",
+            "is_bidi_mirrored",
         },
     },
 };

--- a/src/build_config.zig
+++ b/src/build_config.zig
@@ -7,6 +7,7 @@ const builtin = @import("builtin");
 const options = @import("build_options");
 const assert = std.debug.assert;
 const apprt = @import("apprt.zig");
+const bidipkg = @import("bidi/backend.zig");
 const font = @import("font/main.zig");
 const rendererpkg = @import("renderer.zig");
 const BuildConfig = @import("build/Config.zig");
@@ -41,6 +42,7 @@ pub const snap = options.snap;
 pub const app_runtime: apprt.Runtime = config.app_runtime;
 pub const font_backend: font.Backend = config.font_backend;
 pub const renderer: rendererpkg.Backend = config.renderer;
+pub const bidi_backend: bidipkg.Backend = config.bidi_backend;
 pub const i18n: bool = config.i18n;
 
 /// The bundle ID for the app. This is used in many places and is currently

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -377,6 +377,54 @@ language: ?[:0]const u8 = null,
 /// Available since: 1.2.0
 @"font-shaping-break": FontShapingBreak = .{},
 
+/// Whether to apply the Unicode Bidirectional Algorithm (UAX #9) when
+/// displaying text.
+///
+/// Terminals store text in "logical" order: the order a program wrote it
+/// and the order it will read it back. Scripts such as Arabic, Hebrew and
+/// Persian are written right to left, so displaying them correctly means
+/// reordering each line for display while leaving the stored text alone.
+/// Without this, right-to-left text appears reversed and Arabic letters
+/// are not joined to each other.
+///
+/// Valid values:
+///
+///   * `never` - Never reorder. Text is displayed in the order it is
+///     stored. This is the behavior of Ghostty before this option
+///     existed.
+///
+///   * `auto` - Reorder lines that contain right-to-left text. Lines
+///     without any are unaffected and cost nothing.
+///
+///   * `always` - Run the algorithm on every line regardless of content.
+///     This exists for diagnostics; `auto` produces the same output.
+///
+/// Note that some programs perform their own reordering and send text
+/// already in visual order. Those need `never`, or their output will be
+/// reordered twice.
+bidi: Bidi = .never,
+
+/// The paragraph direction to assume for a line with no strongly
+/// directional characters in it.
+///
+/// Rules P2 and P3 of UAX #9 take the direction of a paragraph from its
+/// first strongly directional character. A line of digits and punctuation
+/// has none, and this decides what happens then.
+///
+/// Valid values:
+///
+///   * `auto` - Use the first strong character, falling back to left to
+///     right when there is none. This is what the Unicode algorithm
+///     specifies.
+///
+///   * `ltr` - Always left to right.
+///
+///   * `rtl` - Always right to left. Useful for a session that is
+///     predominantly in a right-to-left language.
+///
+/// Has no effect when `bidi` is `never`.
+@"bidi-default-direction": BidiDefaultDirection = .auto,
+
 /// What color space to use when performing alpha blending.
 ///
 /// This affects the appearance of text and of any images with transparency.
@@ -8596,6 +8644,20 @@ pub const FontSyntheticStyle = packed struct {
     @"bold-italic": bool = true,
 };
 
+/// See "bidi" for documentation.
+pub const Bidi = enum {
+    never,
+    auto,
+    always,
+};
+
+/// See "bidi-default-direction" for documentation.
+pub const BidiDefaultDirection = enum {
+    auto,
+    ltr,
+    rtl,
+};
+
 /// See "font-shaping-break" for documentation
 pub const FontShapingBreak = packed struct {
     cursor: bool = true,
@@ -10374,6 +10436,50 @@ const TestIterator = struct {
         return result;
     }
 };
+
+test "bidi: defaults to never" {
+    const testing = std.testing;
+    var cfg = try Config.default(testing.allocator);
+    defer cfg.deinit();
+
+    // The default has to stay `never` until the phases that make
+    // reordering safe to enable have landed and been reviewed. A user
+    // who has not asked for bidi must see no change at all.
+    try testing.expectEqual(Bidi.never, cfg.bidi);
+    try testing.expectEqual(
+        BidiDefaultDirection.auto,
+        cfg.@"bidi-default-direction",
+    );
+}
+
+test "bidi: parses every value" {
+    const testing = std.testing;
+    var cfg = try Config.default(testing.allocator);
+    defer cfg.deinit();
+    const alloc = cfg._arena.?.allocator();
+
+    inline for (.{
+        .{ "never", Bidi.never },
+        .{ "auto", Bidi.auto },
+        .{ "always", Bidi.always },
+    }) |case| {
+        var it: TestIterator = .{ .data = &.{"--bidi=" ++ case[0]} };
+        try cli.args.parse(Config, alloc, &cfg, &it);
+        try testing.expectEqual(case[1], cfg.bidi);
+    }
+
+    inline for (.{
+        .{ "auto", BidiDefaultDirection.auto },
+        .{ "ltr", BidiDefaultDirection.ltr },
+        .{ "rtl", BidiDefaultDirection.rtl },
+    }) |case| {
+        var it: TestIterator = .{
+            .data = &.{"--bidi-default-direction=" ++ case[0]},
+        };
+        try cli.args.parse(Config, alloc, &cfg, &it);
+        try testing.expectEqual(case[1], cfg.@"bidi-default-direction");
+    }
+}
 
 test "parse hook: invalid command" {
     const testing = std.testing;

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -402,7 +402,7 @@ language: ?[:0]const u8 = null,
 /// Note that some programs perform their own reordering and send text
 /// already in visual order. Those need `never`, or their output will be
 /// reordered twice.
-bidi: Bidi = .never,
+bidi: Bidi = .auto,
 
 /// The paragraph direction to assume for a line with no strongly
 /// directional characters in it.
@@ -10463,15 +10463,21 @@ const TestIterator = struct {
     }
 };
 
-test "bidi: defaults to never" {
+test "bidi: defaults" {
     const testing = std.testing;
     var cfg = try Config.default(testing.allocator);
     defer cfg.deinit();
 
-    // The default has to stay `never` until the phases that make
-    // reordering safe to enable have landed and been reviewed. A user
-    // who has not asked for bidi must see no change at all.
-    try testing.expectEqual(Bidi.never, cfg.bidi);
+    // Reordering is on by default. Right-to-left text is unreadable
+    // without it, and the people who need it are the least able to know
+    // that a setting exists to fix it.
+    //
+    // This is the line to change to turn the feature off for everyone,
+    // which is why it is asserted rather than left implicit.
+    try testing.expectEqual(Bidi.auto, cfg.bidi);
+
+    // The paragraph direction still follows the content, per rules P2
+    // and P3, rather than being forced either way.
     try testing.expectEqual(
         BidiDefaultDirection.auto,
         cfg.@"bidi-default-direction",

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -425,6 +425,26 @@ bidi: Bidi = .never,
 /// Has no effect when `bidi` is `never`.
 @"bidi-default-direction": BidiDefaultDirection = .auto,
 
+/// What to do with Unicode bidirectional formatting characters when
+/// copying text.
+///
+/// These characters are part of what a program wrote and are meaningful,
+/// so the default keeps them: removing them changes what the text says,
+/// and a copy that does not round trip is worse than one carrying
+/// characters the destination ignores.
+///
+/// Valid values:
+///
+///   * `keep` - Copy them as they are.
+///
+///   * `strip` - Remove them from copied text.
+///
+/// Note that a selection starting or ending inside an embedding or
+/// isolate carries an unbalanced control either way, and will resolve
+/// differently when pasted elsewhere. `strip` avoids that at the cost of
+/// discarding directional information the text depended on.
+@"clipboard-bidi-controls": ClipboardBidiControls = .keep,
+
 /// What color space to use when performing alpha blending.
 ///
 /// This affects the appearance of text and of any images with transparency.
@@ -8642,6 +8662,12 @@ pub const FontSyntheticStyle = packed struct {
     bold: bool = true,
     italic: bool = true,
     @"bold-italic": bool = true,
+};
+
+/// See "clipboard-bidi-controls" for documentation.
+pub const ClipboardBidiControls = enum {
+    keep,
+    strip,
 };
 
 /// See "bidi" for documentation.

--- a/src/font/shape.zig
+++ b/src/font/shape.zig
@@ -127,6 +127,61 @@ pub const Options = struct {
     features: []const []const u8 = &.{},
 };
 
+/// The selected column ranges within a single row, in visual columns.
+///
+/// A selection is stored logically and is always logically contiguous,
+/// but a logically contiguous range is not necessarily contiguous on
+/// screen: a selection that spans a change of direction appears as
+/// several separate stretches. So a row can carry more than one segment
+/// and the run iterator has to break at every segment edge, or a run
+/// would end up partly selected and be shaped and coloured as a unit.
+pub const SelectionSegments = struct {
+    pub const Segment = struct {
+        start: u16,
+        end: u16,
+    };
+
+    /// Almost every row has at most one segment. A row crossing several
+    /// direction changes can have a few; beyond this bound the extra
+    /// edges are dropped, which costs a missing run break rather than
+    /// correctness, and is not reachable by any realistic selection.
+    pub const max = 8;
+
+    buf: [max]Segment = undefined,
+    len: usize = 0,
+
+    pub const empty: SelectionSegments = .{};
+
+    /// A single segment, which is what a row without any direction
+    /// change always produces.
+    pub fn one(seg: Segment) SelectionSegments {
+        var self: SelectionSegments = .empty;
+        self.append(seg);
+        return self;
+    }
+
+    pub fn append(self: *SelectionSegments, seg: Segment) void {
+        if (self.len >= max) return;
+        self.buf[self.len] = seg;
+        self.len += 1;
+    }
+
+    pub fn slice(self: *const SelectionSegments) []const Segment {
+        return self.buf[0..self.len];
+    }
+
+    /// Whether column `x` is the first column of a run that must be
+    /// split off from the preceding one, because the selection starts or
+    /// ends there.
+    pub fn isBoundary(self: *const SelectionSegments, x: u16) bool {
+        for (self.slice()) |seg| {
+            if (seg.start > 0 and x == seg.start) return true;
+            if (seg.end > 0 and x == seg.end + 1) return true;
+        }
+        return false;
+    }
+};
+
 /// Options for runIterator.
 pub const RunOptions = struct {
     /// The font state for the terminal screen. This is mutable because
@@ -136,8 +191,8 @@ pub const RunOptions = struct {
     /// The cells for the row to shape.
     cells: std.MultiArrayList(terminal.RenderState.Cell).Slice = .empty,
 
-    /// The x boundaries of the selection in this row.
-    selection: ?[2]u16 = null,
+    /// The selected column ranges in this row. See `SelectionSegments`.
+    selection: SelectionSegments = .empty,
 
     /// The cursor position within this row. This is used to break shaping
     /// on cursor boundaries. This can be disabled by setting this to
@@ -152,6 +207,59 @@ pub const RunOptions = struct {
         if (!config.cursor) self.cursor_x = null;
     }
 };
+
+test "SelectionSegments: single segment matches the old behavior" {
+    const testing = std.testing;
+
+    // The bounds checks deliberately keep the original semantics,
+    // including treating a zero start or end as "no boundary here", so
+    // that a row with one selected range breaks runs exactly where it
+    // used to.
+    const one: SelectionSegments = .one(.{ .start = 2, .end = 5 });
+    try testing.expectEqual(@as(usize, 1), one.slice().len);
+    try testing.expect(one.isBoundary(2));
+    try testing.expect(one.isBoundary(6));
+    try testing.expect(!one.isBoundary(3));
+    try testing.expect(!one.isBoundary(5));
+    try testing.expect(!one.isBoundary(7));
+
+    // A selection starting at column zero has no left boundary to break
+    // on, because there is nothing before it in the row.
+    const from_zero: SelectionSegments = .one(.{ .start = 0, .end = 3 });
+    try testing.expect(!from_zero.isBoundary(0));
+    try testing.expect(from_zero.isBoundary(4));
+}
+
+test "SelectionSegments: several segments each break runs" {
+    const testing = std.testing;
+
+    // What a logically contiguous selection looks like once it has been
+    // mapped through a row that changes direction partway.
+    var segs: SelectionSegments = .empty;
+    segs.append(.{ .start = 1, .end = 2 });
+    segs.append(.{ .start = 6, .end = 8 });
+
+    try testing.expectEqual(@as(usize, 2), segs.slice().len);
+    for ([_]u16{ 1, 3, 6, 9 }) |x| try testing.expect(segs.isBoundary(x));
+    for ([_]u16{ 0, 2, 4, 5, 7, 8, 10 }) |x| try testing.expect(!segs.isBoundary(x));
+}
+
+test "SelectionSegments: empty never breaks, overflow is dropped" {
+    const testing = std.testing;
+
+    const none: SelectionSegments = .empty;
+    try testing.expectEqual(@as(usize, 0), none.slice().len);
+    for (0..16) |x| try testing.expect(!none.isBoundary(@intCast(x)));
+
+    // Past the bound the extra edges are dropped rather than corrupting
+    // memory. This costs a run break, not correctness, and no realistic
+    // selection reaches it.
+    var full: SelectionSegments = .empty;
+    for (0..SelectionSegments.max + 4) |i| {
+        full.append(.{ .start = @intCast(i * 2 + 1), .end = @intCast(i * 2 + 1) });
+    }
+    try testing.expectEqual(@as(usize, SelectionSegments.max), full.slice().len);
+}
 
 test {
     _ = Cache;

--- a/src/font/shape.zig
+++ b/src/font/shape.zig
@@ -194,6 +194,22 @@ pub const RunOptions = struct {
     /// The selected column ranges in this row. See `SelectionSegments`.
     selection: SelectionSegments = .empty,
 
+    /// Visual column to logical column for this row.
+    ///
+    /// Empty means visual order equals logical order, which is the case
+    /// whenever bidi is disabled and for any row with no right-to-left
+    /// content. The run iterator then reduces exactly to walking logical
+    /// columns, which is what it did before bidi existed.
+    ///
+    /// These are plain slices rather than the renderer's `RowBidi` so
+    /// that the font package does not depend on the renderer. The caller
+    /// fills them from whatever it resolved.
+    v2l: []const u16 = &.{},
+
+    /// Resolved embedding level per logical column. Empty means every
+    /// column is at level zero.
+    levels: []const Level = &.{},
+
     /// The cursor position within this row. This is used to break shaping
     /// on cursor boundaries. This can be disabled by setting this to
     /// null.

--- a/src/font/shape.zig
+++ b/src/font/shape.zig
@@ -66,6 +66,57 @@ pub const Cell = struct {
     glyph_index: u32,
 };
 
+/// Build the logical-to-visual cell offset map for a right-to-left run.
+///
+/// Rule L2 of UAX #9 reverses a right-to-left run's cells, so the
+/// logically first cell is displayed rightmost. `Cell.x` is a visual
+/// offset relative to the run, so it needs that reversal applied.
+///
+/// Cells are not all one column wide, which is what makes this more than
+/// a subtraction. A cell occupying logical columns [c, c+w) must occupy
+/// visual columns [cells-c-w, cells-c), so the visual offset of a cell is
+/// `cells - c - w` rather than `cells - 1 - c`. Widths are recovered from
+/// the gaps between consecutive cluster values, since the run iterator
+/// skips spacer cells and therefore leaves a gap of exactly the cell's
+/// width.
+///
+/// `entries` is the shaper's record of the codepoints it fed the shaping
+/// engine, in logical order, each with a `.cluster` field giving its
+/// logical cell offset within the run. It lives here rather than in a
+/// shaper because the arithmetic is about terminal cells, not about
+/// HarfBuzz or CoreText, and both backends need exactly the same answer.
+pub fn buildVisualMap(
+    alloc: std.mem.Allocator,
+    out: *std.ArrayList(u16),
+    entries: anytype,
+    cells: u16,
+) std.mem.Allocator.Error!void {
+    out.clearRetainingCapacity();
+    try out.resize(alloc, cells);
+    @memset(out.items, 0);
+
+    // Cluster values are non-decreasing and equal for the codepoints of
+    // one grapheme, because they are assigned in logical cell order.
+    var i: usize = 0;
+    while (i < entries.len) {
+        const cluster = entries[i].cluster;
+
+        var j = i + 1;
+        while (j < entries.len and entries[j].cluster == cluster) j += 1;
+
+        const next: u32 = if (j < entries.len) entries[j].cluster else cells;
+        const width = next - cluster;
+
+        // A run always covers the cells its clusters address, so this
+        // cannot underflow unless the run and the shaping buffer
+        // disagree about the run's extent.
+        std.debug.assert(cluster + width <= cells);
+        out.items[@intCast(cluster)] = @intCast(cells - cluster - width);
+
+        i = j;
+    }
+}
+
 /// Options for shapers.
 pub const Options = struct {
     /// Font features to use when shaping.

--- a/src/font/shape.zig
+++ b/src/font/shape.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const bidi = @import("../bidi/types.zig");
 const options = @import("main.zig").options;
 const run = @import("shaper/run.zig");
 const feature = @import("shaper/feature.zig");
@@ -11,6 +12,14 @@ pub const coretext = @import("shaper/coretext.zig");
 pub const web_canvas = @import("shaper/web_canvas.zig");
 pub const Cache = @import("shaper/Cache.zig");
 pub const TextRun = run.TextRun;
+
+/// The direction a text run is shaped in. This is the bidi vocabulary
+/// type rather than a font-local one, because it always originates from
+/// bidi resolution and re-declaring it would invite the two to drift.
+pub const Direction = bidi.Direction;
+
+/// The resolved bidi embedding level of a text run.
+pub const Level = bidi.Level;
 pub const RunIterator = run.RunIterator;
 pub const Feature = feature.Feature;
 pub const FeatureList = feature.FeatureList;
@@ -96,6 +105,10 @@ pub const RunOptions = struct {
 test {
     _ = Cache;
     _ = Shaper;
+
+    // The run iterator had no tests before, so nothing referenced it here
+    // and its test block was never collected.
+    _ = run;
 
     // Always test noop
     _ = noop;

--- a/src/font/shaper/coretext.zig
+++ b/src/font/shaper/coretext.zig
@@ -52,10 +52,17 @@ pub const Shaper = struct {
     /// The shared memory used for shaping results.
     cell_buf: CellBuf,
 
-    /// Cached attributes dict for creating CTTypesetter objects.
-    /// The values in this never change so we can avoid overhead
-    /// by just creating it once and saving it for reuse.
-    typesetter_attr_dict: *macos.foundation.Dictionary,
+    /// Cached attribute dicts for creating CTTypesetter objects, one per
+    /// direction. The values never change so they are created once and
+    /// reused. Indexed by `@intFromEnum(font.shape.Direction)`, which
+    /// lines up with the embedding level each one forces: zero for
+    /// left-to-right, one for right-to-left.
+    typesetter_attr_dicts: [2]*macos.foundation.Dictionary,
+
+    /// For a right-to-left run, maps a logical cell offset within the run
+    /// to its visual cell offset. Empty for left-to-right runs, where the
+    /// two are the same. Rebuilt per shape call.
+    visual_map: std.ArrayList(u16) = .empty,
 
     /// List where we cache fonts, so we don't have to remake them for
     /// every single shaping operation.
@@ -173,34 +180,52 @@ pub const Shaper = struct {
         var run_state = RunState.init();
         errdefer run_state.deinit(alloc);
 
-        // For now we only support LTR text. If we shape RTL text then
-        // rendering will be very wrong so we need to explicitly force
-        // LTR no matter what.
+        // We tell CoreText the embedding level explicitly rather than
+        // letting it decide, and we do it through the typesetter rather
+        // than through the attributed string.
         //
         // See: https://github.com/mitchellh/ghostty/issues/1737
         // See: https://github.com/mitchellh/ghostty/issues/1442
         //
-        // We used to do this by setting the writing direction attribute
-        // on the attributed string we used, but it seems like that will
-        // still allow some weird results, for example a single space at
-        // the end of a line composed of RTL characters will be cause it
-        // to output a run containing just that space, BEFORE it outputs
-        // the rest of the line as a separate run, very weirdly with the
-        // "right to left" flag set in the single space run's run status...
+        // We used to set the writing direction attribute on the
+        // attributed string, but that still allowed some weird results,
+        // for example a single space at the end of a line composed of RTL
+        // characters would cause it to output a run containing just that
+        // space, BEFORE it output the rest of the line as a separate run,
+        // very weirdly with the "right to left" flag set in the single
+        // space run's run status...
         //
         // So instead what we do is use a CTTypesetter to create our line,
         // using the kCTTypesetterOptionForcedEmbeddingLevel attribute to
-        // force CoreText not to try doing any sort of BiDi, instead just
-        // treat all text as embedding level 0 (left to right).
-        const typesetter_attr_dict = dict: {
-            const num = try macos.foundation.Number.create(.int, &0);
+        // tell CoreText the embedding level rather than letting it run
+        // its own bidi over the text.
+        //
+        // Ghostty resolves bidi itself and a run never spans a change of
+        // direction, so the level for a whole run is known up front. We
+        // build one dict per direction here and pick between them per run
+        // in `shape`, since creating a dict per shaping call would put a
+        // CoreFoundation allocation in the hot path.
+        const ltr_attr_dict = dict: {
+            const level: c_int = 0;
+            const num = try macos.foundation.Number.create(.int, &level);
             defer num.release();
             break :dict try macos.foundation.Dictionary.create(
                 &.{macos.c.kCTTypesetterOptionForcedEmbeddingLevel},
                 &.{num},
             );
         };
-        errdefer typesetter_attr_dict.release();
+        errdefer ltr_attr_dict.release();
+
+        const rtl_attr_dict = dict: {
+            const level: c_int = 1;
+            const num = try macos.foundation.Number.create(.int, &level);
+            defer num.release();
+            break :dict try macos.foundation.Dictionary.create(
+                &.{macos.c.kCTTypesetterOptionForcedEmbeddingLevel},
+                &.{num},
+            );
+        };
+        errdefer rtl_attr_dict.release();
 
         // Create the CF release thread.
         var cf_release_thread = try alloc.create(CFReleaseThread);
@@ -222,7 +247,7 @@ pub const Shaper = struct {
             .run_state = run_state,
             .features = features,
             .features_no_default = features_no_default,
-            .typesetter_attr_dict = typesetter_attr_dict,
+            .typesetter_attr_dicts = .{ ltr_attr_dict, rtl_attr_dict },
             .cached_fonts = .empty,
             .cached_font_grid = 0,
             .cf_release_pool = .empty,
@@ -236,7 +261,8 @@ pub const Shaper = struct {
         self.run_state.deinit(self.alloc);
         self.features.release();
         self.features_no_default.release();
-        self.typesetter_attr_dict.release();
+        for (self.typesetter_attr_dicts) |d| d.release();
+        self.visual_map.deinit(self.alloc);
 
         {
             for (self.cached_fonts.items) |ft| {
@@ -318,6 +344,16 @@ pub const Shaper = struct {
         run: font.shape.TextRun,
     ) ![]const font.shape.Cell {
         const state = &self.run_state;
+        const rtl = run.direction == .rtl;
+
+        // For a right-to-left run we need to know where each logical cell
+        // lands visually, because `Cell.x` is a visual offset.
+        if (rtl) try font.shape.buildVisualMap(
+            self.alloc,
+            &self.visual_map,
+            state.codepoints.items,
+            run.cells,
+        );
 
         // {
         //     log.debug("shape -----------------------------------", .{});
@@ -376,7 +412,7 @@ pub const Shaper = struct {
         const typesetter =
             try macos.text.Typesetter.createWithAttributedStringAndOptions(
                 attr_str,
-                self.typesetter_attr_dict,
+                self.typesetter_attr_dicts[@intFromEnum(run.direction)],
             );
         self.cf_release_pool.appendAssumeCapacity(typesetter);
 
@@ -384,9 +420,14 @@ pub const Shaper = struct {
         const line = typesetter.createLine(.{ .location = 0, .length = 0 });
         self.cf_release_pool.appendAssumeCapacity(line);
 
-        // This keeps track of the current x offset (sum of advance.width) and
-        // the furthest cluster we've seen so far (max).
-        var run_offset: Offset = .{};
+        // This keeps track of the current x offset (sum of advance.width)
+        // and the furthest cluster we've seen so far in the order glyphs
+        // are emitted: the largest for a left-to-right run, the smallest
+        // for a right-to-left one, since CoreText emits glyphs in visual
+        // order and RTL clusters therefore descend.
+        var run_offset: Offset = .{
+            .cluster = if (rtl) std.math.maxInt(u32) else 0,
+        };
 
         // This keeps track of the cell starting x and cluster.
         var cell_offset: Offset = .{};
@@ -417,7 +458,14 @@ pub const Shaper = struct {
             const ctrun = runs.getValueAtIndex(macos.text.Run, run_i);
 
             const status = ctrun.getStatus();
-            if (status.non_monotonic or status.right_to_left) non_ltr = true;
+
+            // A right-to-left run status is expected when we asked for a
+            // right-to-left embedding level, so on its own it is not a
+            // reason to sort. What we are guarding against is CoreText
+            // disagreeing with the direction we forced, or producing
+            // non-monotonic output within a run.
+            if (status.non_monotonic) non_ltr = true;
+            if (status.right_to_left != rtl) non_ltr = true;
 
             // Get our glyphs and positions
             const glyphs = ctrun.getGlyphsPtr() orelse try ctrun.getGlyphs(alloc);
@@ -443,10 +491,33 @@ pub const Shaper = struct {
                     // See e.g. the "shape Chakma vowel sign with ligature
                     // (vowel sign renders first)" test.
 
-                    const is_after_glyph_from_current_or_next_clusters =
+                    // Clusters ascend for a left-to-right run and descend
+                    // for a right-to-left one, so the comparison that
+                    // detects out-of-order arrival flips with direction.
+                    const is_after_glyph_from_current_or_next_clusters = if (rtl)
+                        cluster >= run_offset.cluster
+                    else
                         cluster <= run_offset.cluster;
 
+                    // Whether this is the first codepoint of its cluster
+                    // in the order glyphs are emitted. Laying out at a
+                    // right-to-left embedding level reverses the order
+                    // within a cluster too, so the search runs forward
+                    // through the logically ordered codepoints rather
+                    // than backward.
                     const is_first_codepoint_in_cluster = blk: {
+                        if (rtl) {
+                            var i = index + 1;
+                            while (i < state.codepoints.items.len) : (i += 1) {
+                                const codepoint = state.codepoints.items[i];
+
+                                // Skip surrogate pair padding
+                                if (codepoint.codepoint == 0) continue;
+                                break :blk codepoint.cluster != cluster;
+                            }
+                            break :blk true;
+                        }
+
                         var i = index;
                         while (i > 0) {
                             i -= 1;
@@ -505,7 +576,15 @@ pub const Shaper = struct {
                 const x_offset = position.x - cell_offset.x;
 
                 self.cell_buf.appendAssumeCapacity(.{
-                    .x = @intCast(cell_offset.cluster),
+                    // `Cell.x` is a visual offset within the run, because
+                    // the renderer walks visual columns and requires it
+                    // to ascend. For a left-to-right run the logical
+                    // cluster already is that offset; for a right-to-left
+                    // one it has to be mapped.
+                    .x = if (rtl)
+                        self.visual_map.items[@intCast(cell_offset.cluster)]
+                    else
+                        @intCast(cell_offset.cluster),
                     .x_offset = @intFromFloat(@round(x_offset)),
                     .y_offset = @intFromFloat(@round(position.y)),
                     .glyph_index = glyph,
@@ -514,7 +593,10 @@ pub const Shaper = struct {
                 // Add our advances to keep track of our run offsets.
                 // Advances apply to the NEXT cell.
                 run_offset.x += advance.width;
-                run_offset.cluster = @max(run_offset.cluster, cluster);
+                run_offset.cluster = if (rtl)
+                    @min(run_offset.cluster, cluster)
+                else
+                    @max(run_offset.cluster, cluster);
 
                 // For debugging positions, turn this on:
                 //run_offset_y += advance.height;

--- a/src/font/shaper/coretext.zig
+++ b/src/font/shaper/coretext.zig
@@ -2063,7 +2063,7 @@ test "shape selection boundary" {
         var it = shaper.runIterator(.{
             .grid = testdata.grid,
             .cells = state.row_data.get(0).cells.slice(),
-            .selection = .{ 0, @intCast(t.cols - 1) },
+            .selection = .one(.{ .start = 0, .end = @intCast(t.cols - 1) }),
         });
         var count: usize = 0;
         while (try it.next(alloc)) |run| {
@@ -2080,7 +2080,7 @@ test "shape selection boundary" {
         var it = shaper.runIterator(.{
             .grid = testdata.grid,
             .cells = state.row_data.get(0).cells.slice(),
-            .selection = .{ 2, @intCast(t.cols - 1) },
+            .selection = .one(.{ .start = 2, .end = @intCast(t.cols - 1) }),
         });
         var count: usize = 0;
         while (try it.next(alloc)) |run| {
@@ -2097,7 +2097,7 @@ test "shape selection boundary" {
         var it = shaper.runIterator(.{
             .grid = testdata.grid,
             .cells = state.row_data.get(0).cells.slice(),
-            .selection = .{ 0, 3 },
+            .selection = .one(.{ .start = 0, .end = 3 }),
         });
         var count: usize = 0;
         while (try it.next(alloc)) |run| {
@@ -2114,7 +2114,7 @@ test "shape selection boundary" {
         var it = shaper.runIterator(.{
             .grid = testdata.grid,
             .cells = state.row_data.get(0).cells.slice(),
-            .selection = .{ 1, 3 },
+            .selection = .one(.{ .start = 1, .end = 3 }),
         });
         var count: usize = 0;
         while (try it.next(alloc)) |run| {
@@ -2131,7 +2131,7 @@ test "shape selection boundary" {
         var it = shaper.runIterator(.{
             .grid = testdata.grid,
             .cells = state.row_data.get(0).cells.slice(),
-            .selection = .{ 1, 1 },
+            .selection = .one(.{ .start = 1, .end = 1 }),
         });
         var count: usize = 0;
         while (try it.next(alloc)) |run| {

--- a/src/font/shaper/harfbuzz.zig
+++ b/src/font/shaper/harfbuzz.zig
@@ -182,7 +182,12 @@ pub const Shaper = struct {
 
         // For a right-to-left run we need to know where each logical cell
         // lands visually, because `Cell.x` is a visual offset.
-        if (rtl) try self.buildVisualMap(run);
+        if (rtl) try font.shape.buildVisualMap(
+            self.alloc,
+            &self.visual_map,
+            self.codepoints.items,
+            run.cells,
+        );
 
         // This keeps track of the current x and y offsets (sum of advances)
         // and the furthest cluster we've seen so far in the direction the
@@ -319,50 +324,6 @@ pub const Shaper = struct {
         //log.warn("----------------", .{});
 
         return self.cell_buf.items;
-    }
-
-    /// Build the logical-to-visual cell offset map for a right-to-left run.
-    ///
-    /// Rule L2 of UAX #9 reverses a right-to-left run's cells, so the
-    /// logically first cell is displayed rightmost. `Cell.x` is a visual
-    /// offset relative to the run, so it needs that reversal applied.
-    ///
-    /// Cells are not all one column wide, which is what makes this more
-    /// than a subtraction. A cell occupying logical columns [c, c+w) must
-    /// occupy visual columns [cells-c-w, cells-c), so the visual offset of
-    /// a cell is `cells - c - w` rather than `cells - 1 - c`. Widths are
-    /// recovered from the gaps between consecutive cluster values, since
-    /// the run iterator skips spacer cells and therefore leaves a gap of
-    /// exactly the cell's width.
-    fn buildVisualMap(
-        self: *Shaper,
-        run: font.shape.TextRun,
-    ) Allocator.Error!void {
-        self.visual_map.clearRetainingCapacity();
-        try self.visual_map.resize(self.alloc, run.cells);
-        @memset(self.visual_map.items, 0);
-
-        // Codepoints are in logical order, so cluster values here are
-        // non-decreasing and equal for the codepoints of one grapheme.
-        const cps = self.codepoints.items;
-        var i: usize = 0;
-        while (i < cps.len) {
-            const cluster = cps[i].cluster;
-
-            var j = i + 1;
-            while (j < cps.len and cps[j].cluster == cluster) j += 1;
-
-            const next: u32 = if (j < cps.len) cps[j].cluster else run.cells;
-            const width = next - cluster;
-
-            // A run always covers the cells its clusters address, so this
-            // cannot underflow unless the run and the buffer disagree.
-            assert(cluster + width <= run.cells);
-            self.visual_map.items[@intCast(cluster)] =
-                @intCast(run.cells - cluster - width);
-
-            i = j;
-        }
     }
 
     /// The hooks for RunIterator.

--- a/src/font/shaper/harfbuzz.zig
+++ b/src/font/shaper/harfbuzz.zig
@@ -39,6 +39,11 @@ pub const Shaper = struct {
     /// with glyph indices in the buffer.
     codepoints: std.ArrayList(Codepoint) = .empty,
 
+    /// For a right-to-left run, maps a logical cell offset within the run
+    /// to its visual cell offset. Empty for left-to-right runs, where the
+    /// two are the same. Rebuilt per shape call. See `buildVisualMap`.
+    visual_map: std.ArrayList(u16) = .empty,
+
     const Codepoint = struct {
         cluster: u32,
         codepoint: u32,
@@ -98,6 +103,7 @@ pub const Shaper = struct {
         self.cell_buf.deinit(self.alloc);
         self.alloc.free(self.hb_feats);
         self.codepoints.deinit(self.alloc);
+        self.visual_map.deinit(self.alloc);
     }
 
     pub fn endFrame(self: *const Shaper) void {
@@ -129,6 +135,21 @@ pub const Shaper = struct {
     ///
     /// If there is not enough space in the cell buffer, an error is returned.
     pub fn shape(self: *Shaper, run: font.shape.TextRun) ![]const font.shape.Cell {
+        const rtl = run.direction == .rtl;
+
+        // Force the buffer to the run's resolved direction. `finalize`
+        // already ran `guessSegmentProperties` to infer script and
+        // language; the direction it inferred from the script is only a
+        // guess, whereas the run's direction comes from bidi resolution
+        // and is authoritative. A run never spans a direction change, so
+        // one direction for the whole buffer is always correct.
+        //
+        // Codepoints were added in logical order and must stay that way:
+        // HarfBuzz decides Arabic joining forms from logical neighbours
+        // and emits the glyphs in visual order itself. Handing it
+        // pre-reversed text produces the wrong contextual forms.
+        self.hb_buf.setDirection(if (rtl) .rtl else .ltr);
+
         // We only do shaping if the font is not a special-case. For special-case
         // fonts, the codepoint == glyph_index so we don't need to run any shaping.
         if (run.font_index.special() == null) {
@@ -159,9 +180,18 @@ pub const Shaper = struct {
         // If it isn't true, I'd like to catch it and learn more.
         assert(info.len == pos.len);
 
+        // For a right-to-left run we need to know where each logical cell
+        // lands visually, because `Cell.x` is a visual offset.
+        if (rtl) try self.buildVisualMap(run);
+
         // This keeps track of the current x and y offsets (sum of advances)
-        // and the furthest cluster we've seen so far (max).
-        var run_offset: RunOffset = .{};
+        // and the furthest cluster we've seen so far in the direction the
+        // glyphs are being emitted: the largest for a left-to-right run,
+        // the smallest for a right-to-left one, since HarfBuzz emits
+        // glyphs in visual order and RTL clusters therefore descend.
+        var run_offset: RunOffset = .{
+            .cluster = if (rtl) std.math.maxInt(u32) else 0,
+        };
 
         // This keeps track of the cell starting x and cluster.
         var cell_offset: CellOffset = .{};
@@ -176,10 +206,31 @@ pub const Shaper = struct {
             // then we need to reset our current cell offsets.
             const cluster = self.codepoints.items[index].cluster;
             if (cell_offset.cluster != cluster) {
-                const is_after_glyph_from_current_or_next_clusters =
+                // Whether this glyph comes after one from the current or a
+                // later cluster, i.e. whether glyphs are arriving out of
+                // cluster order. Clusters ascend for a left-to-right run
+                // and descend for a right-to-left one, so the comparison
+                // flips with the direction.
+                const is_after_glyph_from_current_or_next_clusters = if (rtl)
+                    cluster >= run_offset.cluster
+                else
                     cluster <= run_offset.cluster;
 
+                // Whether this is the first codepoint of its cluster in
+                // the order the glyphs are being emitted. HarfBuzz
+                // reverses the whole buffer for a right-to-left run, which
+                // reverses the order within a cluster too, so the search
+                // runs forward through the logically ordered codepoints
+                // instead of backward.
                 const is_first_codepoint_in_cluster = blk: {
+                    if (rtl) {
+                        var i = index + 1;
+                        while (i < self.codepoints.items.len) : (i += 1) {
+                            break :blk self.codepoints.items[i].cluster != cluster;
+                        }
+                        break :blk true;
+                    }
+
                     var i = index;
                     while (i > 0) {
                         i -= 1;
@@ -236,7 +287,15 @@ pub const Shaper = struct {
             //try self.debugPositions(run_offset, cell_offset, pos_v, index);
 
             try self.cell_buf.append(self.alloc, .{
-                .x = @intCast(cell_offset.cluster),
+                // `Cell.x` is a visual offset within the run, because the
+                // renderer walks visual columns and requires it to ascend.
+                // For a left-to-right run the logical cluster already is
+                // that offset; for a right-to-left one it has to be
+                // mapped. See `buildVisualMap`.
+                .x = if (rtl)
+                    self.visual_map.items[@intCast(cell_offset.cluster)]
+                else
+                    @intCast(cell_offset.cluster),
                 .x_offset = @intCast(x_offset),
                 .y_offset = @intCast(y_offset),
                 .glyph_index = info_v.codepoint,
@@ -249,7 +308,10 @@ pub const Shaper = struct {
             // whole value here.
             run_offset.x += (pos_v.x_advance + 0b100_000) >> 6;
             run_offset.y += (pos_v.y_advance + 0b100_000) >> 6;
-            run_offset.cluster = @max(run_offset.cluster, cluster);
+            run_offset.cluster = if (rtl)
+                @min(run_offset.cluster, cluster)
+            else
+                @max(run_offset.cluster, cluster);
 
             // const i = self.cell_buf.items.len - 1;
             // log.warn("i={} info={} pos={} cell={}", .{ i, info_v, pos_v, self.cell_buf.items[i] });
@@ -257,6 +319,50 @@ pub const Shaper = struct {
         //log.warn("----------------", .{});
 
         return self.cell_buf.items;
+    }
+
+    /// Build the logical-to-visual cell offset map for a right-to-left run.
+    ///
+    /// Rule L2 of UAX #9 reverses a right-to-left run's cells, so the
+    /// logically first cell is displayed rightmost. `Cell.x` is a visual
+    /// offset relative to the run, so it needs that reversal applied.
+    ///
+    /// Cells are not all one column wide, which is what makes this more
+    /// than a subtraction. A cell occupying logical columns [c, c+w) must
+    /// occupy visual columns [cells-c-w, cells-c), so the visual offset of
+    /// a cell is `cells - c - w` rather than `cells - 1 - c`. Widths are
+    /// recovered from the gaps between consecutive cluster values, since
+    /// the run iterator skips spacer cells and therefore leaves a gap of
+    /// exactly the cell's width.
+    fn buildVisualMap(
+        self: *Shaper,
+        run: font.shape.TextRun,
+    ) Allocator.Error!void {
+        self.visual_map.clearRetainingCapacity();
+        try self.visual_map.resize(self.alloc, run.cells);
+        @memset(self.visual_map.items, 0);
+
+        // Codepoints are in logical order, so cluster values here are
+        // non-decreasing and equal for the codepoints of one grapheme.
+        const cps = self.codepoints.items;
+        var i: usize = 0;
+        while (i < cps.len) {
+            const cluster = cps[i].cluster;
+
+            var j = i + 1;
+            while (j < cps.len and cps[j].cluster == cluster) j += 1;
+
+            const next: u32 = if (j < cps.len) cps[j].cluster else run.cells;
+            const width = next - cluster;
+
+            // A run always covers the cells its clusters address, so this
+            // cannot underflow unless the run and the buffer disagree.
+            assert(cluster + width <= run.cells);
+            self.visual_map.items[@intCast(cluster)] =
+                @intCast(run.cells - cluster - width);
+
+            i = j;
+        }
     }
 
     /// The hooks for RunIterator.
@@ -275,10 +381,11 @@ pub const Shaper = struct {
 
             self.shaper.codepoints.clearRetainingCapacity();
 
-            // We don't support RTL text because RTL in terminals is messy.
-            // Its something we want to improve. For now, we force LTR because
-            // our renderers assume a strictly increasing X value.
-            self.shaper.hb_buf.setDirection(.ltr);
+            // Direction is deliberately left unset here. `finalize` calls
+            // `guessSegmentProperties`, which infers the script from the
+            // buffer contents, and `shape` then forces the direction from
+            // the run. Setting it here would only stop the guess from
+            // running and would be overridden anyway.
         }
 
         pub fn addCodepoint(self: RunIteratorHook, cp: u32, cluster: u32) !void {
@@ -295,6 +402,10 @@ pub const Shaper = struct {
         }
 
         pub fn finalize(self: RunIteratorHook) void {
+            // Infers script and language from the buffer contents. It also
+            // infers direction, but only because direction is still unset
+            // at this point; `shape` overrides it with the run's resolved
+            // direction, which is the authoritative value.
             self.shaper.hb_buf.guessSegmentProperties();
         }
     };
@@ -2198,4 +2309,435 @@ fn testShaperWithDiscoveredFont(alloc: Allocator, font_req: [:0]const u8) !TestS
         .grid = grid_ptr,
         .lib = lib,
     };
+}
+
+/// Shape a single-run string with the Arabic test font, returning the run
+/// and its shaped cells. `direction` overrides the run's direction, which
+/// is how these tests exercise RTL before the run iterator produces it.
+fn testShapeRtl(
+    alloc: Allocator,
+    testdata: *TestShaper,
+    str: []const u8,
+    direction: font.shape.Direction,
+    t: *terminal.Terminal,
+    state: *terminal.RenderState,
+) !struct { run: font.shape.TextRun, cells: []const font.shape.Cell } {
+    var s = t.vtStream();
+    defer s.deinit();
+    s.nextSlice(str);
+    try state.update(alloc, t);
+
+    var shaper = &testdata.shaper;
+    var it = shaper.runIterator(.{
+        .grid = testdata.grid,
+        .cells = state.row_data.get(0).cells.slice(),
+    });
+
+    var run = (try it.next(alloc)).?;
+    run.direction = direction;
+    run.level = if (direction == .rtl) 1 else 0;
+    const cells = try shaper.shape(run);
+    return .{ .run = run, .cells = cells };
+}
+
+test "shape rtl: visual x ascends and stays in range" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    var testdata = try testShaperWithFont(alloc, .arabic);
+    defer testdata.deinit();
+
+    var t = try terminal.Terminal.init(io, alloc, .{ .cols = 120, .rows = 30 });
+    defer t.deinit(alloc);
+    var state: terminal.RenderState = .empty;
+    defer state.deinit(alloc);
+
+    const r = try testShapeRtl(
+        alloc,
+        &testdata,
+        @embedFile("testdata/arabic.txt"),
+        .rtl,
+        &t,
+        &state,
+    );
+
+    // The renderer walks visual columns and matches shaped cells against
+    // them in lockstep, asserting x never moves backwards. That invariant
+    // has to survive right-to-left runs, which is the whole reason the
+    // cluster mapping had to be re-derived rather than just letting
+    // HarfBuzz emit RTL clusters as they come.
+    try testing.expect(r.cells.len > 0);
+    var x: u16 = 0;
+    for (r.cells) |cell| {
+        try testing.expect(cell.x >= x);
+        try testing.expect(cell.x < r.run.cells);
+        x = cell.x;
+    }
+}
+
+test "shape rtl: reorders and reshapes relative to ltr" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    var testdata = try testShaperWithFont(alloc, .arabic);
+    defer testdata.deinit();
+
+    // Beh followed by meem. An asymmetric word matters here: three of the
+    // same letter happens to produce the same (x, glyph) pairs either way
+    // by coincidence, which would make this test pass while proving
+    // nothing.
+    const str = "\u{0628}\u{0645}";
+
+    var ltr: [2]u32 = undefined;
+    {
+        var t = try terminal.Terminal.init(io, alloc, .{ .cols = 20, .rows = 3 });
+        defer t.deinit(alloc);
+        var state: terminal.RenderState = .empty;
+        defer state.deinit(alloc);
+
+        const r = try testShapeRtl(alloc, &testdata, str, .ltr, &t, &state);
+        try testing.expectEqual(@as(usize, 2), r.cells.len);
+        for (r.cells, 0..) |c, i| {
+            try testing.expectEqual(@as(u16, @intCast(i)), c.x);
+            ltr[i] = c.glyph_index;
+        }
+    }
+
+    {
+        var t = try terminal.Terminal.init(io, alloc, .{ .cols = 20, .rows = 3 });
+        defer t.deinit(alloc);
+        var state: terminal.RenderState = .empty;
+        defer state.deinit(alloc);
+
+        const r = try testShapeRtl(alloc, &testdata, str, .rtl, &t, &state);
+        try testing.expectEqual(@as(usize, 2), r.cells.len);
+
+        // Every visual position shows a different glyph than it did
+        // left-to-right. Two things changed at once, and both matter:
+        // the cells were reordered, so the logically first letter is now
+        // rightmost, and HarfBuzz picked different contextual forms
+        // because joining depends on the direction the run is shaped in.
+        // Forcing Arabic to left-to-right, as the shaper did before this,
+        // therefore did not merely reverse the word: it also rendered
+        // every letter in the wrong joining form.
+        for (r.cells, 0..) |c, i| {
+            try testing.expectEqual(@as(u16, @intCast(i)), c.x);
+            try testing.expect(c.glyph_index != ltr[i]);
+        }
+    }
+}
+
+test "shape rtl: arabic contextual joining forms" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    var testdata = try testShaperWithFont(alloc, .arabic);
+    defer testdata.deinit();
+
+    // A run of three identical letters exercises all four joining forms:
+    // the word gives initial, medial, and final, and the same letter
+    // alone gives isolated. If direction or buffer order were wrong,
+    // HarfBuzz would pick the wrong forms and these would collide.
+    var joined: [3]u32 = undefined;
+    {
+        var t = try terminal.Terminal.init(io, alloc, .{ .cols = 20, .rows = 3 });
+        defer t.deinit(alloc);
+        var state: terminal.RenderState = .empty;
+        defer state.deinit(alloc);
+
+        const r = try testShapeRtl(
+            alloc,
+            &testdata,
+            "\u{0628}\u{0628}\u{0628}",
+            .rtl,
+            &t,
+            &state,
+        );
+        try testing.expectEqual(@as(usize, 3), r.cells.len);
+        for (r.cells, 0..) |c, i| joined[i] = c.glyph_index;
+    }
+
+    var isolated: u32 = undefined;
+    {
+        var t = try terminal.Terminal.init(io, alloc, .{ .cols = 20, .rows = 3 });
+        defer t.deinit(alloc);
+        var state: terminal.RenderState = .empty;
+        defer state.deinit(alloc);
+
+        const r = try testShapeRtl(alloc, &testdata, "\u{0628}", .rtl, &t, &state);
+        try testing.expectEqual(@as(usize, 1), r.cells.len);
+        isolated = r.cells[0].glyph_index;
+    }
+
+    // All four forms must be distinct glyphs. Unjoined Arabic renders as
+    // a row of isolated letters, which is legible but wrong, and is
+    // exactly what a run that was split per cell would produce.
+    try testing.expect(joined[0] != joined[1]);
+    try testing.expect(joined[1] != joined[2]);
+    try testing.expect(joined[0] != joined[2]);
+    for (joined) |g| try testing.expect(g != isolated);
+}
+
+test "shape rtl: lam-alef ligature" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    var testdata = try testShaperWithFont(alloc, .arabic);
+    defer testdata.deinit();
+
+    var t = try terminal.Terminal.init(io, alloc, .{ .cols = 20, .rows = 3 });
+    defer t.deinit(alloc);
+    var state: terminal.RenderState = .empty;
+    defer state.deinit(alloc);
+
+    // Lam followed by alef is a mandatory ligature: two codepoints, two
+    // terminal cells, but a single glyph. The glyph belongs to the lam's
+    // cluster, which is logically first and therefore rightmost, so it
+    // lands at the higher visual offset. The other cell is left empty,
+    // which is the known cell-grid limitation noted in the RFC rather
+    // than a mapping bug.
+    const r = try testShapeRtl(
+        alloc,
+        &testdata,
+        "\u{0644}\u{0627}",
+        .rtl,
+        &t,
+        &state,
+    );
+
+    try testing.expectEqual(@as(u16, 2), r.run.cells);
+    try testing.expectEqual(@as(usize, 1), r.cells.len);
+    try testing.expectEqual(@as(u16, 1), r.cells[0].x);
+}
+
+test "shape rtl: marks share the cell of their base" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    var testdata = try testShaperWithFont(alloc, .arabic);
+    defer testdata.deinit();
+
+    var t = try terminal.Terminal.init(io, alloc, .{ .cols = 20, .rows = 3 });
+    defer t.deinit(alloc);
+    var state: terminal.RenderState = .empty;
+    defer state.deinit(alloc);
+
+    // Beh with fatha above it. The mark is non-spacing, so it occupies no
+    // column of its own and must land on the same cell as its base.
+    // HarfBuzz reverses the whole buffer for a right-to-left run, which
+    // reverses the order within a cluster too, so the mark arrives before
+    // its base; the cluster bookkeeping has to cope with that.
+    const r = try testShapeRtl(
+        alloc,
+        &testdata,
+        "\u{0628}\u{064E}",
+        .rtl,
+        &t,
+        &state,
+    );
+
+    try testing.expectEqual(@as(u16, 1), r.run.cells);
+    try testing.expectEqual(@as(usize, 2), r.cells.len);
+    for (r.cells) |c| try testing.expectEqual(@as(u16, 0), c.x);
+
+    // The two glyphs are different: one is the letter, one is the mark.
+    try testing.expect(r.cells[0].glyph_index != r.cells[1].glyph_index);
+}
+
+test "shape rtl: zwnj breaks cursive joining" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    var testdata = try testShaperWithFont(alloc, .arabic);
+    defer testdata.deinit();
+
+    // Two beh separated by a zero width non-joiner, the construction
+    // Persian uses inside compound words. The letters must not join, so
+    // the isolated form appears where a joined form otherwise would.
+    //
+    // Note this exercises less than it looks. The test font does not
+    // cover U+200C, so the run iterator's font fallback replaces the
+    // grapheme containing it, and the shaper never sees the ZWNJ itself.
+    // What is verified is the observable outcome: no cursive joining.
+    var t = try terminal.Terminal.init(io, alloc, .{ .cols = 20, .rows = 3 });
+    defer t.deinit(alloc);
+    var state: terminal.RenderState = .empty;
+    defer state.deinit(alloc);
+
+    // The shaper reuses one cell buffer, so the result of the first call
+    // has to be copied out before the second call overwrites it.
+    var glyphs: [8]u32 = undefined;
+    var xs: [8]u16 = undefined;
+    var len: usize = 0;
+    {
+        const r = try testShapeRtl(
+            alloc,
+            &testdata,
+            "\u{0628}\u{200C}\u{0628}",
+            .rtl,
+            &t,
+            &state,
+        );
+        len = r.cells.len;
+        for (r.cells, 0..) |c, i| {
+            glyphs[i] = c.glyph_index;
+            xs[i] = c.x;
+            try testing.expect(c.x < r.run.cells);
+        }
+    }
+
+    var isolated: u32 = undefined;
+    {
+        var t2 = try terminal.Terminal.init(io, alloc, .{ .cols = 20, .rows = 3 });
+        defer t2.deinit(alloc);
+        var state2: terminal.RenderState = .empty;
+        defer state2.deinit(alloc);
+        const iso = try testShapeRtl(alloc, &testdata, "\u{0628}", .rtl, &t2, &state2);
+        isolated = iso.cells[0].glyph_index;
+    }
+
+    var saw_isolated = false;
+    for (glyphs[0..len], xs[0..len]) |g, x| {
+        _ = x;
+        if (g == isolated) saw_isolated = true;
+    }
+    try testing.expect(saw_isolated);
+}
+
+test "shape rtl: visual map accounts for wide cells" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    var testdata = try testShaper(alloc);
+    defer testdata.deinit();
+
+    var t = try terminal.Terminal.init(io, alloc, .{ .cols = 20, .rows = 3 });
+    defer t.deinit(alloc);
+    var state: terminal.RenderState = .empty;
+    defer state.deinit(alloc);
+
+    // Two double-width characters, so the run is four columns wide but
+    // only two of them start a cell. Reversing a run is not simply
+    // `cells - 1 - c`: a cell occupying logical columns [c, c+w) has to
+    // land on visual columns [cells-c-w, cells-c), or wide characters end
+    // up shifted one column from where they belong.
+    const r = try testShapeRtl(alloc, &testdata, "👍👍", .rtl, &t, &state);
+
+    try testing.expectEqual(@as(u16, 4), r.run.cells);
+
+    // Logical cell 0 is two columns wide, so it occupies visual columns
+    // 2 and 3, and logical cell 2 occupies visual columns 0 and 1.
+    const map = testdata.shaper.visual_map.items;
+    try testing.expectEqual(@as(usize, 4), map.len);
+    try testing.expectEqual(@as(u16, 2), map[0]);
+    try testing.expectEqual(@as(u16, 0), map[2]);
+
+    // And the emitted cells still ascend.
+    var x: u16 = 0;
+    for (r.cells) |cell| {
+        try testing.expect(cell.x >= x);
+        try testing.expect(cell.x < r.run.cells);
+        x = cell.x;
+    }
+}
+
+/// The cases covered by the golden vectors in `testdata/rtl_shaping.txt`.
+const rtl_golden_cases = [_]struct { name: []const u8, str: []const u8 }{
+    .{ .name = "arabic beh x3 (initial/medial/final)", .str = "\u{0628}\u{0628}\u{0628}" },
+    .{ .name = "arabic beh isolated", .str = "\u{0628}" },
+    .{ .name = "arabic beh+meem", .str = "\u{0628}\u{0645}" },
+    .{ .name = "arabic lam-alef ligature", .str = "\u{0644}\u{0627}" },
+    .{ .name = "arabic tatweel", .str = "\u{0628}\u{0640}\u{0645}" },
+    .{ .name = "arabic fatha", .str = "\u{0628}\u{064E}" },
+    .{ .name = "arabic shadda+kasra", .str = "\u{0628}\u{0651}\u{0650}" },
+    // A mark on a cell other than the first. This is the only case that
+    // reaches the direction-dependent "first codepoint in cluster"
+    // search, because a multi-codepoint cluster at offset zero never
+    // triggers a cell reset.
+    .{ .name = "arabic mark on second letter", .str = "\u{0628}\u{0628}\u{064E}" },
+    .{ .name = "arabic marks on both letters", .str = "\u{0628}\u{064E}\u{0628}\u{0650}" },
+    .{ .name = "persian peh-cheh-jeh", .str = "\u{067E}\u{0686}\u{0698}" },
+    .{ .name = "persian gaf+farsi yeh", .str = "\u{06AF}\u{06CC}" },
+    .{ .name = "persian zwnj compound", .str = "\u{0645}\u{06CC}\u{200C}\u{0631}" },
+};
+
+fn rtlGoldenDump(
+    alloc: Allocator,
+    writer: *std.Io.Writer,
+) !void {
+    const io = std.testing.io;
+
+    try writer.writeAll(
+        \\# Golden shaping vectors for right-to-left runs.
+        \\#
+        \\# Generated from KawkabMono-Regular (src/font/res) via the
+        \\# "shape rtl: golden vectors" test. Regenerate by making that
+        \\# test print its dump rather than compare it.
+        \\#
+        \\# These lock in mark placement, which is where a regression in
+        \\# the cluster-to-cell mapping shows up as text that still looks
+        \\# plausible. "arabic shadda+kasra" is the most sensitive case:
+        \\# three glyphs on one cell, each with its own offset.
+        \\#
+        \\# Glyph ids are specific to this font. Changing the font
+        \\# invalidates the file.
+        \\
+        \\
+    );
+
+    var testdata = try testShaperWithFont(alloc, .arabic);
+    defer testdata.deinit();
+
+    for (rtl_golden_cases) |case| {
+        var t = try terminal.Terminal.init(io, alloc, .{ .cols = 20, .rows = 3 });
+        defer t.deinit(alloc);
+        var state: terminal.RenderState = .empty;
+        defer state.deinit(alloc);
+
+        const r = try testShapeRtl(alloc, &testdata, case.str, .rtl, &t, &state);
+
+        try writer.print("{s}\n  cells={d} glyphs={d}\n", .{
+            case.name,
+            r.run.cells,
+            r.cells.len,
+        });
+        for (r.cells) |c| {
+            try writer.print("  x={d} xoff={d} yoff={d} gid={d}\n", .{
+                c.x,
+                c.x_offset,
+                c.y_offset,
+                c.glyph_index,
+            });
+        }
+    }
+}
+
+test "shape rtl: golden vectors" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    // Regression vectors for right-to-left shaping. The relational tests
+    // above prove the behavior is right; these prove it stays that way.
+    // Mark placement in particular has no cheap invariant to assert, and
+    // a mispositioned tashkeel or niqqud is invisible to a reviewer who
+    // does not read the script, so the exact offsets are pinned here.
+    var buf: [16384]u8 = undefined;
+    var w: std.Io.Writer = .fixed(&buf);
+    try rtlGoldenDump(alloc, &w);
+
+    const expected = @embedFile("testdata/rtl_shaping.txt");
+    if (!std.mem.eql(u8, expected, w.buffered())) {
+        std.debug.print(
+            "\ngolden mismatch. actual output:\n{s}\n",
+            .{w.buffered()},
+        );
+        return error.TestExpectedEqual;
+    }
 }

--- a/src/font/shaper/harfbuzz.zig
+++ b/src/font/shaper/harfbuzz.zig
@@ -1636,7 +1636,7 @@ test "shape selection boundary" {
         var it = shaper.runIterator(.{
             .grid = testdata.grid,
             .cells = state.row_data.get(0).cells.slice(),
-            .selection = .{ 0, 9 },
+            .selection = .one(.{ .start = 0, .end = 9 }),
         });
         var count: usize = 0;
         while (try it.next(alloc)) |run| {
@@ -1653,7 +1653,7 @@ test "shape selection boundary" {
         var it = shaper.runIterator(.{
             .grid = testdata.grid,
             .cells = state.row_data.get(0).cells.slice(),
-            .selection = .{ 2, 9 },
+            .selection = .one(.{ .start = 2, .end = 9 }),
         });
         var count: usize = 0;
         while (try it.next(alloc)) |run| {
@@ -1670,7 +1670,7 @@ test "shape selection boundary" {
         var it = shaper.runIterator(.{
             .grid = testdata.grid,
             .cells = state.row_data.get(0).cells.slice(),
-            .selection = .{ 0, 3 },
+            .selection = .one(.{ .start = 0, .end = 3 }),
         });
         var count: usize = 0;
         while (try it.next(alloc)) |run| {
@@ -1687,7 +1687,7 @@ test "shape selection boundary" {
         var it = shaper.runIterator(.{
             .grid = testdata.grid,
             .cells = state.row_data.get(0).cells.slice(),
-            .selection = .{ 1, 3 },
+            .selection = .one(.{ .start = 1, .end = 3 }),
         });
         var count: usize = 0;
         while (try it.next(alloc)) |run| {
@@ -1704,7 +1704,7 @@ test "shape selection boundary" {
         var it = shaper.runIterator(.{
             .grid = testdata.grid,
             .cells = state.row_data.get(0).cells.slice(),
-            .selection = .{ 1, 1 },
+            .selection = .one(.{ .start = 1, .end = 1 }),
         });
         var count: usize = 0;
         while (try it.next(alloc)) |run| {

--- a/src/font/shaper/harfbuzz.zig
+++ b/src/font/shaper/harfbuzz.zig
@@ -4,6 +4,7 @@ const Allocator = std.mem.Allocator;
 const harfbuzz = @import("harfbuzz");
 const font = @import("../main.zig");
 const terminal = @import("../../terminal/main.zig");
+const bidi = @import("../../bidi/main.zig");
 const unicode = @import("../../unicode/main.zig");
 const Feature = font.shape.Feature;
 const FeatureList = font.shape.FeatureList;
@@ -2733,5 +2734,290 @@ test "shape: mirroring never reaches the screen" {
     const raw = row.items(.raw);
     for (str, 0..) |want, i| {
         try testing.expectEqual(@as(u21, want), raw[i].codepoint());
+    }
+}
+
+test "run: identity bidi map produces byte-identical runs" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    var testdata = try testShaper(alloc);
+    defer testdata.deinit();
+
+    // The acceptance gate for visual-order iteration. Walking visual
+    // columns through an identity map has to produce exactly what
+    // walking logical columns produced, run for run and field for
+    // field. Equal test counts are not enough: this compares the runs
+    // themselves, including the hash the shaper cache keys on.
+    inline for (.{
+        "hello world",
+        "abc def ghi jkl mno pqr",
+        "a\u{4E00}b\u{4E8C}c",
+        "\u{1F44D}\u{1F44D} ok",
+        "f\u{FE0F}i fl st >= != ->",
+        "",
+        " ",
+        "                    ",
+    }) |str| {
+        var t = try terminal.Terminal.init(io, alloc, .{ .cols = 32, .rows = 3 });
+        defer t.deinit(alloc);
+
+        var s = t.vtStream();
+        defer s.deinit();
+        s.nextSlice(str);
+
+        var state: terminal.RenderState = .empty;
+        defer state.deinit(alloc);
+        try state.update(alloc, &t);
+
+        const cells = state.row_data.get(0).cells.slice();
+
+        // An identity map: every visual column shows the logical column
+        // of the same index, and every level is zero.
+        var v2l: [32]u16 = undefined;
+        for (&v2l, 0..) |*v, i| v.* = @intCast(i);
+        const levels: [32]bidi.Level = @splat(0);
+
+        var shaper = &testdata.shaper;
+
+        // Collect the runs produced without any map.
+        var plain: [64]font.shape.TextRun = undefined;
+        var plain_len: usize = 0;
+        {
+            var it = shaper.runIterator(.{ .grid = testdata.grid, .cells = cells });
+            while (try it.next(alloc)) |run| {
+                plain[plain_len] = run;
+                plain_len += 1;
+            }
+        }
+
+        // And with the identity map, which takes the mapped code path.
+        var mapped: [64]font.shape.TextRun = undefined;
+        var mapped_len: usize = 0;
+        {
+            var it = shaper.runIterator(.{
+                .grid = testdata.grid,
+                .cells = cells,
+                .v2l = &v2l,
+                .levels = &levels,
+            });
+            while (try it.next(alloc)) |run| {
+                mapped[mapped_len] = run;
+                mapped_len += 1;
+            }
+        }
+
+        try testing.expectEqual(plain_len, mapped_len);
+        for (plain[0..plain_len], mapped[0..mapped_len]) |a, b| {
+            try testing.expectEqual(a.hash, b.hash);
+            try testing.expectEqual(a.offset, b.offset);
+            try testing.expectEqual(a.cells, b.cells);
+            try testing.expectEqual(a.direction, b.direction);
+            try testing.expectEqual(a.level, b.level);
+            try testing.expectEqual(a.font_index, b.font_index);
+        }
+    }
+}
+
+test "run: breaks on level change and keeps rtl runs maximal" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    var testdata = try testShaperWithFont(alloc, .arabic);
+    defer testdata.deinit();
+
+    var t = try terminal.Terminal.init(io, alloc, .{ .cols = 6, .rows = 3 });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+
+    // Three Latin letters then three Arabic ones. In a left-to-right
+    // paragraph the Arabic resolves to level 1 and is displayed
+    // reversed, so the visual order is a b c and then the Arabic
+    // backwards.
+    s.nextSlice("abc\u{0628}\u{0628}\u{0628}");
+
+    var state: terminal.RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &t);
+
+    const v2l = [_]u16{ 0, 1, 2, 5, 4, 3 };
+    const levels = [_]bidi.Level{ 0, 0, 0, 1, 1, 1 };
+
+    var shaper = &testdata.shaper;
+    var it = shaper.runIterator(.{
+        .grid = testdata.grid,
+        .cells = state.row_data.get(0).cells.slice(),
+        .v2l = &v2l,
+        .levels = &levels,
+    });
+
+    var runs: [8]font.shape.TextRun = undefined;
+    var len: usize = 0;
+    while (try it.next(alloc)) |run| {
+        runs[len] = run;
+        len += 1;
+    }
+
+    // The level change forces a break, so the row is at least two runs,
+    // and every run is at one level.
+    try testing.expect(len >= 2);
+
+    // Runs are emitted in visual order and tile the row without gaps.
+    var expect_offset: u16 = 0;
+    for (runs[0..len]) |run| {
+        try testing.expectEqual(expect_offset, run.offset);
+        expect_offset += run.cells;
+    }
+    try testing.expectEqual(@as(u16, 6), expect_offset);
+
+    // The Arabic is ONE run of three cells, not three runs of one. A run
+    // split per cell would pass every bidi test and still render Arabic
+    // unjoined, so this is the property worth pinning.
+    const last = runs[len - 1];
+    try testing.expectEqual(font.shape.Direction.rtl, last.direction);
+    try testing.expectEqual(@as(font.shape.Level, 1), last.level);
+    try testing.expectEqual(@as(u16, 3), last.cells);
+    try testing.expectEqual(@as(u16, 3), last.offset);
+
+    // And the first run is the left-to-right half.
+    try testing.expectEqual(font.shape.Direction.ltr, runs[0].direction);
+    try testing.expectEqual(@as(u16, 0), runs[0].offset);
+}
+
+test "run: rtl codepoints reach the shaper in logical order" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    var testdata = try testShaperWithFont(alloc, .arabic);
+    defer testdata.deinit();
+
+    var t = try terminal.Terminal.init(io, alloc, .{ .cols = 3, .rows = 3 });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+
+    // Beh, teh, meem: three different letters so their order is
+    // observable, unlike three of the same.
+    s.nextSlice("\u{0628}\u{062A}\u{0645}");
+
+    var state: terminal.RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &t);
+
+    // A fully right-to-left row: visual order is the reverse of logical.
+    const v2l = [_]u16{ 2, 1, 0 };
+    const levels = [_]bidi.Level{ 1, 1, 1 };
+
+    var shaper = &testdata.shaper;
+    var it = shaper.runIterator(.{
+        .grid = testdata.grid,
+        .cells = state.row_data.get(0).cells.slice(),
+        .v2l = &v2l,
+        .levels = &levels,
+    });
+
+    const run = (try it.next(alloc)).?;
+    try testing.expectEqual(font.shape.Direction.rtl, run.direction);
+    try testing.expectEqual(@as(u16, 3), run.cells);
+
+    // The run is walked in visual order but must be handed to HarfBuzz
+    // in logical order, because joining forms are decided from logical
+    // neighbours and HarfBuzz reverses the glyphs itself. Feeding it
+    // pre-reversed text produces the wrong contextual forms while still
+    // looking superficially plausible, so the order is asserted here
+    // rather than inferred from the rendered result.
+    const added = shaper.codepoints.items;
+    try testing.expectEqual(@as(usize, 3), added.len);
+    try testing.expectEqual(@as(u32, 0x0628), added[0].codepoint);
+    try testing.expectEqual(@as(u32, 0x062A), added[1].codepoint);
+    try testing.expectEqual(@as(u32, 0x0645), added[2].codepoint);
+
+    // Clusters are logical cell offsets within the run and ascend with
+    // the logical order.
+    try testing.expectEqual(@as(u32, 0), added[0].cluster);
+    try testing.expectEqual(@as(u32, 1), added[1].cluster);
+    try testing.expectEqual(@as(u32, 2), added[2].cluster);
+}
+
+test "run: clusters are relative to the run's logical start" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    var testdata = try testShaperWithFont(alloc, .arabic);
+    defer testdata.deinit();
+
+    var t = try terminal.Terminal.init(io, alloc, .{ .cols = 6, .rows = 3 });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+
+    // Latin then Arabic, in a right-to-left paragraph. Rule L2 reverses
+    // the whole row and then un-reverses the Latin, so the Arabic is
+    // displayed first and the Latin after it:
+    //
+    //   logical:  a  b  c  ب  ت  م      levels 2 2 2 1 1 1
+    //   visual:   م  ت  ب  a  b  c      v2l    5 4 3 0 1 2
+    //
+    // This is the arrangement where a run's visual offset and its lowest
+    // logical column differ, for both runs. Cluster values are offsets
+    // from the logical start, not from the visual one, and every other
+    // arrangement hides the difference because the two coincide.
+    s.nextSlice("abc\u{0628}\u{062A}\u{0645}");
+
+    var state: terminal.RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &t);
+
+    const v2l = [_]u16{ 5, 4, 3, 0, 1, 2 };
+    const levels = [_]bidi.Level{ 2, 2, 2, 1, 1, 1 };
+
+    var shaper = &testdata.shaper;
+    var it = shaper.runIterator(.{
+        .grid = testdata.grid,
+        .cells = state.row_data.get(0).cells.slice(),
+        .v2l = &v2l,
+        .levels = &levels,
+    });
+
+    // First run: the Arabic, right-to-left, at visual 0 but logical 3.
+    {
+        const run = (try it.next(alloc)).?;
+        try testing.expectEqual(font.shape.Direction.rtl, run.direction);
+        try testing.expectEqual(@as(u16, 0), run.offset);
+        try testing.expectEqual(@as(u16, 3), run.cells);
+
+        // Logical order, with clusters counted from the run's logical
+        // start of 3 rather than from its visual offset of 0.
+        const added = shaper.codepoints.items;
+        try testing.expectEqual(@as(usize, 3), added.len);
+        try testing.expectEqual(@as(u32, 0x0628), added[0].codepoint);
+        try testing.expectEqual(@as(u32, 0), added[0].cluster);
+        try testing.expectEqual(@as(u32, 0x062A), added[1].codepoint);
+        try testing.expectEqual(@as(u32, 1), added[1].cluster);
+        try testing.expectEqual(@as(u32, 0x0645), added[2].codepoint);
+        try testing.expectEqual(@as(u32, 2), added[2].cluster);
+    }
+
+    // Second run: the Latin, left-to-right, at visual 3 but logical 0.
+    {
+        const run = (try it.next(alloc)).?;
+        try testing.expectEqual(font.shape.Direction.ltr, run.direction);
+        try testing.expectEqual(@as(u16, 3), run.offset);
+        try testing.expectEqual(@as(u16, 3), run.cells);
+
+        const added = shaper.codepoints.items;
+        try testing.expectEqual(@as(usize, 3), added.len);
+        try testing.expectEqual(@as(u32, 'a'), added[0].codepoint);
+        try testing.expectEqual(@as(u32, 0), added[0].cluster);
+        try testing.expectEqual(@as(u32, 'c'), added[2].codepoint);
+        try testing.expectEqual(@as(u32, 2), added[2].cluster);
     }
 }

--- a/src/font/shaper/harfbuzz.zig
+++ b/src/font/shaper/harfbuzz.zig
@@ -5,6 +5,7 @@ const harfbuzz = @import("harfbuzz");
 const font = @import("../main.zig");
 const terminal = @import("../../terminal/main.zig");
 const bidi = @import("../../bidi/main.zig");
+const rendererbidi = @import("../../renderer/bidi.zig");
 const unicode = @import("../../unicode/main.zig");
 const Feature = font.shape.Feature;
 const FeatureList = font.shape.FeatureList;
@@ -3020,4 +3021,116 @@ test "run: clusters are relative to the run's logical start" {
         try testing.expectEqual(@as(u32, 'c'), added[2].codepoint);
         try testing.expectEqual(@as(u32, 2), added[2].cluster);
     }
+}
+
+test "end to end: arabic renders in visual order with joining" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    // Everything except the GPU: resolve a real row of Arabic through
+    // the bidi cache, iterate its runs in visual order, shape them, and
+    // check the glyphs come out where and how they should.
+    //
+    // The noop backend cannot reorder, so there is nothing to check.
+    if (comptime bidi.options.backend == .noop) return error.SkipZigTest;
+
+    var testdata = try testShaperWithFont(alloc, .arabic);
+    defer testdata.deinit();
+
+    var cache: rendererbidi.BidiCache = .init(alloc);
+    defer cache.deinit(alloc);
+
+    var t = try terminal.Terminal.init(io, alloc, .{ .cols = 8, .rows = 3 });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+
+    // "abc" then three Arabic letters. In a left-to-right paragraph the
+    // Latin stays put and the Arabic is displayed right to left after
+    // it.
+    s.nextSlice("abc\u{0628}\u{062A}\u{0645}");
+
+    var state: terminal.RenderState = .empty;
+    defer state.deinit(alloc);
+    try state.update(alloc, &t);
+
+    const cells = state.row_data.get(0).cells.slice();
+    const row_bidi = try cache.resolve(alloc, cells, 8, .{});
+
+    // The row contains right-to-left text, so it must have been
+    // reordered. If this fails the rest of the test proves nothing.
+    try testing.expect(!row_bidi.identity);
+    try testing.expectEqual(bidi.Direction.ltr, row_bidi.direction);
+
+    // Logical columns 3, 4, 5 hold the Arabic and must appear in the
+    // reverse order on screen.
+    try testing.expect(
+        row_bidi.visualCol(.from(3)).int() >
+            row_bidi.visualCol(.from(5)).int(),
+    );
+
+    // The Latin is untouched.
+    for (0..3) |i| {
+        try testing.expectEqual(i, row_bidi.visualCol(.from(@intCast(i))).int());
+    }
+
+    var shaper = &testdata.shaper;
+    var it = shaper.runIterator(.{
+        .grid = testdata.grid,
+        .cells = cells,
+        .v2l = row_bidi.v2l,
+        .levels = row_bidi.levels,
+    });
+
+    var total_cells: u16 = 0;
+    var expect_offset: u16 = 0;
+    var saw_rtl = false;
+    var arabic_glyphs: [8]u32 = undefined;
+    var arabic_len: usize = 0;
+
+    while (try it.next(alloc)) |run| {
+        // Runs tile the row in visual order without gaps or overlap,
+        // which is what the renderer's cell loop requires.
+        try testing.expectEqual(expect_offset, run.offset);
+        expect_offset += run.cells;
+        total_cells += run.cells;
+
+        const shaped = try shaper.shape(run);
+
+        // Shaped cell x always ascends. This is the invariant the
+        // renderer asserts while walking visual columns.
+        var x: u16 = 0;
+        for (shaped) |c| {
+            try testing.expect(c.x >= x);
+            try testing.expect(c.x < run.cells);
+            x = c.x;
+        }
+
+        if (run.direction == .rtl) {
+            saw_rtl = true;
+            try testing.expectEqual(@as(font.shape.Level, 1), run.level);
+            for (shaped) |c| {
+                arabic_glyphs[arabic_len] = c.glyph_index;
+                arabic_len += 1;
+            }
+        }
+    }
+
+    try testing.expect(saw_rtl);
+
+    // Six cells of content, not the eight columns of the grid: the
+    // trailing empty columns are trimmed, and "trailing" is visual, so
+    // trimming still works on a reordered row.
+    try testing.expectEqual(@as(u16, 6), total_cells);
+
+    // The Arabic is one run of three cells, so its letters are joined:
+    // three distinct contextual forms rather than three isolated ones.
+    // A pipeline that reordered correctly but split the run per cell
+    // would still fail here, which is the point.
+    try testing.expectEqual(@as(usize, 3), arabic_len);
+    try testing.expect(arabic_glyphs[0] != arabic_glyphs[1]);
+    try testing.expect(arabic_glyphs[1] != arabic_glyphs[2]);
+    try testing.expect(arabic_glyphs[0] != arabic_glyphs[2]);
 }

--- a/src/font/shaper/harfbuzz.zig
+++ b/src/font/shaper/harfbuzz.zig
@@ -3057,7 +3057,7 @@ test "end to end: arabic renders in visual order with joining" {
     try state.update(alloc, &t);
 
     const cells = state.row_data.get(0).cells.slice();
-    const row_bidi = try cache.resolve(alloc, cells, 8, .{});
+    const row_bidi = try cache.resolve(alloc, cells.items(.raw), 8, .{});
 
     // The row contains right-to-left text, so it must have been
     // reordered. If this fails the rest of the test proves nothing.

--- a/src/font/shaper/harfbuzz.zig
+++ b/src/font/shaper/harfbuzz.zig
@@ -2702,3 +2702,36 @@ test "shape rtl: golden vectors" {
         return error.TestExpectedEqual;
     }
 }
+
+test "shape: mirroring never reaches the screen" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    var testdata = try testShaper(alloc);
+    defer testdata.deinit();
+
+    var t = try terminal.Terminal.init(io, alloc, .{ .cols = 20, .rows = 3 });
+    defer t.deinit(alloc);
+    var state: terminal.RenderState = .empty;
+    defer state.deinit(alloc);
+
+    // Rule L4 substitutes a mirrored codepoint for display only. The
+    // screen must keep what the program actually wrote, because that is
+    // what gets copied to the clipboard and what the program will read
+    // back. A mirrored bracket landing in the buffer would be silent
+    // data corruption rather than a rendering glitch, so the invariant
+    // is asserted rather than assumed.
+    //
+    // Runs are still left-to-right at level zero, so no mirroring occurs
+    // yet; this pins the invariant for when that changes.
+    const str = "([{<>}])";
+    const r = try testShapeRtl(alloc, &testdata, str, .rtl, &t, &state);
+    try testing.expect(r.cells.len > 0);
+
+    const row = state.row_data.get(0).cells.slice();
+    const raw = row.items(.raw);
+    for (str, 0..) |want, i| {
+        try testing.expectEqual(@as(u21, want), raw[i].codepoint());
+    }
+}

--- a/src/font/shaper/run.zig
+++ b/src/font/shaper/run.zig
@@ -168,14 +168,10 @@ pub const RunIterator = struct {
             const cluster = j - self.i;
             const cell: *const terminal.page.Cell = &cells[j];
 
-            // If we have a selection and we're at a boundary point, then
-            // we break the run here.
-            if (self.opts.selection) |bounds| {
-                if (j > self.i) {
-                    if (bounds[0] > 0 and j == bounds[0]) break;
-                    if (bounds[1] > 0 and j == bounds[1] + 1) break;
-                }
-            }
+            // If we're at a selection boundary then we break the run
+            // here, so that a run is never partly selected.
+            if (j > self.i and
+                self.opts.selection.isBoundary(@intCast(j))) break;
 
             // If we're a spacer, then we ignore it
             switch (cell.wide) {

--- a/src/font/shaper/run.zig
+++ b/src/font/shaper/run.zig
@@ -36,6 +36,42 @@ pub const TextRun = struct {
 
     /// The font index to use for the glyphs of this run.
     font_index: font.Collection.Index,
+
+    /// The direction to shape this run in.
+    ///
+    /// Runs never span a change of direction, because rule L2 of UAX #9
+    /// reverses maximal ranges of equal embedding level, which makes such
+    /// a range contiguous in both logical and visual order. That is what
+    /// lets a shaper treat a run as a plain logical substring plus a
+    /// direction.
+    direction: shape.Direction = .ltr,
+
+    /// The resolved bidi embedding level of this run. Even levels are
+    /// left-to-right and odd levels right-to-left, so this always agrees
+    /// with `direction`; it is kept because later phases need the level
+    /// itself, not just its parity.
+    level: shape.Level = 0,
+
+    /// Fold a run's direction and embedding level into its content hash.
+    ///
+    /// This is a separate, separately tested function because of one
+    /// specific failure it exists to prevent. `shaper.Cache` keys purely
+    /// on `hash` and never compares the underlying run, so two runs over
+    /// identical codepoints shaped in opposite directions must not
+    /// produce the same hash. If they did, the cache would hand one run's
+    /// shaped cells to the other and the text would render backwards, but
+    /// only when the cache happened to be warm. That is the kind of
+    /// intermittent, ordering-dependent bug that survives to a release.
+    pub fn foldDirection(
+        content_hash: u64,
+        direction: shape.Direction,
+        level: shape.Level,
+    ) u64 {
+        var hasher = Hasher.init(content_hash);
+        autoHash(&hasher, direction);
+        autoHash(&hasher, level);
+        return hasher.final();
+    }
 };
 
 /// RunIterator is an iterator that yields text runs.
@@ -294,12 +330,22 @@ pub const RunIterator = struct {
         // Move our cursor. Must defer since we use self.i below.
         defer self.i = j;
 
+        // Runs are always left-to-right at level zero for now. Bidi
+        // resolution is not yet wired into the run iterator, so this is
+        // the only direction any run can have; the plumbing exists so
+        // that turning it on later is not also a cache-correctness
+        // change. See `foldDirection`.
+        const direction: shape.Direction = .ltr;
+        const level: shape.Level = 0;
+
         return .{
-            .hash = hasher.final(),
+            .hash = TextRun.foldDirection(hasher.final(), direction, level),
             .offset = @intCast(self.i),
             .cells = @intCast(j - self.i),
             .grid = self.opts.grid,
             .font_index = current_font,
+            .direction = direction,
+            .level = level,
         };
     }
 
@@ -406,4 +452,65 @@ fn comparableStyle(style: terminal.Style) terminal.Style {
     s.bg_color = .none;
 
     return s;
+}
+
+test "TextRun: direction and level are folded into the hash" {
+    const testing = std.testing;
+
+    // This is the test the whole phase exists for. `shaper.Cache` looks
+    // up shaped cells by `TextRun.hash` alone and never compares the run
+    // itself, so a run's direction and embedding level must reach the
+    // hash. If they do not, an RTL run over the same codepoints as an
+    // earlier LTR run gets that run's cells straight out of the cache and
+    // renders backwards.
+    const base: u64 = 0x1234_5678_9ABC_DEF0;
+
+    const ltr0 = TextRun.foldDirection(base, .ltr, 0);
+    const rtl1 = TextRun.foldDirection(base, .rtl, 1);
+    const ltr2 = TextRun.foldDirection(base, .ltr, 2);
+    const rtl3 = TextRun.foldDirection(base, .rtl, 3);
+
+    // Same content, opposite direction: must differ.
+    try testing.expect(ltr0 != rtl1);
+
+    // Same content and direction, different level: must also differ.
+    // Levels matter beyond their parity because a level change splits a
+    // run even when the direction is unchanged.
+    try testing.expect(ltr0 != ltr2);
+    try testing.expect(rtl1 != rtl3);
+
+    // All four distinct.
+    const all = [_]u64{ ltr0, rtl1, ltr2, rtl3 };
+    for (all, 0..) |a, i| {
+        for (all[i + 1 ..]) |b| try testing.expect(a != b);
+    }
+
+    // And the fold must be deterministic, or the cache would miss every
+    // time rather than hit wrongly.
+    try testing.expectEqual(ltr0, TextRun.foldDirection(base, .ltr, 0));
+
+    // Different content with the same direction must still differ.
+    try testing.expect(ltr0 != TextRun.foldDirection(base +% 1, .ltr, 0));
+}
+
+test "TextRun: adding direction and level did not change the layout class" {
+    const testing = std.testing;
+
+    // The run is copied around per frame and lives in a cache keyed by
+    // hash. Growing it, or worse changing its alignment, would be a
+    // silent per-frame cost. Both new fields fit in existing padding.
+    try testing.expectEqual(@as(usize, 8), @alignOf(TextRun));
+    try testing.expect(@sizeOf(TextRun) <= 24);
+
+    // The defaults keep the phase inert: anything that builds a run
+    // without mentioning bidi gets exactly the previous behavior.
+    const r: TextRun = .{
+        .hash = 0,
+        .offset = 0,
+        .cells = 0,
+        .grid = undefined,
+        .font_index = .{},
+    };
+    try testing.expectEqual(shape.Direction.ltr, r.direction);
+    try testing.expectEqual(@as(shape.Level, 0), r.level);
 }

--- a/src/font/shaper/run.zig
+++ b/src/font/shaper/run.zig
@@ -4,6 +4,7 @@ const Allocator = std.mem.Allocator;
 const font = @import("../main.zig");
 const shape = @import("../shape.zig");
 const terminal = @import("../../terminal/main.zig");
+const unicode = @import("../../unicode/main.zig");
 const autoHash = std.hash.autoHash;
 const Hasher = std.hash.Wyhash;
 
@@ -74,11 +75,42 @@ pub const TextRun = struct {
     }
 };
 
+/// Rule L4 of UAX #9: the codepoint to actually display for `cp` at
+/// embedding level `level`.
+///
+/// A character is depicted by a mirrored glyph when the resolved
+/// direction is right-to-left and it has Bidi_Mirrored set. Parentheses
+/// and brackets are the everyday case: an opening parenthesis in
+/// right-to-left text must be drawn as a closing one so that the pair
+/// still visually encloses what is between them.
+///
+/// Substituting the codepoint is the only mirroring available to us, so
+/// characters that are mirrored but have no designated mirroring glyph
+/// (U+2202 PARTIAL DIFFERENTIAL, for instance) are left alone and the
+/// font is relied on. This matches what the property tables can express.
+///
+/// Sprite glyphs need no exclusion here even though the RFC calls for
+/// one. No codepoint Ghostty draws itself, box drawing, blocks, braille,
+/// Powerline separators, or the legacy computing symbols, is mirrored;
+/// a test below asserts that and will fail if a future sprite range
+/// overlaps the mirrored set.
+pub fn mirroredCodepoint(cp: u32, level: shape.Level) u32 {
+    // Even levels are left-to-right, where L4 does not apply.
+    if (level & 1 == 0) return cp;
+    if (cp > std.math.maxInt(u21)) return cp;
+    return unicode.bidiMirroringGlyph(@intCast(cp)) orelse cp;
+}
+
 /// RunIterator is an iterator that yields text runs.
 pub const RunIterator = struct {
     hooks: font.Shaper.RunIteratorHook,
     opts: shape.RunOptions,
     i: usize = 0,
+
+    /// The resolved bidi embedding level of the run currently being
+    /// built, set at the start of each `next` call. Rule L4 consults it
+    /// to decide whether a character is displayed mirrored.
+    level: shape.Level = 0,
 
     pub fn next(self: *RunIterator, alloc: Allocator) !?TextRun {
         const slice = &self.opts.cells;
@@ -104,6 +136,15 @@ pub const RunIterator = struct {
 
         // We're over at the max
         if (self.i >= max) return null;
+
+        // Runs are always left-to-right at level zero for now. Bidi
+        // resolution is not yet wired into the run iterator, so this is
+        // the only direction any run can have. It is decided here rather
+        // than at the end because the codepoints emitted below depend on
+        // it: rule L4 mirrors certain characters at odd levels.
+        const direction: shape.Direction = .ltr;
+        const level: shape.Level = 0;
+        self.level = level;
 
         // Track the font for our current run
         var current_font: font.Collection.Index = .{};
@@ -330,14 +371,6 @@ pub const RunIterator = struct {
         // Move our cursor. Must defer since we use self.i below.
         defer self.i = j;
 
-        // Runs are always left-to-right at level zero for now. Bidi
-        // resolution is not yet wired into the run iterator, so this is
-        // the only direction any run can have; the plumbing exists so
-        // that turning it on later is not also a cache-correctness
-        // change. See `foldDirection`.
-        const direction: shape.Direction = .ltr;
-        const level: shape.Level = 0;
-
         return .{
             .hash = TextRun.foldDirection(hasher.final(), direction, level),
             .offset = @intCast(self.i),
@@ -350,9 +383,19 @@ pub const RunIterator = struct {
     }
 
     fn addCodepoint(self: *RunIterator, hasher: anytype, cp: u32, cluster: u32) !void {
-        autoHash(hasher, cp);
+        // Rule L4. Note the font for this cell was chosen from the
+        // original codepoint, not the mirrored one. In practice a font
+        // covering one half of a mirrored pair covers the other, and
+        // resolving the font from the original keeps run splitting
+        // independent of direction.
+        const display_cp = mirroredCodepoint(cp, self.level);
+
+        // The hash covers what is actually shaped, so a mirrored run and
+        // an unmirrored one over the same source text cannot collide in
+        // the shaper cache.
+        autoHash(hasher, display_cp);
         autoHash(hasher, cluster);
-        try self.hooks.addCodepoint(cp, cluster);
+        try self.hooks.addCodepoint(display_cp, cluster);
     }
 
     /// Find a font index that supports the grapheme for the given cell,
@@ -513,4 +556,90 @@ test "TextRun: adding direction and level did not change the layout class" {
     };
     try testing.expectEqual(shape.Direction.ltr, r.direction);
     try testing.expectEqual(@as(shape.Level, 0), r.level);
+}
+
+test "mirroredCodepoint: applies only at odd levels" {
+    const testing = std.testing;
+
+    // Rule L4 applies at right-to-left (odd) levels only.
+    try testing.expectEqual(@as(u32, ')'), mirroredCodepoint('(', 1));
+    try testing.expectEqual(@as(u32, '('), mirroredCodepoint(')', 1));
+    try testing.expectEqual(@as(u32, '>'), mirroredCodepoint('<', 1));
+    try testing.expectEqual(@as(u32, ']'), mirroredCodepoint('[', 1));
+    try testing.expectEqual(@as(u32, '}'), mirroredCodepoint('{', 1));
+
+    // Higher odd levels mirror too; higher even levels do not.
+    try testing.expectEqual(@as(u32, ')'), mirroredCodepoint('(', 3));
+    try testing.expectEqual(@as(u32, ')'), mirroredCodepoint('(', 125));
+    try testing.expectEqual(@as(u32, '('), mirroredCodepoint('(', 0));
+    try testing.expectEqual(@as(u32, '('), mirroredCodepoint('(', 2));
+    try testing.expectEqual(@as(u32, '('), mirroredCodepoint('(', 124));
+}
+
+test "mirroredCodepoint: leaves unmirrored characters alone" {
+    const testing = std.testing;
+
+    for ([_]u32{ 'a', 'Z', '0', ' ', '.', 0x05D0, 0x0627, 0x4E00, 0x1F600 }) |cp| {
+        try testing.expectEqual(cp, mirroredCodepoint(cp, 0));
+        try testing.expectEqual(cp, mirroredCodepoint(cp, 1));
+    }
+
+    // Mirrored but with no designated mirroring glyph. Bidi_Mirrored is a
+    // strict superset of Bidi_Mirroring_Glyph, and a codepoint
+    // substitution cannot express the difference, so these pass through.
+    try testing.expect(unicode.isBidiMirrored(0x2202));
+    try testing.expectEqual(@as(u32, 0x2202), mirroredCodepoint(0x2202, 1));
+
+    // Out of Unicode range values are returned untouched rather than
+    // being fed to the table lookup.
+    try testing.expectEqual(
+        @as(u32, std.math.maxInt(u32)),
+        mirroredCodepoint(std.math.maxInt(u32), 1),
+    );
+}
+
+test "mirroredCodepoint: is an involution at odd levels" {
+    const testing = std.testing;
+
+    // Mirroring twice returns the original. If this failed, text that
+    // crossed a direction boundary twice would not round trip.
+    for (0..std.math.maxInt(u21) + 1) |i| {
+        const cp: u32 = @intCast(i);
+        const m = mirroredCodepoint(cp, 1);
+        if (m == cp) continue;
+        try testing.expectEqual(cp, mirroredCodepoint(m, 1));
+    }
+}
+
+test "mirroredCodepoint: no sprite glyph is ever mirrored" {
+    const testing = std.testing;
+
+    // The RFC calls for excluding the glyphs Ghostty draws itself, box
+    // drawing, blocks, braille, Powerline separators and the legacy
+    // computing symbols, from mirroring. No such exclusion exists in
+    // `mirroredCodepoint`, because none is needed: not one of those
+    // codepoints has Bidi_Mirrored set.
+    //
+    // That is a fact about the Unicode data rather than about this code,
+    // so it is asserted rather than assumed. Adding a sprite range that
+    // overlaps the mirrored set will fail here, which is the point.
+    const face: font.SpriteFace = .{ .metrics = undefined };
+
+    var checked: usize = 0;
+    for (0..std.math.maxInt(u21) + 1) |i| {
+        const cp: u32 = @intCast(i);
+        if (mirroredCodepoint(cp, 1) == cp) continue;
+        checked += 1;
+
+        if (face.hasCodepoint(cp, null)) {
+            std.log.warn(
+                "codepoint U+{X} is both mirrored and drawn as a sprite",
+                .{cp},
+            );
+            try testing.expect(false);
+        }
+    }
+
+    // Guard against the loop above silently checking nothing.
+    try testing.expect(checked > 400);
 }

--- a/src/font/shaper/run.zig
+++ b/src/font/shaper/run.zig
@@ -112,17 +112,58 @@ pub const RunIterator = struct {
     /// to decide whether a character is displayed mirrored.
     level: shape.Level = 0,
 
+    /// Cells accepted into a right-to-left run, in the visual order they
+    /// were walked. See the note on emission order in `next`.
+    rtl_buf: [rtl_max]RtlCell = undefined,
+    rtl_len: usize = 0,
+
+    /// A right-to-left run longer than this is split. Runs already break
+    /// on style, font, cursor and selection boundaries, so reaching this
+    /// takes a very long stretch of uniform right-to-left text, and
+    /// splitting it is harmless. The bound exists so that the iterator
+    /// needs no owned allocation: it is created per row per frame and
+    /// never deinitialized.
+    const rtl_max = 256;
+
+    const RtlCell = struct {
+        /// Logical column of the cell.
+        col: u16,
+
+        /// A single codepoint to emit in place of the cell's own
+        /// contents, for a font fallback or a Kitty placeholder.
+        fallback: ?u32,
+    };
+
+    /// The logical column displayed at visual column `v`.
+    inline fn logicalCol(self: *const RunIterator, v: usize) usize {
+        const map = self.opts.v2l;
+        return if (map.len == 0) v else map[v];
+    }
+
+    /// The resolved embedding level of logical column `l`.
+    inline fn levelAt(self: *const RunIterator, l: usize) shape.Level {
+        const levels = self.opts.levels;
+        return if (levels.len == 0) 0 else levels[l];
+    }
+
     pub fn next(self: *RunIterator, alloc: Allocator) !?TextRun {
         const slice = &self.opts.cells;
         const cells: []const terminal.page.Cell = slice.items(.raw);
         const graphemes: []const []const u21 = slice.items(.grapheme);
         const styles: []const terminal.Style = slice.items(.style);
 
-        // Trim the right side of a row that might be empty
+        // The iterator walks VISUAL columns. Without a bidi map that is
+        // the same thing as walking logical columns, so everything below
+        // reduces exactly to what it did before bidi existed.
+        const cols: usize = if (self.opts.v2l.len > 0) self.opts.v2l.len else cells.len;
+
+        // Trim the right side of a row that might be empty. "Right" is
+        // visual, so an empty logical cell that was reordered into the
+        // middle of the row is not trimmed.
         const max: usize = max: {
-            for (0..cells.len) |i| {
-                const rev_i = cells.len - i - 1;
-                if (!cells[rev_i].isEmpty()) break :max rev_i + 1;
+            for (0..cols) |i| {
+                const rev_i = cols - i - 1;
+                if (!cells[self.logicalCol(rev_i)].isEmpty()) break :max rev_i + 1;
             }
 
             break :max 0;
@@ -130,21 +171,31 @@ pub const RunIterator = struct {
 
         // Invisible cells don't have any glyphs rendered,
         // so we explicitly skip them in the shaping process.
-        while (self.i < max and
-            (cells[self.i].hasStyling() and
-                styles[self.i].flags.invisible)) self.i += 1;
+        while (self.i < max) : (self.i += 1) {
+            const l = self.logicalCol(self.i);
+            if (!(cells[l].hasStyling() and styles[l].flags.invisible)) break;
+        }
 
         // We're over at the max
         if (self.i >= max) return null;
 
-        // Runs are always left-to-right at level zero for now. Bidi
-        // resolution is not yet wired into the run iterator, so this is
-        // the only direction any run can have. It is decided here rather
-        // than at the end because the codepoints emitted below depend on
-        // it: rule L4 mirrors certain characters at odd levels.
-        const direction: shape.Direction = .ltr;
-        const level: shape.Level = 0;
+        // The run takes the embedding level of its first cell and breaks
+        // when the level changes, which is what makes a run shapeable as
+        // one direction. It is decided here rather than at the end
+        // because the codepoints emitted below depend on it: rule L4
+        // mirrors certain characters at odd levels.
+        const start_logical = self.logicalCol(self.i);
+        const level: shape.Level = self.levelAt(start_logical);
+        const direction: shape.Direction = if (level & 1 == 0) .ltr else .rtl;
+        const rtl = direction == .rtl;
         self.level = level;
+        self.rtl_len = 0;
+
+        // The lowest logical column in the run, which cluster values are
+        // relative to. For a left-to-right run that is the first cell
+        // walked; for a right-to-left one the walk descends through
+        // logical columns, so it is only known once the run ends.
+        var logical_min: usize = start_logical;
 
         // Track the font for our current run
         var current_font: font.Collection.Index = .{};
@@ -156,20 +207,28 @@ pub const RunIterator = struct {
         var hasher = Hasher.init(0);
 
         // Let's get our style that we'll expect for the run.
-        const style: terminal.Style = if (cells[self.i].hasStyling()) styles[self.i] else .{};
+        const style: terminal.Style = if (cells[start_logical].hasStyling())
+            styles[start_logical]
+        else
+            .{};
 
         // Go through cell by cell and accumulate while we build our run.
+        // `v` is a visual column and `l` the logical column shown there.
         var j: usize = self.i;
         while (j < max) : (j += 1) {
-            // Use relative cluster positions (offset from run start) to make
-            // the shaping cache position-independent. This ensures that runs
-            // with identical content but different starting positions in the
-            // row produce the same hash, enabling cache reuse.
-            const cluster = j - self.i;
-            const cell: *const terminal.page.Cell = &cells[j];
+            const l = self.logicalCol(j);
+            const cell: *const terminal.page.Cell = &cells[l];
+
+            // Runs never span a change of embedding level. This is what
+            // keeps a run shapeable in one direction, and it is also
+            // what keeps runs maximal: everything else being equal, a
+            // stretch of one level stays one run, so Arabic keeps its
+            // cursive joining instead of being split per cell.
+            if (j > self.i and self.levelAt(l) != level) break;
 
             // If we're at a selection boundary then we break the run
-            // here, so that a run is never partly selected.
+            // here, so that a run is never partly selected. Selection
+            // segments are visual, so this compares against `v`.
             if (j > self.i and
                 self.opts.selection.isBoundary(@intCast(j))) break;
 
@@ -182,8 +241,14 @@ pub const RunIterator = struct {
             // If our cell attributes are changing, then we split the run.
             // This prevents a single glyph for ">=" to be rendered with
             // one color when the two components have different styling.
+            //
+            // The comparison is against the previous VISUAL cell. Rule L2
+            // reverses maximal ranges of equal level, so within a run the
+            // visual neighbour is also the logical neighbour, just on the
+            // other side for a right-to-left run. Either way it is the
+            // cell the glyphs would be shaped next to.
             if (j > self.i) style: {
-                const prev_cell = cells[j - 1];
+                const prev_cell = cells[self.logicalCol(j - 1)];
 
                 // If the prev cell and this cell are both plain
                 // codepoints then we check if they are commonly "bad"
@@ -215,7 +280,7 @@ pub const RunIterator = struct {
                 // The style is different. We allow differing background
                 // styles but any other change results in a new run.
                 const c1 = comparableStyle(style);
-                const c2 = comparableStyle(if (cell.hasStyling()) styles[j] else .{});
+                const c2 = comparableStyle(if (cell.hasStyling()) styles[l] else .{});
                 if (!c1.eql(c2)) break;
             }
 
@@ -235,7 +300,7 @@ pub const RunIterator = struct {
             const presentation: ?font.Presentation = if (cell.hasGrapheme()) p: {
                 // We only check the FIRST codepoint because I believe the
                 // presentation format must be directly adjacent to the codepoint.
-                const cps = graphemes[j];
+                const cps = graphemes[l];
                 assert(cps.len > 0);
                 if (cps[0] == 0xFE0E) break :p .text;
                 if (cps[0] == 0xFE0F) break :p .emoji;
@@ -294,7 +359,7 @@ pub const RunIterator = struct {
                 if (try self.indexForCell(
                     alloc,
                     cell,
-                    graphemes[j],
+                    graphemes[l],
                     font_style,
                     presentation,
                 )) |idx| break :font_info .{ .idx = idx };
@@ -327,31 +392,50 @@ pub const RunIterator = struct {
             // If our fonts are not equal, then we're done with our run.
             if (font_info.idx != current_font) break;
 
-            // If we're a fallback character, add that and continue; we
-            // don't want to add the entire grapheme.
-            if (font_info.fallback) |cp| {
-                try self.addCodepoint(&hasher, cp, @intCast(cluster));
-                continue;
-            }
-
-            // If we're a Kitty unicode placeholder then we add a blank.
-            if (cell.codepoint() == terminal.kitty.graphics.unicode.placeholder) {
-                try self.addCodepoint(&hasher, ' ', @intCast(cluster));
-                continue;
-            }
-
-            // Add all the codepoints for our grapheme
-            try self.addCodepoint(
-                &hasher,
-                if (cell.codepoint() == 0) ' ' else cell.codepoint(),
-                @intCast(cluster),
-            );
-            if (cell.hasGrapheme()) {
-                for (graphemes[j]) |cp| {
-                    // Do not send presentation modifiers
-                    if (cp == 0xFE0E or cp == 0xFE0F) continue;
-                    try self.addCodepoint(&hasher, cp, @intCast(cluster));
+            // A Kitty unicode placeholder is shaped as a blank.
+            const fallback: ?u32 = font_info.fallback orelse blank: {
+                if (cell.codepoint() == terminal.kitty.graphics.unicode.placeholder) {
+                    break :blank ' ';
                 }
+                break :blank null;
+            };
+
+            // A right-to-left run is walked in visual order but has to be
+            // handed to the shaper in logical order: shaping engines
+            // decide Arabic joining from logical neighbours and reverse
+            // the glyphs themselves. So its cells are collected here and
+            // emitted after the run ends, in reverse. A left-to-right run
+            // is already in logical order and is emitted as it is walked,
+            // which is exactly what happened before bidi existed.
+            if (rtl) {
+                if (self.rtl_len >= rtl_max) break;
+                self.rtl_buf[self.rtl_len] = .{
+                    .col = @intCast(l),
+                    .fallback = fallback,
+                };
+                self.rtl_len += 1;
+                logical_min = @min(logical_min, l);
+                continue;
+            }
+
+            try self.emitCell(&hasher, cells, graphemes, l, l - logical_min, fallback);
+        }
+
+        // Emit a right-to-left run's cells in logical order, which is the
+        // reverse of the visual order they were collected in.
+        if (rtl) {
+            var k: usize = self.rtl_len;
+            while (k > 0) {
+                k -= 1;
+                const entry = self.rtl_buf[k];
+                try self.emitCell(
+                    &hasher,
+                    cells,
+                    graphemes,
+                    entry.col,
+                    entry.col - logical_min,
+                    entry.fallback,
+                );
             }
         }
 
@@ -376,6 +460,39 @@ pub const RunIterator = struct {
             .direction = direction,
             .level = level,
         };
+    }
+
+    /// Emit the codepoints for one cell at the given cluster.
+    fn emitCell(
+        self: *RunIterator,
+        hasher: anytype,
+        cells: []const terminal.page.Cell,
+        graphemes: []const []const u21,
+        l: usize,
+        cluster: usize,
+        fallback: ?u32,
+    ) !void {
+        // A fallback replaces the cell's contents entirely; we don't want
+        // to add the rest of the grapheme behind it.
+        if (fallback) |cp| {
+            try self.addCodepoint(hasher, cp, @intCast(cluster));
+            return;
+        }
+
+        const cell = cells[l];
+        try self.addCodepoint(
+            hasher,
+            if (cell.codepoint() == 0) ' ' else cell.codepoint(),
+            @intCast(cluster),
+        );
+
+        if (cell.hasGrapheme()) {
+            for (graphemes[l]) |cp| {
+                // Do not send presentation modifiers
+                if (cp == 0xFE0E or cp == 0xFE0F) continue;
+                try self.addCodepoint(hasher, cp, @intCast(cluster));
+            }
+        }
     }
 
     fn addCodepoint(self: *RunIterator, hasher: anytype, cp: u32, cluster: u32) !void {

--- a/src/font/shaper/testdata/rtl_shaping.txt
+++ b/src/font/shaper/testdata/rtl_shaping.txt
@@ -1,0 +1,68 @@
+# Golden shaping vectors for right-to-left runs.
+#
+# Generated from KawkabMono-Regular (src/font/res) via the
+# "shape rtl: golden vectors" test. Regenerate by making that
+# test print its dump rather than compare it.
+#
+# These lock in mark placement, which is where a regression in
+# the cluster-to-cell mapping shows up as text that still looks
+# plausible. "arabic shadda+kasra" is the most sensitive case:
+# three glyphs on one cell, each with its own offset.
+#
+# Glyph ids are specific to this font. Changing the font
+# invalidates the file.
+
+arabic beh x3 (initial/medial/final)
+  cells=3 glyphs=3
+  x=0 xoff=0 yoff=0 gid=868
+  x=1 xoff=0 yoff=0 gid=869
+  x=2 xoff=0 yoff=0 gid=870
+arabic beh isolated
+  cells=1 glyphs=1
+  x=0 xoff=0 yoff=0 gid=867
+arabic beh+meem
+  cells=2 glyphs=2
+  x=0 xoff=0 yoff=0 gid=1004
+  x=1 xoff=0 yoff=0 gid=870
+arabic lam-alef ligature
+  cells=2 glyphs=1
+  x=1 xoff=0 yoff=0 gid=1064
+arabic tatweel
+  cells=3 glyphs=3
+  x=0 xoff=0 yoff=0 gid=1004
+  x=1 xoff=0 yoff=0 gid=1063
+  x=2 xoff=0 yoff=0 gid=870
+arabic fatha
+  cells=1 glyphs=2
+  x=0 xoff=0 yoff=1 gid=1734
+  x=0 xoff=0 yoff=0 gid=867
+arabic shadda+kasra
+  cells=1 glyphs=3
+  x=0 xoff=1 yoff=-4 gid=1736
+  x=0 xoff=0 yoff=1 gid=1737
+  x=0 xoff=0 yoff=0 gid=867
+arabic mark on second letter
+  cells=2 glyphs=3
+  x=0 xoff=0 yoff=0 gid=1734
+  x=0 xoff=0 yoff=0 gid=868
+  x=1 xoff=0 yoff=0 gid=870
+arabic marks on both letters
+  cells=2 glyphs=4
+  x=0 xoff=0 yoff=-4 gid=1736
+  x=0 xoff=0 yoff=0 gid=868
+  x=1 xoff=0 yoff=0 gid=1734
+  x=1 xoff=0 yoff=0 gid=870
+persian peh-cheh-jeh
+  cells=3 glyphs=3
+  x=0 xoff=0 yoff=0 gid=918
+  x=1 xoff=0 yoff=0 gid=893
+  x=2 xoff=0 yoff=0 gid=874
+persian gaf+farsi yeh
+  cells=2 glyphs=2
+  x=0 xoff=0 yoff=0 gid=1055
+  x=1 xoff=0 yoff=0 gid=992
+persian zwnj compound
+  cells=3 glyphs=3
+  x=0 xoff=0 yoff=0 gid=909
+  x=1 xoff=0 yoff=0 gid=1
+  x=2 xoff=0 yoff=0 gid=1003

--- a/src/font/sprite.zig
+++ b/src/font/sprite.zig
@@ -32,6 +32,7 @@ pub const Sprite = enum(u32) {
     cursor_rect,
     cursor_hollow_rect,
     cursor_bar,
+    cursor_bar_rtl,
     cursor_underline,
 
     test {

--- a/src/font/sprite/Face.zig
+++ b/src/font/sprite/Face.zig
@@ -666,3 +666,49 @@ test "full height cursor sprites respect cursor height metric" {
 test {
     std.testing.refAllDecls(@This());
 }
+
+test "rtl bar cursor renders and mirrors the ltr one" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var atlas: font.Atlas = try .init(alloc, 128, .grayscale);
+    defer atlas.deinit(alloc);
+
+    var face: Face = .{
+        .metrics = .calc(.{
+            .px_per_em = 16,
+            .cell_width = 8.0,
+            .ascent = 12.0,
+            .descent = -4.0,
+            .line_gap = 0.0,
+        }),
+    };
+
+    // The sprite exists and draws. Adding an enum value without a
+    // matching draw function silently yields a blank glyph, since the
+    // lookup returns null and the renderer substitutes an empty one, so
+    // this checks it actually produced something.
+    const rtl = try face.renderGlyph(
+        alloc,
+        &atlas,
+        @intFromEnum(Sprite.cursor_bar_rtl),
+        .{ .grid_metrics = face.metrics },
+    );
+    try testing.expect(rtl.width > 0);
+    try testing.expect(rtl.height > 0);
+
+    // It follows the same height rules as the left-to-right bar, since
+    // it is the same cursor drawn on the other edge.
+    const ltr = try face.renderGlyph(
+        alloc,
+        &atlas,
+        @intFromEnum(Sprite.cursor_bar),
+        .{ .grid_metrics = face.metrics },
+    );
+    try testing.expectEqual(ltr.height, rtl.height);
+    try testing.expectEqual(ltr.offset_y, rtl.offset_y);
+
+    // And it is a different shape: it carries the flag that says which
+    // way the text runs, so it must be wider than a plain bar.
+    try testing.expect(rtl.width > ltr.width);
+}

--- a/src/font/sprite/draw/special.zig
+++ b/src/font/sprite/draw/special.zig
@@ -345,6 +345,48 @@ pub fn cursor_bar(
     }, .on);
 }
 
+/// The bar cursor for a right-to-left position.
+///
+/// A bar cursor marks the gap where the next character will go. In
+/// right-to-left text that gap is on the other side of the cell, so the
+/// bar sits on the right edge, mirroring `cursor_bar`.
+///
+/// The short flag along the top points the way the text runs. Without
+/// some such mark, a bar between two characters at a direction boundary
+/// is ambiguous: it sits in the same place either way, and nothing tells
+/// you which run the next character will join.
+pub fn cursor_bar_rtl(
+    cp: u32,
+    canvas: *font.sprite.Canvas,
+    width: u32,
+    height: u32,
+    metrics: font.Metrics,
+) !void {
+    _ = cp;
+
+    const thickness: i32 = @intCast(metrics.cursor_thickness);
+    const right: i32 = @as(i32, @intCast(width)) - @divFloor(thickness + 1, 2);
+
+    // The bar itself, half its thickness over the right edge so that it
+    // sits centered between characters, as the left-to-right one does
+    // over the left edge.
+    canvas.rect(.{
+        .x = right,
+        .y = 0,
+        .width = @intCast(metrics.cursor_thickness),
+        .height = @intCast(height),
+    }, .on);
+
+    // The flag, pointing left along the top.
+    const flag_width: i32 = @max(thickness * 3, 3);
+    canvas.rect(.{
+        .x = right - flag_width,
+        .y = 0,
+        .width = @intCast(flag_width),
+        .height = @intCast(metrics.cursor_thickness),
+    }, .on);
+}
+
 pub fn cursor_underline(
     cp: u32,
     canvas: *font.sprite.Canvas,

--- a/src/input/mouse_encode.zig
+++ b/src/input/mouse_encode.zig
@@ -55,6 +55,25 @@ pub const Event = struct {
     /// The action of this mouse event.
     action: mouse.Action = .press,
 
+    /// The logical column to report, overriding the one derived from
+    /// `pos`.
+    ///
+    /// A pixel position gives the VISUAL column the pointer is over. A
+    /// program that turns on mouse tracking addresses the screen in
+    /// logical columns, the same space its own cursor movement uses, so
+    /// on a row displaying right-to-left text the two differ and
+    /// reporting the visual one makes every click land elsewhere.
+    ///
+    /// The caller resolves this, because doing so needs the screen and
+    /// this module deliberately has no access to it. Null means the two
+    /// spaces coincide, which is the case for any row without
+    /// right-to-left text and for every row when bidi is off.
+    ///
+    /// Note this does not affect the SGR-Pixels format, which reports
+    /// raw pixel coordinates by design and leaves the caller to
+    /// interpret them.
+    logical_x: ?u16 = null,
+
     /// The button involved in this event. This can be null in the
     /// case of a motion action with no pressed buttons.
     button: ?mouse.Button = null,
@@ -101,7 +120,11 @@ pub fn encode(
         if (!opts.any_button_pressed) return;
     }
 
-    const cell = posToCell(event.pos, opts.size);
+    const cell = cell: {
+        var c = posToCell(event.pos, opts.size);
+        if (event.logical_x) |x| c.x = x;
+        break :cell c;
+    };
 
     // We only send motion events when the cell changed unless
     // we're tracking raw pixels.
@@ -777,5 +800,105 @@ test "motion is deduped by last cell except sgr pixels" {
             .last_cell = &last,
         });
         try testing.expect(writer.buffered().len > 0);
+    }
+}
+
+test "logical column override replaces the derived column" {
+    // A click reported at the wrong column is the failure this exists to
+    // prevent: a program tracking the mouse would place its cursor on a
+    // different character than the one clicked, on every row containing
+    // right-to-left text.
+    var data: [32]u8 = undefined;
+
+    // Without an override the column comes from the pixel position.
+    {
+        var writer: std.Io.Writer = .fixed(&data);
+        try encode(&writer, .{
+            .button = .left,
+            .action = .press,
+            .pos = .{ .x = 4, .y = 5 },
+        }, .{
+            .event = .any,
+            .format = .sgr,
+            .size = testSize(),
+        });
+        try testing.expectEqualStrings("\x1B[<0;5;6M", writer.buffered());
+    }
+
+    // With one, the column is replaced and the row is untouched.
+    {
+        var writer: std.Io.Writer = .fixed(&data);
+        try encode(&writer, .{
+            .button = .left,
+            .action = .press,
+            .logical_x = 7,
+            .pos = .{ .x = 4, .y = 5 },
+        }, .{
+            .event = .any,
+            .format = .sgr,
+            .size = testSize(),
+        });
+        try testing.expectEqualStrings("\x1B[<0;8;6M", writer.buffered());
+    }
+}
+
+test "logical column override participates in motion deduplication" {
+    var data: [32]u8 = undefined;
+    var last: ?point.Coordinate = null;
+
+    // Two motions over the same pixel but different logical columns are
+    // different events and both must be reported. Deduplicating on the
+    // pixel-derived column would swallow the second, which on a
+    // reordered row is a real motion the program needs to see.
+    {
+        var writer: std.Io.Writer = .fixed(&data);
+        try encode(&writer, .{
+            .button = .left,
+            .action = .motion,
+            .logical_x = 3,
+            .pos = .{ .x = 4, .y = 5 },
+        }, .{
+            .event = .any,
+            .format = .sgr,
+            .size = testSize(),
+            .any_button_pressed = true,
+            .last_cell = &last,
+        });
+        try testing.expect(writer.buffered().len > 0);
+    }
+
+    {
+        var writer: std.Io.Writer = .fixed(&data);
+        try encode(&writer, .{
+            .button = .left,
+            .action = .motion,
+            .logical_x = 9,
+            .pos = .{ .x = 4, .y = 5 },
+        }, .{
+            .event = .any,
+            .format = .sgr,
+            .size = testSize(),
+            .any_button_pressed = true,
+            .last_cell = &last,
+        });
+        try testing.expect(writer.buffered().len > 0);
+    }
+
+    // And repeating the same logical column still deduplicates.
+    {
+        var writer: std.Io.Writer = .fixed(&data);
+        try encode(&writer, .{
+            .button = .left,
+            .action = .motion,
+            .logical_x = 9,
+            .pos = .{ .x = 4, .y = 5 },
+        }, .{
+            .event = .any,
+            .format = .sgr,
+            .size = testSize(),
+            .any_button_pressed = true,
+            .last_cell = &last,
+        });
+        try testing.expectEqual(@as(usize, 0), writer.buffered().len);
     }
 }

--- a/src/input/paste.zig
+++ b/src/input/paste.zig
@@ -133,6 +133,59 @@ pub fn isSafe(data: []const u8) bool {
         std.mem.indexOf(u8, data, "\x1b[201~") == null;
 }
 
+/// Whether the data contains a bidi directional override.
+///
+/// These are the characters behind CVE-2021-42574, "Trojan Source". An
+/// override forces the characters after it to display in the opposite
+/// direction, so the text on screen can be made to read completely
+/// differently from the bytes that a shell will execute. The classic
+/// shape is a filename whose extension appears harmless while the bytes
+/// say otherwise.
+///
+/// Ghostty was never affected before, because it did not reorder text at
+/// all. Enabling bidi is what makes these characters do something, which
+/// is exactly why this check arrives alongside it.
+///
+/// Only the two overrides are treated as suspicious. Embeddings and
+/// isolates also reorder, but they appear routinely in legitimate
+/// right-to-left text, and warning on those would train people to click
+/// through the warning. An override in a terminal paste has essentially
+/// no honest use.
+pub fn hasBidiOverride(data: []const u8) bool {
+    // U+202D LEFT-TO-RIGHT OVERRIDE and U+202E RIGHT-TO-LEFT OVERRIDE.
+    // Searching the UTF-8 bytes directly avoids decoding the paste, and
+    // these sequences cannot occur as a subsequence of any other valid
+    // encoding.
+    return std.mem.indexOf(u8, data, "\u{202D}") != null or
+        std.mem.indexOf(u8, data, "\u{202E}") != null;
+}
+
+test hasBidiOverride {
+    const testing = std.testing;
+
+    try testing.expect(!hasBidiOverride(""));
+    try testing.expect(!hasBidiOverride("rm -rf /tmp/file.txt"));
+
+    // Plain right-to-left text is not suspicious.
+    try testing.expect(!hasBidiOverride("\u{05D0}\u{05D1}\u{05D2}"));
+
+    // Neither are embeddings or isolates, which legitimate text uses.
+    try testing.expect(!hasBidiOverride("a\u{202A}b\u{202C}c"));
+    try testing.expect(!hasBidiOverride("a\u{2066}b\u{2069}c"));
+
+    // The overrides are, wherever they appear.
+    try testing.expect(hasBidiOverride("\u{202E}"));
+    try testing.expect(hasBidiOverride("\u{202D}"));
+    try testing.expect(hasBidiOverride("rm -rf /tmp/\u{202E}txt.exe"));
+    try testing.expect(hasBidiOverride("trailing\u{202E}"));
+
+    // A canonical Trojan Source line: what is displayed and what is
+    // executed differ.
+    try testing.expect(hasBidiOverride(
+        "if access_level != \"user\u{202E} \u{2066}// Check if admin\u{2069} \u{2066}\" {",
+    ));
+}
+
 test isSafe {
     const testing = std.testing;
     try testing.expect(isSafe("hello"));

--- a/src/main_ghostty.zig
+++ b/src/main_ghostty.zig
@@ -224,6 +224,7 @@ test {
     _ = @import("unicode/main.zig");
     _ = @import("unicode/props_uucode.zig");
     _ = @import("unicode/symbols_uucode.zig");
+    _ = @import("unicode/bidi_uucode.zig");
 
     // Extra
     _ = @import("extra/bash.zig");

--- a/src/main_ghostty.zig
+++ b/src/main_ghostty.zig
@@ -213,6 +213,7 @@ test {
     // Libraries
     _ = @import("tripwire.zig");
     _ = @import("benchmark/main.zig");
+    _ = @import("bidi/main.zig");
     _ = @import("crash/main.zig");
     _ = @import("datastruct/main.zig");
     _ = @import("inspector/main.zig");

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -12,6 +12,7 @@ const build_config = @import("build_config.zig");
 const cursor = @import("renderer/cursor.zig");
 const message = @import("renderer/message.zig");
 const size = @import("renderer/size.zig");
+pub const bidi = @import("renderer/bidi.zig");
 pub const shadertoy = @import("renderer/shadertoy.zig");
 pub const Backend = @import("renderer/backend.zig").Backend;
 pub const GenericRenderer = @import("renderer/generic.zig").Renderer;

--- a/src/renderer/bidi.zig
+++ b/src/renderer/bidi.zig
@@ -299,7 +299,7 @@ pub const BidiCache = struct {
     pub fn resolve(
         self: *BidiCache,
         alloc: Allocator,
-        cells: std.MultiArrayList(terminal.RenderState.Cell).Slice,
+        cells: []const terminal.page.Cell,
         cols: u16,
         opts: Options,
     ) Allocator.Error!RowBidi {
@@ -324,7 +324,7 @@ pub const BidiCache = struct {
     fn resolveUncached(
         self: *BidiCache,
         alloc: Allocator,
-        cells: std.MultiArrayList(terminal.RenderState.Cell).Slice,
+        cells: []const terminal.page.Cell,
         cols: u16,
         hash: u64,
         opts: Options,
@@ -353,15 +353,12 @@ pub const BidiCache = struct {
     fn buildElements(
         self: *BidiCache,
         alloc: Allocator,
-        cells: std.MultiArrayList(terminal.RenderState.Cell).Slice,
+        cells: []const terminal.page.Cell,
         cols: u16,
     ) Allocator.Error!void {
-        const raw = cells.items(.raw);
-        const graphemes = cells.items(.grapheme);
-
         var x: u16 = 0;
-        while (x < cols and x < raw.len) : (x += 1) {
-            const cell = raw[x];
+        while (x < cols and x < cells.len) : (x += 1) {
+            const cell = cells[x];
 
             // A spacer belongs to the cell before it and contributes no
             // element of its own; its width is accounted for there.
@@ -371,18 +368,13 @@ pub const BidiCache = struct {
             }
 
             // The base codepoint decides the character's bidi class.
-            // Combining marks in a grapheme are all Nonspacing_Mark and
-            // would resolve to the base's level anyway, so feeding only
-            // the base keeps one element per cell without changing the
-            // answer.
-            const cp: u21 = cp: {
-                if (cell.hasGrapheme()) {
-                    const cps = graphemes[x];
-                    if (cps.len > 0) break :cp cell.codepoint();
-                }
-                if (cell.isEmpty()) break :cp ' ';
-                break :cp cell.codepoint();
-            };
+            // Combining marks in a grapheme are all Nonspacing_Mark, and
+            // rule W1 gives those the type of the character before them,
+            // so they resolve to the base's level regardless. Feeding
+            // only the base keeps one element per cell without changing
+            // the answer, and means the whole adapter needs nothing but
+            // the raw cells.
+            const cp: u21 = if (cell.isEmpty()) ' ' else cell.codepoint();
 
             try self.scratch.codepoints.append(alloc, cp);
             try self.scratch.cols.append(alloc, x);
@@ -512,27 +504,24 @@ pub const BidiCache = struct {
 
 /// Hash a row's content for cache lookup.
 ///
-/// Only what bidi resolution actually depends on is hashed: the
-/// codepoints and the cell widths. Styles are deliberately excluded, so
-/// two rows with the same text in different colours share one entry.
+/// Only what bidi resolution actually depends on is hashed: the base
+/// codepoints and the cell widths. Styles are excluded, so two rows with
+/// the same text in different colours share an entry. Combining marks
+/// are excluded for the same reason they are excluded from resolution:
+/// they take the level of the character they attach to, so a row with
+/// and without them resolve identically.
 pub fn hashRow(
-    cells: std.MultiArrayList(terminal.RenderState.Cell).Slice,
+    cells: []const terminal.page.Cell,
     cols: u16,
 ) u64 {
     var hasher = std.hash.Wyhash.init(0);
-    const raw = cells.items(.raw);
-    const graphemes = cells.items(.grapheme);
-
     std.hash.autoHash(&hasher, cols);
 
     var x: u16 = 0;
-    while (x < cols and x < raw.len) : (x += 1) {
-        const cell = raw[x];
+    while (x < cols and x < cells.len) : (x += 1) {
+        const cell = cells[x];
         std.hash.autoHash(&hasher, cell.wide);
         std.hash.autoHash(&hasher, cell.codepoint());
-        if (cell.hasGrapheme()) {
-            for (graphemes[x]) |cp| std.hash.autoHash(&hasher, cp);
-        }
     }
 
     return hasher.final();
@@ -568,8 +557,8 @@ const TestRow = struct {
         self.t.deinit(alloc);
     }
 
-    fn cells(self: *TestRow) std.MultiArrayList(terminal.RenderState.Cell).Slice {
-        return self.state.row_data.get(0).cells.slice();
+    fn cells(self: *TestRow) []const terminal.page.Cell {
+        return self.state.row_data.get(0).cells.slice().items(.raw);
     }
 };
 

--- a/src/renderer/bidi.zig
+++ b/src/renderer/bidi.zig
@@ -26,6 +26,7 @@ const std = @import("std");
 const assert = std.debug.assert;
 const Allocator = std.mem.Allocator;
 const bidi = @import("../bidi/main.zig");
+const font = @import("../font/main.zig");
 const terminal = @import("../terminal/main.zig");
 const point = @import("../terminal/point.zig");
 
@@ -88,6 +89,46 @@ pub const RowBidi = struct {
         const i = l.int();
         assert(i < self.cols);
         return if (self.identity) 0 else self.levels[i];
+    }
+
+    /// Convert a logical column range into the visual ranges it covers.
+    ///
+    /// A selection is logically contiguous, but a logically contiguous
+    /// range is not visually contiguous when it spans a change of
+    /// direction: selecting across a boundary highlights two separate
+    /// stretches, which is what every text editor does and what readers
+    /// of right-to-left scripts expect. Snapping it back to one range
+    /// would be wrong, not tidier.
+    ///
+    /// Each level run is contiguous in both orders, so the range is
+    /// clipped against each run in turn and mapped through `l2v`. For a
+    /// right-to-left run the endpoints swap, since the logically first
+    /// column is displayed rightmost.
+    pub fn visualSegments(
+        self: *const RowBidi,
+        lo: u16,
+        hi: u16,
+    ) font.shape.SelectionSegments {
+        // Nothing was reordered, so the range is already visual.
+        if (self.identity) return .one(.{ .start = lo, .end = hi });
+
+        var out: font.shape.SelectionSegments = .empty;
+        for (self.runs) |run| {
+            const run_lo = run.logical_start;
+            const run_hi = run.logical_start + run.len - 1;
+
+            const clip_lo = @max(lo, run_lo);
+            const clip_hi = @min(hi, run_hi);
+            if (clip_lo > clip_hi) continue;
+
+            const a = self.l2v[clip_lo];
+            const b = self.l2v[clip_hi];
+            out.append(if (a <= b)
+                .{ .start = a, .end = b }
+            else
+                .{ .start = b, .end = a });
+        }
+        return out;
     }
 
     /// An identity result for a row that needs no reordering.
@@ -650,4 +691,213 @@ test "BidiCache: reordering keeps wide cells intact" {
         expect_start += run.len;
     }
     try testing.expectEqual(@as(usize, r.cols), covered);
+}
+
+/// A hand-built RowBidi for the arrangement:
+///
+///   logical:  a  b  c  A  B  C     levels 0 0 0 1 1 1
+///   visual:   a  b  c  C  B  A     v2l    0 1 2 5 4 3
+///
+/// which is Latin followed by right-to-left text in a left-to-right
+/// paragraph, the most common mixed case there is.
+fn testMixedRow() RowBidi {
+    const S = struct {
+        const v2l = [_]u16{ 0, 1, 2, 5, 4, 3 };
+        const l2v = [_]u16{ 0, 1, 2, 5, 4, 3 };
+        const levels = [_]bidi.Level{ 0, 0, 0, 1, 1, 1 };
+        const runs = [_]bidi.LevelRun{
+            .{ .visual_start = 0, .len = 3, .logical_start = 0, .level = 0 },
+            .{ .visual_start = 3, .len = 3, .logical_start = 3, .level = 1 },
+        };
+    };
+    return .{
+        .hash = 0,
+        .direction = .ltr,
+        .cols = 6,
+        .identity = false,
+        .v2l = &S.v2l,
+        .l2v = &S.l2v,
+        .levels = &S.levels,
+        .runs = &S.runs,
+    };
+}
+
+test "visualSegments: identity passes the range through" {
+    const r: RowBidi = .identityFor(10, &.{});
+    const segs = r.visualSegments(2, 5);
+    try testing.expectEqual(@as(usize, 1), segs.slice().len);
+    try testing.expectEqual(@as(u16, 2), segs.slice()[0].start);
+    try testing.expectEqual(@as(u16, 5), segs.slice()[0].end);
+}
+
+test "visualSegments: a right-to-left run swaps its endpoints" {
+    const r = testMixedRow();
+
+    // Selecting the whole right-to-left half. Logical 3..5 is displayed
+    // at visual 5..3, so the segment runs 3..5 with its ends swapped.
+    const segs = r.visualSegments(3, 5);
+    try testing.expectEqual(@as(usize, 1), segs.slice().len);
+    try testing.expectEqual(@as(u16, 3), segs.slice()[0].start);
+    try testing.expectEqual(@as(u16, 5), segs.slice()[0].end);
+
+    // A partial one: logical 3..4 is displayed at visual 5 and 4.
+    const partial = r.visualSegments(3, 4);
+    try testing.expectEqual(@as(usize, 1), partial.slice().len);
+    try testing.expectEqual(@as(u16, 4), partial.slice()[0].start);
+    try testing.expectEqual(@as(u16, 5), partial.slice()[0].end);
+}
+
+test "visualSegments: a selection across a direction change splits" {
+    const r = testMixedRow();
+
+    // Selecting logical c, A, B. On screen "c" sits at visual 2 while A
+    // and B sit at visual 5 and 4, so the highlight is two separate
+    // stretches with a gap at visual 3. That is what a text editor does
+    // and what a reader of the script expects; collapsing it into one
+    // range would highlight a character that is not selected.
+    const segs = r.visualSegments(2, 4);
+    try testing.expectEqual(@as(usize, 2), segs.slice().len);
+
+    try testing.expectEqual(@as(u16, 2), segs.slice()[0].start);
+    try testing.expectEqual(@as(u16, 2), segs.slice()[0].end);
+
+    try testing.expectEqual(@as(u16, 4), segs.slice()[1].start);
+    try testing.expectEqual(@as(u16, 5), segs.slice()[1].end);
+}
+
+test "visualSegments: covers every column when the whole row is selected" {
+    const r = testMixedRow();
+
+    const segs = r.visualSegments(0, 5);
+
+    var seen: [6]bool = @splat(false);
+    for (segs.slice()) |seg| {
+        var i = seg.start;
+        while (i <= seg.end) : (i += 1) seen[i] = true;
+    }
+    for (seen) |v| try testing.expect(v);
+}
+
+test "visualSegments: a range outside every run yields nothing" {
+    const r = testMixedRow();
+
+    // Selecting past the end of the row covers no run.
+    const segs = r.visualSegments(8, 9);
+    try testing.expectEqual(@as(usize, 0), segs.slice().len);
+}
+
+test "visualCol and logicalCol round trip on a mixed row" {
+    const r = testMixedRow();
+
+    for (0..r.cols) |i| {
+        const l: LogicalCol = .from(@intCast(i));
+        const v: VisualCol = .from(@intCast(i));
+        try testing.expectEqual(i, r.logicalCol(r.visualCol(l)).int());
+        try testing.expectEqual(i, r.visualCol(r.logicalCol(v)).int());
+    }
+
+    // The right-to-left half really is reversed.
+    try testing.expectEqual(@as(u16, 5), r.visualCol(.from(3)).int());
+    try testing.expectEqual(@as(u16, 3), r.visualCol(.from(5)).int());
+}
+
+test "identity mapping is a true no-op for every accessor" {
+    // The acceptance criterion for the renderer's coordinate mapping:
+    // with no reordering, every mapping has to be the identity, so the
+    // frame is built from exactly the same columns it was before any of
+    // this existed.
+    const r: RowBidi = .identityFor(80, &.{});
+
+    for (0..80) |i| {
+        const l: LogicalCol = .from(@intCast(i));
+        const v: VisualCol = .from(@intCast(i));
+        try testing.expectEqual(i, r.logicalCol(v).int());
+        try testing.expectEqual(i, r.visualCol(l).int());
+        try testing.expectEqual(@as(bidi.Level, 0), r.level(l));
+    }
+
+    // And a selection maps to itself, unsplit.
+    for ([_][2]u16{ .{ 0, 0 }, .{ 0, 79 }, .{ 13, 42 }, .{ 79, 79 } }) |range| {
+        const segs = r.visualSegments(range[0], range[1]);
+        try testing.expectEqual(@as(usize, 1), segs.slice().len);
+        try testing.expectEqual(range[0], segs.slice()[0].start);
+        try testing.expectEqual(range[1], segs.slice()[0].end);
+    }
+}
+
+test "a resolved ascii row maps identically" {
+    const alloc = testing.allocator;
+
+    // The same check but through the real path: resolve an actual row
+    // of plain text and confirm the result is the identity, so the
+    // renderer's mapped code path is a no-op on ordinary content
+    // whatever backend is compiled in.
+    var cache: BidiCache = .init(alloc);
+    defer cache.deinit(alloc);
+
+    var row = try TestRow.init(alloc, 20, "hello world 123");
+    defer row.deinit(alloc);
+
+    const r = try cache.resolve(alloc, row.cells(), 20);
+    try testing.expect(r.identity);
+
+    for (0..20) |i| {
+        const l: LogicalCol = .from(@intCast(i));
+        const v: VisualCol = .from(@intCast(i));
+        try testing.expectEqual(i, r.logicalCol(v).int());
+        try testing.expectEqual(i, r.visualCol(l).int());
+    }
+
+    const segs = r.visualSegments(3, 8);
+    try testing.expectEqual(@as(usize, 1), segs.slice().len);
+    try testing.expectEqual(@as(u16, 3), segs.slice()[0].start);
+    try testing.expectEqual(@as(u16, 8), segs.slice()[0].end);
+}
+
+test "wide cell: stepping back happens logically, not visually" {
+    // A cursor on the spacer tail of a wide character steps back one
+    // column to reach the character's head, and only then is mapped to
+    // where that character is drawn.
+    //
+    // Doing it the other way round would step back from a visual column
+    // into whatever sits to its left on screen, which after reordering
+    // need not be part of the same character at all. This test pins the
+    // arrangement that makes the difference observable.
+    //
+    //   logical:  A  B  |  W  W      A,B rtl; W a wide cell at level 0
+    //   visual:   B  A  |  W  W
+    const S = struct {
+        const v2l = [_]u16{ 1, 0, 2, 3 };
+        const l2v = [_]u16{ 1, 0, 2, 3 };
+        const levels = [_]bidi.Level{ 1, 1, 0, 0 };
+        const runs = [_]bidi.LevelRun{
+            .{ .visual_start = 0, .len = 2, .logical_start = 0, .level = 1 },
+            .{ .visual_start = 2, .len = 2, .logical_start = 2, .level = 0 },
+        };
+    };
+    const r: RowBidi = .{
+        .hash = 0,
+        .direction = .ltr,
+        .cols = 4,
+        .identity = false,
+        .v2l = &S.v2l,
+        .l2v = &S.l2v,
+        .levels = &S.levels,
+        .runs = &S.runs,
+    };
+
+    // The wide character's head is logical column 2, drawn at visual 2.
+    // A cursor sitting on its tail is at logical 3; stepping back
+    // logically gives 2, which maps to visual 2. Correct.
+    const head_logical: LogicalCol = .from(3 - 1);
+    try testing.expectEqual(@as(u16, 2), r.visualCol(head_logical).int());
+
+    // Had the order been reversed, the cursor at logical 3 would map to
+    // visual 3 and then step back to visual 2, which happens to agree
+    // here but does not in general. The case that separates them is a
+    // cursor at logical 0: it maps to visual 1, and stepping back from
+    // there lands on visual 0, which displays logical 1, a different
+    // character entirely.
+    try testing.expectEqual(@as(u16, 1), r.visualCol(.from(0)).int());
+    try testing.expectEqual(@as(u16, 1), r.logicalCol(.from(0)).int());
 }

--- a/src/renderer/bidi.zig
+++ b/src/renderer/bidi.zig
@@ -91,6 +91,51 @@ pub const RowBidi = struct {
         return if (self.identity) 0 else self.levels[i];
     }
 
+    /// The logical column a pointer at the given visual column is over.
+    ///
+    /// This is what mouse reporting has to send. A program that enables
+    /// mouse tracking addresses the screen in logical columns, the same
+    /// space its own cursor movement uses, so reporting the visual
+    /// column would make every click land somewhere else in any editor
+    /// showing right-to-left text.
+    pub inline fn hitTest(self: *const RowBidi, v: VisualCol) LogicalCol {
+        return self.logicalCol(v);
+    }
+
+    /// The logical position a selection anchored at this pointer should
+    /// start from.
+    ///
+    /// A click does not select a cell, it places a caret between two of
+    /// them, so which side of the cell the pointer is on decides which
+    /// gap is meant. For a left-to-right cell the right half means the
+    /// gap after it; for a right-to-left cell the halves are mirrored on
+    /// screen, so the LEFT half is the one that means "after" in logical
+    /// order.
+    ///
+    /// Without this, selecting a single right-to-left character by
+    /// dragging across it is fiddly in a way that feels broken rather
+    /// than merely imprecise.
+    pub fn selectionAnchor(
+        self: *const RowBidi,
+        v: VisualCol,
+        right_half: bool,
+    ) LogicalCol {
+        const l = self.logicalCol(v);
+        const rtl = self.level(l) & 1 == 1;
+
+        // The pointer is past the middle of the character in logical
+        // terms when it is on the trailing side of the cell, which is
+        // the right half going left to right and the left half going
+        // right to left.
+        const trailing = if (rtl) !right_half else right_half;
+        if (!trailing) return l;
+
+        // Clamp at the end of the row: there is no gap past the last
+        // column to anchor in.
+        const next = l.int() +| 1;
+        return .from(@min(next, self.cols));
+    }
+
     /// Convert a logical column range into the visual ranges it covers.
     ///
     /// A selection is logically contiguous, but a logically contiguous
@@ -1008,5 +1053,139 @@ test "forced rtl direction reorders a row with no strong characters" {
             const l: LogicalCol = .from(@intCast(i));
             try testing.expectEqual(i, r.logicalCol(r.visualCol(l)).int());
         }
+    }
+}
+
+test "selection: per-cell membership agrees with visual segments" {
+    // Two different mechanisms decide what a selection covers, and they
+    // have to agree or the highlight will not line up with the runs
+    // beneath it.
+    //
+    // The cell loop draws a background wherever the LOGICAL column it is
+    // displaying falls inside the selected range. The run iterator
+    // instead breaks runs at the edges of the VISUAL segments returned
+    // by visualSegments. If those disagreed, a run could be shaped as
+    // partly selected while a different set of cells was painted, and
+    // the boundary would land in the wrong place.
+    const r = testMixedRow();
+
+    var lo: u16 = 0;
+    while (lo < r.cols) : (lo += 1) {
+        var hi: u16 = lo;
+        while (hi < r.cols) : (hi += 1) {
+            // What the cell loop would paint: walk visual columns and
+            // test the logical column each one shows.
+            var painted: [8]bool = @splat(false);
+            var v: u16 = 0;
+            while (v < r.cols) : (v += 1) {
+                const l = r.logicalCol(.from(v)).int();
+                if (l >= lo and l <= hi) painted[v] = true;
+            }
+
+            // What the run iterator would break on.
+            var covered: [8]bool = @splat(false);
+            for (r.visualSegments(lo, hi).slice()) |seg| {
+                var i = seg.start;
+                while (i <= seg.end) : (i += 1) covered[i] = true;
+            }
+
+            try testing.expectEqualSlices(
+                bool,
+                painted[0..r.cols],
+                covered[0..r.cols],
+            );
+        }
+    }
+}
+
+test "selection: a range crossing a direction boundary is discontiguous" {
+    const r = testMixedRow();
+
+    // Logical c, A, B. On screen "c" is at visual 2 while A and B are at
+    // visual 5 and 4, leaving a gap at visual 3 that is not selected.
+    // The gap is correct: the character displayed there is logical 5,
+    // which is outside the range.
+    var painted: [6]bool = @splat(false);
+    for (r.visualSegments(2, 4).slice()) |seg| {
+        var i = seg.start;
+        while (i <= seg.end) : (i += 1) painted[i] = true;
+    }
+
+    try testing.expectEqualSlices(
+        bool,
+        &.{ false, false, true, false, true, true },
+        &painted,
+    );
+
+    // And the unselected gap really does display a column outside the
+    // range, rather than being an off-by-one.
+    const gap_logical = r.logicalCol(.from(3)).int();
+    try testing.expect(gap_logical < 2 or gap_logical > 4);
+}
+
+test "hitTest: reports the logical column under the pointer" {
+    const r = testMixedRow();
+
+    // The Latin half is untouched.
+    for (0..3) |i| {
+        try testing.expectEqual(i, r.hitTest(.from(@intCast(i))).int());
+    }
+
+    // The right-to-left half is reversed on screen, so clicking the
+    // leftmost of those three cells is a click on the LAST of them in
+    // logical order. A program tracking the mouse addresses columns
+    // logically, so this is the number it has to receive.
+    try testing.expectEqual(@as(u16, 5), r.hitTest(.from(3)).int());
+    try testing.expectEqual(@as(u16, 4), r.hitTest(.from(4)).int());
+    try testing.expectEqual(@as(u16, 3), r.hitTest(.from(5)).int());
+}
+
+test "hitTest: identity rows report the column itself" {
+    const r: RowBidi = .identityFor(40, &.{});
+    for (0..40) |i| {
+        try testing.expectEqual(i, r.hitTest(.from(@intCast(i))).int());
+    }
+}
+
+test "selectionAnchor: which half means after depends on direction" {
+    const r = testMixedRow();
+
+    // Left to right: the left half anchors before the cell, the right
+    // half after it.
+    try testing.expectEqual(@as(u16, 1), r.selectionAnchor(.from(1), false).int());
+    try testing.expectEqual(@as(u16, 2), r.selectionAnchor(.from(1), true).int());
+
+    // Right to left: the halves are mirrored on screen, so it is the
+    // LEFT half that means "after" in logical order. Visual column 4
+    // shows logical column 4; its left half anchors at logical 5.
+    try testing.expectEqual(@as(u16, 4), r.selectionAnchor(.from(4), true).int());
+    try testing.expectEqual(@as(u16, 5), r.selectionAnchor(.from(4), false).int());
+}
+
+test "selectionAnchor: clamps at the end of the row" {
+    const r = testMixedRow();
+
+    // The trailing side of the logically last column has no gap after
+    // it to anchor in, so it clamps rather than running past the row.
+    const last = r.selectionAnchor(.from(3), false);
+    try testing.expect(last.int() <= r.cols);
+
+    const identity: RowBidi = .identityFor(4, &.{});
+    try testing.expectEqual(
+        @as(u16, 4),
+        identity.selectionAnchor(.from(3), true).int(),
+    );
+}
+
+test "selectionAnchor: identity rows behave as they always did" {
+    const r: RowBidi = .identityFor(10, &.{});
+
+    // With no reordering every cell is left to right, so the left half
+    // anchors on the cell and the right half after it, which is what
+    // the gesture code has always assumed.
+    for (0..10) |i| {
+        const v: VisualCol = .from(@intCast(i));
+        try testing.expectEqual(i, r.selectionAnchor(v, false).int());
+        try testing.expectEqual(i + 1, r.selectionAnchor(v, true).int());
     }
 }

--- a/src/renderer/bidi.zig
+++ b/src/renderer/bidi.zig
@@ -1,0 +1,653 @@
+//! Per-row bidi resolution results and the cache that holds them.
+//!
+//! This is the layer between `src/bidi`, which knows nothing about
+//! terminals, and the renderer, which thinks in grid columns. It does two
+//! things: adapt a row of cells into the flat codepoint array the resolver
+//! wants, and expand the resolver's per-element answer back out into
+//! per-column maps.
+//!
+//! ## Elements are not columns
+//!
+//! A double-width cell occupies two columns but is one character. Feeding
+//! the resolver one entry per column would let rule L2 reverse a wide
+//! cell's two halves against each other, putting the spacer before the
+//! head. So the resolver sees one element per *cell*, and the permutation
+//! it returns is expanded back to columns afterwards, keeping the columns
+//! within a cell in order.
+//!
+//! ## Nothing here is consumed yet
+//!
+//! The renderer populates this cache but still renders from logical
+//! order. Wiring it into run iteration is a separate change, which means
+//! the adapter and the cache lifecycle can be reviewed and measured on
+//! their own.
+
+const std = @import("std");
+const assert = std.debug.assert;
+const Allocator = std.mem.Allocator;
+const bidi = @import("../bidi/main.zig");
+const terminal = @import("../terminal/main.zig");
+const point = @import("../terminal/point.zig");
+
+const LogicalCol = point.LogicalCol;
+const VisualCol = point.VisualCol;
+
+const log = std.log.scoped(.renderer_bidi);
+
+/// The resolved bidi state for a single row, in grid columns.
+///
+/// All slices are column-indexed and `cols` long, except `runs`. They are
+/// owned by the `BidiCache` that produced this value and live until that
+/// cache is reset.
+pub const RowBidi = struct {
+    /// Content hash of the row this was resolved from.
+    hash: u64,
+
+    /// The resolved paragraph direction.
+    direction: bidi.Direction,
+
+    /// The number of columns covered.
+    cols: u16,
+
+    /// True when visual order equals logical order.
+    ///
+    /// The maps below are empty in that case rather than holding a
+    /// trivial 0..n mapping. A row of plain left-to-right text is the
+    /// overwhelmingly common case and it costs no allocation at all.
+    identity: bool,
+
+    /// Visual column to logical column. Empty when `identity`.
+    v2l: []const u16,
+
+    /// Logical column to visual column. Empty when `identity`.
+    l2v: []const u16,
+
+    /// Resolved embedding level per logical column. Empty when
+    /// `identity`.
+    levels: []const bidi.Level,
+
+    /// Level runs in visual order, in columns. Always populated.
+    runs: []const bidi.LevelRun,
+
+    /// The logical column displayed at the given visual column.
+    pub inline fn logicalCol(self: *const RowBidi, v: VisualCol) LogicalCol {
+        const i = v.int();
+        assert(i < self.cols);
+        return .from(if (self.identity) i else self.v2l[i]);
+    }
+
+    /// The visual column at which the given logical column is displayed.
+    pub inline fn visualCol(self: *const RowBidi, l: LogicalCol) VisualCol {
+        const i = l.int();
+        assert(i < self.cols);
+        return .from(if (self.identity) i else self.l2v[i]);
+    }
+
+    /// The resolved embedding level of the given logical column.
+    pub inline fn level(self: *const RowBidi, l: LogicalCol) bidi.Level {
+        const i = l.int();
+        assert(i < self.cols);
+        return if (self.identity) 0 else self.levels[i];
+    }
+
+    /// An identity result for a row that needs no reordering.
+    pub fn identityFor(cols: u16, runs: []const bidi.LevelRun) RowBidi {
+        return .{
+            .hash = 0,
+            .direction = .ltr,
+            .cols = cols,
+            .identity = true,
+            .v2l = &.{},
+            .l2v = &.{},
+            .levels = &.{},
+            .runs = runs,
+        };
+    }
+};
+
+/// A cache of resolved rows, keyed by row content.
+///
+/// Keying on content rather than on row position means a stale entry is
+/// never *wrong*, only wasteful, and that a row keeps its entry when the
+/// screen scrolls. Identical rows share one entry.
+pub const BidiCache = struct {
+    /// Hash to resolved row.
+    entries: std.AutoHashMapUnmanaged(u64, RowBidi) = .empty,
+
+    /// Backing storage for the column maps. Freed all at once on reset
+    /// rather than per entry, since entries are never removed
+    /// individually.
+    arena: std.heap.ArenaAllocator,
+
+    /// Bumped on every reset. Only used for logging and tests; the map
+    /// and arena are cleared outright.
+    generation: u32 = 0,
+
+    /// Scratch buffers reused across resolves so that a steady state
+    /// costs no allocation beyond new cache entries.
+    scratch: Scratch = .{},
+
+    /// The bidi resolver. Owned here so its internal buffers stay warm.
+    resolver: bidi.Resolver = .empty,
+
+    /// The most entries we hold before dropping everything and starting
+    /// over. A terminal screen is at most a few hundred rows and many
+    /// repeat, so this is generous; the point is only to stop unbounded
+    /// growth over a long session.
+    pub const max_entries: u32 = 1024;
+
+    const Scratch = struct {
+        /// One codepoint per non-spacer cell, in logical order.
+        codepoints: std.ArrayList(u21) = .empty,
+
+        /// The logical column each element starts at.
+        cols: std.ArrayList(u16) = .empty,
+
+        /// The column width of each element.
+        widths: std.ArrayList(u8) = .empty,
+
+        fn deinit(self: *Scratch, alloc: Allocator) void {
+            self.codepoints.deinit(alloc);
+            self.cols.deinit(alloc);
+            self.widths.deinit(alloc);
+        }
+
+        fn clear(self: *Scratch) void {
+            self.codepoints.clearRetainingCapacity();
+            self.cols.clearRetainingCapacity();
+            self.widths.clearRetainingCapacity();
+        }
+    };
+
+    pub fn init(alloc: Allocator) BidiCache {
+        return .{ .arena = .init(alloc) };
+    }
+
+    pub fn deinit(self: *BidiCache, alloc: Allocator) void {
+        self.entries.deinit(alloc);
+        self.scratch.deinit(alloc);
+        self.resolver.deinit(alloc);
+        self.arena.deinit();
+        self.* = undefined;
+    }
+
+    /// Drop every entry and release their storage.
+    ///
+    /// Called when something invalidates the whole cache: a resize, a
+    /// font change, or a config reload that touches bidi. Entries keyed
+    /// by content would survive those correctly, but the memory would
+    /// not be worth keeping for rows that no longer exist.
+    pub fn reset(self: *BidiCache) void {
+        self.entries.clearRetainingCapacity();
+        _ = self.arena.reset(.retain_capacity);
+        self.generation +%= 1;
+    }
+
+    /// Resolve a row, returning a cached entry when the content matches
+    /// one already held.
+    ///
+    /// The returned pointer is valid until the next `reset`. It is
+    /// invalidated by further `resolve` calls only if they cause the
+    /// entry map to grow, so callers should not hold it across rows.
+    pub fn resolve(
+        self: *BidiCache,
+        alloc: Allocator,
+        cells: std.MultiArrayList(terminal.RenderState.Cell).Slice,
+        cols: u16,
+    ) Allocator.Error!RowBidi {
+        const hash = hashRow(cells, cols);
+        if (self.entries.get(hash)) |cached| return cached;
+
+        // Dropping everything at the bound is crude but correct, and it
+        // keeps entry storage in one arena rather than needing per-entry
+        // frees. Rows are re-resolved on the next frame that draws them.
+        if (self.entries.count() >= max_entries) {
+            log.debug("bidi cache full, resetting generation={}", .{self.generation});
+            self.reset();
+        }
+
+        const row = try self.resolveUncached(alloc, cells, cols, hash);
+        try self.entries.put(alloc, hash, row);
+        return row;
+    }
+
+    fn resolveUncached(
+        self: *BidiCache,
+        alloc: Allocator,
+        cells: std.MultiArrayList(terminal.RenderState.Cell).Slice,
+        cols: u16,
+        hash: u64,
+    ) Allocator.Error!RowBidi {
+        self.scratch.clear();
+        try self.buildElements(alloc, cells, cols);
+
+        const result = try self.resolver.resolve(
+            alloc,
+            self.scratch.codepoints.items,
+            .{},
+        );
+
+        // The common case: nothing to reorder, so nothing is stored.
+        if (result.identity) {
+            var row: RowBidi = .identityFor(cols, &.{});
+            row.hash = hash;
+            row.runs = try self.storeIdentityRun(cols);
+            return row;
+        }
+
+        return try self.expand(result, cols, hash);
+    }
+
+    /// Collect one element per non-spacer cell.
+    fn buildElements(
+        self: *BidiCache,
+        alloc: Allocator,
+        cells: std.MultiArrayList(terminal.RenderState.Cell).Slice,
+        cols: u16,
+    ) Allocator.Error!void {
+        const raw = cells.items(.raw);
+        const graphemes = cells.items(.grapheme);
+
+        var x: u16 = 0;
+        while (x < cols and x < raw.len) : (x += 1) {
+            const cell = raw[x];
+
+            // A spacer belongs to the cell before it and contributes no
+            // element of its own; its width is accounted for there.
+            switch (cell.wide) {
+                .spacer_head, .spacer_tail => continue,
+                .narrow, .wide => {},
+            }
+
+            // The base codepoint decides the character's bidi class.
+            // Combining marks in a grapheme are all Nonspacing_Mark and
+            // would resolve to the base's level anyway, so feeding only
+            // the base keeps one element per cell without changing the
+            // answer.
+            const cp: u21 = cp: {
+                if (cell.hasGrapheme()) {
+                    const cps = graphemes[x];
+                    if (cps.len > 0) break :cp cell.codepoint();
+                }
+                if (cell.isEmpty()) break :cp ' ';
+                break :cp cell.codepoint();
+            };
+
+            try self.scratch.codepoints.append(alloc, cp);
+            try self.scratch.cols.append(alloc, x);
+            try self.scratch.widths.append(alloc, if (cell.wide == .wide) 2 else 1);
+        }
+
+        // Widen the last element to cover any trailing spacer so the
+        // widths sum to the column count.
+        if (self.scratch.widths.items.len > 0) {
+            const last = self.scratch.widths.items.len - 1;
+            const start = self.scratch.cols.items[last];
+            const covered = start + self.scratch.widths.items[last];
+            if (covered < cols) {
+                self.scratch.widths.items[last] = @intCast(cols - start);
+            }
+        }
+    }
+
+    /// Expand a per-element result into per-column maps.
+    fn expand(
+        self: *BidiCache,
+        result: bidi.Result,
+        cols: u16,
+        hash: u64,
+    ) Allocator.Error!RowBidi {
+        const arena = self.arena.allocator();
+
+        const v2l = try arena.alloc(u16, cols);
+        const l2v = try arena.alloc(u16, cols);
+        const levels = try arena.alloc(bidi.Level, cols);
+
+        const starts = self.scratch.cols.items;
+        const widths = self.scratch.widths.items;
+
+        // Walk the elements in visual order, laying each one's columns
+        // down left to right. The columns within one element keep their
+        // order, which is what stops a wide cell's halves from swapping.
+        var runs: std.ArrayList(bidi.LevelRun) = .empty;
+        errdefer runs.deinit(arena);
+
+        var vis: u16 = 0;
+        var run_start: u16 = 0;
+        var run_level: ?bidi.Level = null;
+        var run_log_min: u16 = 0;
+
+        for (0..result.len) |v| {
+            const l = result.logicalIndex(v);
+            const lvl = result.level(l);
+            const start = starts[l];
+            const width = widths[l];
+
+            if (run_level) |cur| {
+                if (cur != lvl) {
+                    try runs.append(arena, .{
+                        .visual_start = run_start,
+                        .len = vis - run_start,
+                        .logical_start = run_log_min,
+                        .level = cur,
+                    });
+                    run_start = vis;
+                    run_level = lvl;
+                    run_log_min = start;
+                }
+            } else {
+                run_level = lvl;
+                run_start = vis;
+                run_log_min = start;
+            }
+            run_log_min = @min(run_log_min, start);
+
+            for (0..width) |k| {
+                const lc: u16 = start + @as(u16, @intCast(k));
+                const vc: u16 = vis + @as(u16, @intCast(k));
+                assert(lc < cols);
+                assert(vc < cols);
+                v2l[vc] = lc;
+                l2v[lc] = vc;
+                levels[lc] = lvl;
+            }
+
+            vis += width;
+        }
+
+        if (run_level) |cur| try runs.append(arena, .{
+            .visual_start = run_start,
+            .len = vis - run_start,
+            .logical_start = run_log_min,
+            .level = cur,
+        });
+
+        // Any columns the elements did not cover (a row shorter than the
+        // grid) map to themselves at the paragraph level.
+        while (vis < cols) : (vis += 1) {
+            v2l[vis] = vis;
+            l2v[vis] = vis;
+            levels[vis] = 0;
+        }
+
+        return .{
+            .hash = hash,
+            .direction = result.direction,
+            .cols = cols,
+            .identity = false,
+            .v2l = v2l,
+            .l2v = l2v,
+            .levels = levels,
+            .runs = try runs.toOwnedSlice(arena),
+        };
+    }
+
+    fn storeIdentityRun(
+        self: *BidiCache,
+        cols: u16,
+    ) Allocator.Error![]const bidi.LevelRun {
+        if (cols == 0) return &.{};
+        const arena = self.arena.allocator();
+        const runs = try arena.alloc(bidi.LevelRun, 1);
+        runs[0] = .{
+            .visual_start = 0,
+            .len = cols,
+            .logical_start = 0,
+            .level = 0,
+        };
+        return runs;
+    }
+};
+
+/// Hash a row's content for cache lookup.
+///
+/// Only what bidi resolution actually depends on is hashed: the
+/// codepoints and the cell widths. Styles are deliberately excluded, so
+/// two rows with the same text in different colours share one entry.
+pub fn hashRow(
+    cells: std.MultiArrayList(terminal.RenderState.Cell).Slice,
+    cols: u16,
+) u64 {
+    var hasher = std.hash.Wyhash.init(0);
+    const raw = cells.items(.raw);
+    const graphemes = cells.items(.grapheme);
+
+    std.hash.autoHash(&hasher, cols);
+
+    var x: u16 = 0;
+    while (x < cols and x < raw.len) : (x += 1) {
+        const cell = raw[x];
+        std.hash.autoHash(&hasher, cell.wide);
+        std.hash.autoHash(&hasher, cell.codepoint());
+        if (cell.hasGrapheme()) {
+            for (graphemes[x]) |cp| std.hash.autoHash(&hasher, cp);
+        }
+    }
+
+    return hasher.final();
+}
+
+const testing = std.testing;
+
+/// Build a RenderState for a single row of the given text.
+const TestRow = struct {
+    t: terminal.Terminal,
+    state: terminal.RenderState,
+
+    fn init(alloc: Allocator, cols: u16, str: []const u8) !TestRow {
+        var t = try terminal.Terminal.init(testing.io, alloc, .{
+            .cols = cols,
+            .rows = 3,
+        });
+        errdefer t.deinit(alloc);
+
+        var s = t.vtStream();
+        defer s.deinit();
+        s.nextSlice(str);
+
+        var state: terminal.RenderState = .empty;
+        errdefer state.deinit(alloc);
+        try state.update(alloc, &t);
+
+        return .{ .t = t, .state = state };
+    }
+
+    fn deinit(self: *TestRow, alloc: Allocator) void {
+        self.state.deinit(alloc);
+        self.t.deinit(alloc);
+    }
+
+    fn cells(self: *TestRow) std.MultiArrayList(terminal.RenderState.Cell).Slice {
+        return self.state.row_data.get(0).cells.slice();
+    }
+};
+
+test "hashRow: same text hashes the same regardless of position in time" {
+    const alloc = testing.allocator;
+
+    var a = try TestRow.init(alloc, 20, "hello");
+    defer a.deinit(alloc);
+    var b = try TestRow.init(alloc, 20, "hello");
+    defer b.deinit(alloc);
+    var c = try TestRow.init(alloc, 20, "world");
+    defer c.deinit(alloc);
+
+    try testing.expectEqual(hashRow(a.cells(), 20), hashRow(b.cells(), 20));
+    try testing.expect(hashRow(a.cells(), 20) != hashRow(c.cells(), 20));
+}
+
+test "hashRow: styles do not affect the hash" {
+    const alloc = testing.allocator;
+
+    // Bidi resolution depends on codepoints and cell widths, not on
+    // colour or weight, so two rows with the same text in different
+    // styles must share a cache entry.
+    var plain = try TestRow.init(alloc, 20, "hello");
+    defer plain.deinit(alloc);
+    var bold = try TestRow.init(alloc, 20, "\x1b[1;31mhello\x1b[0m");
+    defer bold.deinit(alloc);
+
+    try testing.expectEqual(hashRow(plain.cells(), 20), hashRow(bold.cells(), 20));
+}
+
+test "BidiCache: ascii resolves to identity and allocates nothing per row" {
+    const alloc = testing.allocator;
+
+    var cache: BidiCache = .init(alloc);
+    defer cache.deinit(alloc);
+
+    var row = try TestRow.init(alloc, 20, "hello world");
+    defer row.deinit(alloc);
+
+    const r = try cache.resolve(alloc, row.cells(), 20);
+    try testing.expect(r.identity);
+    try testing.expectEqual(@as(u16, 20), r.cols);
+
+    // The identity case stores no column maps at all. That is the
+    // property the whole design leans on: a row of plain left-to-right
+    // text costs nothing but a hash.
+    try testing.expectEqual(@as(usize, 0), r.v2l.len);
+    try testing.expectEqual(@as(usize, 0), r.l2v.len);
+    try testing.expectEqual(@as(usize, 0), r.levels.len);
+
+    // The accessors still answer correctly.
+    for (0..20) |i| {
+        const l: LogicalCol = .from(@intCast(i));
+        const v: VisualCol = .from(@intCast(i));
+        try testing.expectEqual(i, r.logicalCol(v).int());
+        try testing.expectEqual(i, r.visualCol(l).int());
+        try testing.expectEqual(@as(bidi.Level, 0), r.level(l));
+    }
+}
+
+test "BidiCache: repeated resolves of the same row hit the cache" {
+    const alloc = testing.allocator;
+
+    var cache: BidiCache = .init(alloc);
+    defer cache.deinit(alloc);
+
+    var row = try TestRow.init(alloc, 20, "hello");
+    defer row.deinit(alloc);
+
+    _ = try cache.resolve(alloc, row.cells(), 20);
+    try testing.expectEqual(@as(u32, 1), cache.entries.count());
+
+    for (0..32) |_| _ = try cache.resolve(alloc, row.cells(), 20);
+    try testing.expectEqual(@as(u32, 1), cache.entries.count());
+}
+
+test "BidiCache: reset drops entries and bumps the generation" {
+    const alloc = testing.allocator;
+
+    var cache: BidiCache = .init(alloc);
+    defer cache.deinit(alloc);
+
+    var a = try TestRow.init(alloc, 20, "one");
+    defer a.deinit(alloc);
+    var b = try TestRow.init(alloc, 20, "two");
+    defer b.deinit(alloc);
+
+    _ = try cache.resolve(alloc, a.cells(), 20);
+    _ = try cache.resolve(alloc, b.cells(), 20);
+    try testing.expectEqual(@as(u32, 2), cache.entries.count());
+
+    const gen = cache.generation;
+    cache.reset();
+    try testing.expectEqual(@as(u32, 0), cache.entries.count());
+    try testing.expectEqual(gen +% 1, cache.generation);
+
+    // Still usable afterwards.
+    _ = try cache.resolve(alloc, a.cells(), 20);
+    try testing.expectEqual(@as(u32, 1), cache.entries.count());
+}
+
+test "BidiCache: elements are per cell, not per column" {
+    const alloc = testing.allocator;
+
+    var cache: BidiCache = .init(alloc);
+    defer cache.deinit(alloc);
+
+    // Two double-width characters fill four columns but are two
+    // characters. Feeding the resolver one element per column would let
+    // rule L2 reverse a wide cell's own halves.
+    var row = try TestRow.init(alloc, 4, "\u{4E00}\u{4E8C}");
+    defer row.deinit(alloc);
+
+    _ = try cache.resolve(alloc, row.cells(), 4);
+    try testing.expectEqual(@as(usize, 2), cache.scratch.codepoints.items.len);
+    try testing.expectEqualSlices(u16, &.{ 0, 2 }, cache.scratch.cols.items);
+    try testing.expectEqualSlices(u8, &.{ 2, 2 }, cache.scratch.widths.items);
+}
+
+test "BidiCache: element widths always cover the row" {
+    const alloc = testing.allocator;
+
+    var cache: BidiCache = .init(alloc);
+    defer cache.deinit(alloc);
+
+    // Whatever the content, the element widths have to sum to the column
+    // count or the expansion below would leave holes in the maps.
+    inline for (.{
+        "hello",
+        "\u{4E00}\u{4E8C}",
+        "a\u{4E00}b",
+        "\u{05D0}\u{05D1}",
+        "",
+    }) |str| {
+        var row = try TestRow.init(alloc, 8, str);
+        defer row.deinit(alloc);
+
+        _ = try cache.resolve(alloc, row.cells(), 8);
+
+        var sum: usize = 0;
+        for (cache.scratch.widths.items) |w| sum += w;
+        if (cache.scratch.widths.items.len > 0) {
+            try testing.expectEqual(@as(usize, 8), sum);
+        }
+    }
+}
+
+test "BidiCache: reordering keeps wide cells intact" {
+    // Reordering only happens with a real backend. Under the default
+    // noop build there is nothing to check, and skipping is honest:
+    // the assertions below are meaningless without a resolver.
+    if (comptime bidi.options.backend == .noop) return error.SkipZigTest;
+
+    const alloc = testing.allocator;
+
+    var cache: BidiCache = .init(alloc);
+    defer cache.deinit(alloc);
+
+    // Hebrew followed by a double-width ideograph, which reorders.
+    var row = try TestRow.init(alloc, 6, "\u{05D0}\u{05D1}\u{4E00}");
+    defer row.deinit(alloc);
+
+    const r = try cache.resolve(alloc, row.cells(), 6);
+    try testing.expect(!r.identity);
+
+    // The two permutations must be mutual inverses over every column.
+    for (0..r.cols) |i| {
+        const l: LogicalCol = .from(@intCast(i));
+        const v: VisualCol = .from(@intCast(i));
+        try testing.expectEqual(i, r.logicalCol(r.visualCol(l)).int());
+        try testing.expectEqual(i, r.visualCol(r.logicalCol(v)).int());
+    }
+
+    // The wide cell's two columns stay adjacent and in order, whatever
+    // the reordering did with the cell as a whole.
+    const head_logical: LogicalCol = .from(2);
+    const tail_logical: LogicalCol = .from(3);
+    const head_visual = r.visualCol(head_logical).int();
+    const tail_visual = r.visualCol(tail_logical).int();
+    try testing.expectEqual(head_visual + 1, tail_visual);
+
+    // Level runs cover every column exactly once, in visual order.
+    var covered: usize = 0;
+    var expect_start: u16 = 0;
+    for (r.runs) |run| {
+        try testing.expectEqual(expect_start, run.visual_start);
+        covered += run.len;
+        expect_start += run.len;
+    }
+    try testing.expectEqual(@as(usize, r.cols), covered);
+}

--- a/src/renderer/bidi.zig
+++ b/src/renderer/bidi.zig
@@ -1178,3 +1178,52 @@ test "selectionAnchor: identity rows behave as they always did" {
         try testing.expectEqual(i + 1, r.selectionAnchor(v, true).int());
     }
 }
+
+test "rectangle: a visual span covers a set of logical columns" {
+    // The extraction for a rectangular selection walks the visual span
+    // and marks the logical column each position displays. This is the
+    // same relationship visualSegments expresses from the other
+    // direction, so the two must agree: a rectangle from visual a to b
+    // has to cover exactly the columns a selection would.
+    const r = testMixedRow();
+
+    var vx0: u16 = 0;
+    while (vx0 < r.cols) : (vx0 += 1) {
+        var vx1: u16 = vx0;
+        while (vx1 < r.cols) : (vx1 += 1) {
+            // What the rectangle extraction marks.
+            var covered: [6]bool = @splat(false);
+            var v = vx0;
+            while (v <= vx1) : (v += 1) {
+                covered[r.logicalCol(.from(v)).int()] = true;
+            }
+
+            // The same set arrived at by mapping each logical column
+            // forward instead of each visual column back.
+            var expect: [6]bool = @splat(false);
+            for (0..r.cols) |i| {
+                const vis = r.visualCol(.from(@intCast(i))).int();
+                if (vis >= vx0 and vis <= vx1) expect[i] = true;
+            }
+
+            try testing.expectEqualSlices(bool, &expect, &covered);
+        }
+    }
+}
+
+test "rectangle: a visual column span is discontiguous logically" {
+    const r = testMixedRow();
+
+    // Visual columns 2 and 3 sit either side of the direction change:
+    // one shows logical 2, the other logical 5. Taking that two-column
+    // strip out of the row yields two separate pieces of text, not one
+    // range, which is why extraction cannot just use the corners.
+    try testing.expectEqual(@as(u16, 2), r.logicalCol(.from(2)).int());
+    try testing.expectEqual(@as(u16, 5), r.logicalCol(.from(3)).int());
+
+    // And the columns between them logically are not in the strip.
+    for ([_]u16{ 3, 4 }) |l| {
+        const vis = r.visualCol(.from(l)).int();
+        try testing.expect(vis < 2 or vis > 3);
+    }
+}

--- a/src/renderer/bidi.zig
+++ b/src/renderer/bidi.zig
@@ -146,6 +146,19 @@ pub const RowBidi = struct {
     }
 };
 
+/// How to resolve a row.
+pub const Options = struct {
+    /// The paragraph direction to use when a row has no strongly
+    /// directional character (UAX #9 rules P2/P3).
+    direction: bidi.ParagraphDirection = .auto,
+
+    /// Folded into the cache key, so a change of direction does not
+    /// serve results resolved under the previous one.
+    fn hashSeed(self: Options) u64 {
+        return @intFromEnum(self.direction) +% 1;
+    }
+};
+
 /// A cache of resolved rows, keyed by row content.
 ///
 /// Keying on content rather than on row position means a stale entry is
@@ -170,6 +183,14 @@ pub const BidiCache = struct {
 
     /// The bidi resolver. Owned here so its internal buffers stay warm.
     resolver: bidi.Resolver = .empty,
+
+    /// Number of times the resolver was actually invoked.
+    ///
+    /// Only maintained in debug builds. It exists so that "bidi = never
+    /// is a complete bypass" can be asserted rather than argued: a test
+    /// renders with the option off and checks this never moved.
+    resolve_count: if (std.debug.runtime_safety) usize else void =
+        if (std.debug.runtime_safety) 0 else {},
 
     /// The most entries we hold before dropping everything and starting
     /// over. A terminal screen is at most a few hundred rows and many
@@ -235,8 +256,11 @@ pub const BidiCache = struct {
         alloc: Allocator,
         cells: std.MultiArrayList(terminal.RenderState.Cell).Slice,
         cols: u16,
+        opts: Options,
     ) Allocator.Error!RowBidi {
-        const hash = hashRow(cells, cols);
+        if (std.debug.runtime_safety) self.resolve_count += 1;
+
+        const hash = hashRow(cells, cols) ^ opts.hashSeed();
         if (self.entries.get(hash)) |cached| return cached;
 
         // Dropping everything at the bound is crude but correct, and it
@@ -247,7 +271,7 @@ pub const BidiCache = struct {
             self.reset();
         }
 
-        const row = try self.resolveUncached(alloc, cells, cols, hash);
+        const row = try self.resolveUncached(alloc, cells, cols, hash, opts);
         try self.entries.put(alloc, hash, row);
         return row;
     }
@@ -258,6 +282,7 @@ pub const BidiCache = struct {
         cells: std.MultiArrayList(terminal.RenderState.Cell).Slice,
         cols: u16,
         hash: u64,
+        opts: Options,
     ) Allocator.Error!RowBidi {
         self.scratch.clear();
         try self.buildElements(alloc, cells, cols);
@@ -265,7 +290,7 @@ pub const BidiCache = struct {
         const result = try self.resolver.resolve(
             alloc,
             self.scratch.codepoints.items,
-            .{},
+            .{ .direction = opts.direction },
         );
 
         // The common case: nothing to reorder, so nothing is stored.
@@ -540,7 +565,7 @@ test "BidiCache: ascii resolves to identity and allocates nothing per row" {
     var row = try TestRow.init(alloc, 20, "hello world");
     defer row.deinit(alloc);
 
-    const r = try cache.resolve(alloc, row.cells(), 20);
+    const r = try cache.resolve(alloc, row.cells(), 20, .{});
     try testing.expect(r.identity);
     try testing.expectEqual(@as(u16, 20), r.cols);
 
@@ -570,10 +595,10 @@ test "BidiCache: repeated resolves of the same row hit the cache" {
     var row = try TestRow.init(alloc, 20, "hello");
     defer row.deinit(alloc);
 
-    _ = try cache.resolve(alloc, row.cells(), 20);
+    _ = try cache.resolve(alloc, row.cells(), 20, .{});
     try testing.expectEqual(@as(u32, 1), cache.entries.count());
 
-    for (0..32) |_| _ = try cache.resolve(alloc, row.cells(), 20);
+    for (0..32) |_| _ = try cache.resolve(alloc, row.cells(), 20, .{});
     try testing.expectEqual(@as(u32, 1), cache.entries.count());
 }
 
@@ -588,8 +613,8 @@ test "BidiCache: reset drops entries and bumps the generation" {
     var b = try TestRow.init(alloc, 20, "two");
     defer b.deinit(alloc);
 
-    _ = try cache.resolve(alloc, a.cells(), 20);
-    _ = try cache.resolve(alloc, b.cells(), 20);
+    _ = try cache.resolve(alloc, a.cells(), 20, .{});
+    _ = try cache.resolve(alloc, b.cells(), 20, .{});
     try testing.expectEqual(@as(u32, 2), cache.entries.count());
 
     const gen = cache.generation;
@@ -598,7 +623,7 @@ test "BidiCache: reset drops entries and bumps the generation" {
     try testing.expectEqual(gen +% 1, cache.generation);
 
     // Still usable afterwards.
-    _ = try cache.resolve(alloc, a.cells(), 20);
+    _ = try cache.resolve(alloc, a.cells(), 20, .{});
     try testing.expectEqual(@as(u32, 1), cache.entries.count());
 }
 
@@ -614,7 +639,7 @@ test "BidiCache: elements are per cell, not per column" {
     var row = try TestRow.init(alloc, 4, "\u{4E00}\u{4E8C}");
     defer row.deinit(alloc);
 
-    _ = try cache.resolve(alloc, row.cells(), 4);
+    _ = try cache.resolve(alloc, row.cells(), 4, .{});
     try testing.expectEqual(@as(usize, 2), cache.scratch.codepoints.items.len);
     try testing.expectEqualSlices(u16, &.{ 0, 2 }, cache.scratch.cols.items);
     try testing.expectEqualSlices(u8, &.{ 2, 2 }, cache.scratch.widths.items);
@@ -638,7 +663,7 @@ test "BidiCache: element widths always cover the row" {
         var row = try TestRow.init(alloc, 8, str);
         defer row.deinit(alloc);
 
-        _ = try cache.resolve(alloc, row.cells(), 8);
+        _ = try cache.resolve(alloc, row.cells(), 8, .{});
 
         var sum: usize = 0;
         for (cache.scratch.widths.items) |w| sum += w;
@@ -663,7 +688,7 @@ test "BidiCache: reordering keeps wide cells intact" {
     var row = try TestRow.init(alloc, 6, "\u{05D0}\u{05D1}\u{4E00}");
     defer row.deinit(alloc);
 
-    const r = try cache.resolve(alloc, row.cells(), 6);
+    const r = try cache.resolve(alloc, row.cells(), 6, .{});
     try testing.expect(!r.identity);
 
     // The two permutations must be mutual inverses over every column.
@@ -838,7 +863,7 @@ test "a resolved ascii row maps identically" {
     var row = try TestRow.init(alloc, 20, "hello world 123");
     defer row.deinit(alloc);
 
-    const r = try cache.resolve(alloc, row.cells(), 20);
+    const r = try cache.resolve(alloc, row.cells(), 20, .{});
     try testing.expect(r.identity);
 
     for (0..20) |i| {
@@ -900,4 +925,88 @@ test "wide cell: stepping back happens logically, not visually" {
     // character entirely.
     try testing.expectEqual(@as(u16, 1), r.visualCol(.from(0)).int());
     try testing.expectEqual(@as(u16, 1), r.logicalCol(.from(0)).int());
+}
+
+test "resolve_count tracks invocations" {
+    if (!std.debug.runtime_safety) return error.SkipZigTest;
+
+    const alloc = testing.allocator;
+
+    var cache: BidiCache = .init(alloc);
+    defer cache.deinit(alloc);
+
+    var row = try TestRow.init(alloc, 20, "hello");
+    defer row.deinit(alloc);
+
+    try testing.expectEqual(@as(usize, 0), cache.resolve_count);
+
+    // Every call counts, cache hit or not. The renderer's guarantee is
+    // that with bidi off it does not call this at all, so what has to be
+    // observable is the call, not the work it did.
+    _ = try cache.resolve(alloc, row.cells(), 20, .{});
+    try testing.expectEqual(@as(usize, 1), cache.resolve_count);
+
+    for (0..9) |_| _ = try cache.resolve(alloc, row.cells(), 20, .{});
+    try testing.expectEqual(@as(usize, 10), cache.resolve_count);
+}
+
+test "paragraph direction is part of the cache key" {
+    const alloc = testing.allocator;
+
+    var cache: BidiCache = .init(alloc);
+    defer cache.deinit(alloc);
+
+    var row = try TestRow.init(alloc, 20, "hello");
+    defer row.deinit(alloc);
+
+    // Resolving the same row under a different assumed paragraph
+    // direction can give a different answer, so the two must not share a
+    // cache entry. Without the direction in the key the second call
+    // would be served the first one's result.
+    _ = try cache.resolve(alloc, row.cells(), 20, .{ .direction = .ltr });
+    const after_first = cache.entries.count();
+
+    _ = try cache.resolve(alloc, row.cells(), 20, .{ .direction = .rtl });
+    try testing.expect(cache.entries.count() > after_first);
+
+    // And the same options do share one.
+    const before = cache.entries.count();
+    _ = try cache.resolve(alloc, row.cells(), 20, .{ .direction = .ltr });
+    try testing.expectEqual(before, cache.entries.count());
+}
+
+test "forced rtl direction reorders a row with no strong characters" {
+    if (comptime bidi.options.backend == .noop) return error.SkipZigTest;
+
+    const alloc = testing.allocator;
+
+    var cache: BidiCache = .init(alloc);
+    defer cache.deinit(alloc);
+
+    // Digits and punctuation only: no strongly directional character, so
+    // rules P2 and P3 have nothing to go on and the configured default
+    // decides. This is exactly what bidi-default-direction is for.
+    var row = try TestRow.init(alloc, 5, "12 34");
+    defer row.deinit(alloc);
+
+    // Left to right leaves it alone.
+    {
+        const r = try cache.resolve(alloc, row.cells(), 5, .{ .direction = .ltr });
+        try testing.expect(r.identity);
+    }
+
+    // Right to left moves the run to the other end. The digits keep
+    // their own left-to-right order within the run, which is rule L1
+    // and the reason a phone number in Hebrew text still reads
+    // correctly.
+    {
+        const r = try cache.resolve(alloc, row.cells(), 5, .{ .direction = .rtl });
+        try testing.expect(!r.identity);
+        try testing.expectEqual(bidi.Direction.rtl, r.direction);
+
+        for (0..r.cols) |i| {
+            const l: LogicalCol = .from(@intCast(i));
+            try testing.expectEqual(i, r.logicalCol(r.visualCol(l)).int());
+        }
+    }
 }

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -2685,7 +2685,10 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             var run_iter_opts: font.shape.RunOptions = .{
                 .grid = self.font_grid,
                 .cells = cells_slice,
-                .selection = if (selection) |s| s else null,
+                .selection = if (selection) |s|
+                    .one(.{ .start = s[0], .end = s[1] })
+                else
+                    .empty,
 
                 // We want to do font shaping as long as the cursor is
                 // visible on this viewport.

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -2685,7 +2685,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             if (self.bidiEnabled()) {
                 row_bidi = self.bidi_cache.resolve(
                     self.alloc,
-                    cells_slice,
+                    cells_raw[0..cells_len],
                     @intCast(cells_len),
                     self.bidiOptions(),
                 ) catch |err| bidi: {
@@ -3335,7 +3335,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             const rows = state.row_data.items(.cells);
             if (y >= rows.len) return logical_x;
 
-            const cells = rows[y].slice();
+            const cells = rows[y].slice().items(.raw);
             const cols: u16 = @intCast(cells.len);
             if (logical_x >= cols) return logical_x;
 

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -2527,10 +2527,13 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                         // If we are a spacer tail of a wide cell, our cursor needs
                         // to move back one cell. The saturate is to ensure we don't
                         // overflow but this shouldn't happen with well-formed input.
-                        switch (wide) {
+                        // As in addCursor, the step back happens in logical
+                        // space and the result is then mapped to where it
+                        // is drawn.
+                        self.visualColFor(cursor_vp.y, switch (wide) {
                             .narrow, .spacer_head, .wide => cursor_vp.x,
                             .spacer_tail => cursor_vp.x -| 1,
-                        },
+                        }),
                         @intCast(cursor_vp.y),
                     };
 
@@ -2696,8 +2699,11 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             var run_iter_opts: font.shape.RunOptions = .{
                 .grid = self.font_grid,
                 .cells = cells_slice,
+                // The selection is stored logically. Mapping it can
+                // yield several visual stretches when it spans a change
+                // of direction.
                 .selection = if (selection) |s|
-                    .one(.{ .start = s[0], .end = s[1] })
+                    row_bidi.visualSegments(s[0], s[1])
                 else
                     .empty,
 
@@ -2708,10 +2714,15 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
 
                 // We want to do font shaping as long as the cursor is
                 // visible on this viewport.
+                //
+                // The cursor position is logical, because that is what
+                // the running program addresses, but the run iterator
+                // walks visual columns, so it is mapped here.
                 .cursor_x = cursor_x: {
                     const vp = state.cursor.viewport orelse break :cursor_x null;
                     if (vp.y != y) break :cursor_x null;
-                    break :cursor_x vp.x;
+                    if (vp.x >= cells_len) break :cursor_x vp.x;
+                    break :cursor_x row_bidi.visualCol(.from(vp.x)).int();
                 },
             };
             run_iter_opts.applyBreakConfig(self.config.font_shaping_break);
@@ -2720,11 +2731,19 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             var shaper_cells: ?[]const font.shape.Cell = null;
             var shaper_cells_i: usize = 0;
 
-            for (
-                0..,
-                cells_raw[0..cells_len],
-                cells_style[0..cells_len],
-            ) |x, *cell, *managed_style| {
+            // The loop below walks VISUAL columns: `x` is where a cell
+            // is drawn, and is what the shaper's cells are matched
+            // against. `lx` is the logical column whose contents are
+            // displayed there, and is what the selection, highlight and
+            // link ranges are expressed in, since those come from the
+            // terminal and are always logical.
+            //
+            // Without reordering the two are equal and this is the same
+            // loop it has always been.
+            for (0..cells_len) |x| {
+                const lx: usize = row_bidi.logicalCol(.from(@intCast(x))).int();
+                const cell: *const terminal.page.Cell = &cells_raw[lx];
+                const managed_style: *const terminal.Style = &cells_style[lx];
                 // If this cell falls within our preedit range then we
                 // skip this because preedits are setup separately.
                 if (preedit_range) |range| preedit: {
@@ -2803,10 +2822,15 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     // Order below matters for precedence.
 
                     // Selection should take the highest precedence.
+                    // Membership is tested logically because that is
+                    // the space the ranges live in; the result is drawn
+                    // at the visual column, which is what makes a
+                    // logically contiguous selection render as several
+                    // stretches when it crosses a direction change.
                     const x_compare = if (wide == .spacer_tail)
-                        x -| 1
+                        lx -| 1
                     else
-                        x;
+                        lx;
                     if (selection) |sel| {
                         if (x_compare >= sel[0] and
                             x_compare <= sel[1]) break :selected .selection;
@@ -2977,7 +3001,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 // distinguish them.
                 const underline: terminal.Attribute.Underline = underline: {
                     if (links.contains(.{
-                        .x = @intCast(x),
+                        .x = @intCast(lx),
                         .y = @intCast(y),
                     })) {
                         break :underline if (style.flags.underline == .single)
@@ -3266,6 +3290,39 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             });
         }
 
+        /// Map a logical column on a viewport row to the visual column
+        /// it is displayed at.
+        ///
+        /// The cursor position is logical, because that is the space the
+        /// running program addresses, but it has to be drawn where the
+        /// character actually appears. The row was already resolved
+        /// while its cells were built, so this is a cache hit.
+        fn visualColFor(
+            self: *Self,
+            y: usize,
+            logical_x: terminal.size.CellCountInt,
+        ) terminal.size.CellCountInt {
+            // Nothing reorders, so the two spaces coincide. This is the
+            // whole cost of the mapping in the default build.
+            if (comptime bidipkg.options.backend == .noop) return logical_x;
+
+            const state = &self.terminal_state;
+            const rows = state.row_data.items(.cells);
+            if (y >= rows.len) return logical_x;
+
+            const cells = rows[y].slice();
+            const cols: u16 = @intCast(cells.len);
+            if (logical_x >= cols) return logical_x;
+
+            const row_bidi = self.bidi_cache.resolve(
+                self.alloc,
+                cells,
+                cols,
+            ) catch return logical_x;
+
+            return @intCast(row_bidi.visualCol(.from(logical_x)).int());
+        }
+
         fn addCursor(
             self: *Self,
             cursor_state: *const terminal.RenderState.Cursor,
@@ -3276,7 +3333,13 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
 
             // Add the cursor. We render the cursor over the wide character if
             // we're on the wide character tail.
-            const wide, const x = cell: {
+            //
+            // The logical column is resolved first, including the step
+            // back onto a wide character's head, and only then mapped to
+            // where that character is drawn. Mapping first would step
+            // back from a visual column into whatever happens to be to
+            // its left, which need not be the same character.
+            const wide, const logical_x = cell: {
                 // The cursor goes over the screen cursor position.
                 if (!cursor_vp.wide_tail) break :cell .{
                     cursor_state.cell.wide == .wide,
@@ -3287,6 +3350,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 // to the actual character.
                 break :cell .{ true, cursor_vp.x - 1 };
             };
+            const x = self.visualColFor(cursor_vp.y, logical_x);
 
             const alpha: u8 = if (!self.focused) 255 else alpha: {
                 const alpha = 255 * self.config.cursor_opacity;

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -2667,17 +2667,28 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             //
             // This is comptime-gated on the backend so that the default
             // build, which does no reordering, does not pay for a row
-            // hash it would never use.
+            // hash it would never use. With the noop backend the maps
+            // stay empty and the run iterator walks logical order, which
+            // is exactly what it did before bidi existed.
+            //
+            // Note the cursor and selection columns passed below are
+            // still logical. Converting them to visual columns is a
+            // separate change; until then a build with reordering
+            // enabled will place the cursor and selection edges wrongly
+            // on rows that reorder.
+            var row_bidi: rendererbidi.RowBidi =
+                .identityFor(@intCast(cells_len), &.{});
             if (comptime bidipkg.options.backend != .noop) {
-                _ = self.bidi_cache.resolve(
+                row_bidi = self.bidi_cache.resolve(
                     self.alloc,
                     cells_slice,
                     @intCast(cells_len),
-                ) catch |err| {
+                ) catch |err| bidi: {
                     log.warn(
                         "error resolving bidi row y={} err={}",
                         .{ y, err },
                     );
+                    break :bidi .identityFor(@intCast(cells_len), &.{});
                 };
             }
 
@@ -2689,6 +2700,11 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     .one(.{ .start = s[0], .end = s[1] })
                 else
                     .empty,
+
+                // Empty for a row that needs no reordering, which makes
+                // the run iterator walk logical columns.
+                .v2l = row_bidi.v2l,
+                .levels = row_bidi.levels,
 
                 // We want to do font shaping as long as the cursor is
                 // visible on this viewport.

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -3322,6 +3322,36 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
         /// running program addresses, but it has to be drawn where the
         /// character actually appears. The row was already resolved
         /// while its cells were built, so this is a cache hit.
+        /// Whether the given logical column on a viewport row resolves
+        /// to a right-to-left embedding level.
+        ///
+        /// Used only to pick the cursor's shape. The cursor position
+        /// itself is never changed by this.
+        fn isRtlAt(
+            self: *Self,
+            y: usize,
+            logical_x: terminal.size.CellCountInt,
+        ) bool {
+            if (!self.bidiEnabled()) return false;
+
+            const state = &self.terminal_state;
+            const rows = state.row_data.items(.cells);
+            if (y >= rows.len) return false;
+
+            const cells = rows[y].slice().items(.raw);
+            const cols: u16 = @intCast(cells.len);
+            if (logical_x >= cols) return false;
+
+            const row_bidi = self.bidi_cache.resolve(
+                self.alloc,
+                cells,
+                cols,
+                self.bidiOptions(),
+            ) catch return false;
+
+            return row_bidi.level(.from(logical_x)) & 1 == 1;
+        }
+
         fn visualColFor(
             self: *Self,
             y: usize,
@@ -3392,7 +3422,17 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     const sprite: font.Sprite = switch (cursor_style) {
                         .block => .cursor_rect,
                         .block_hollow => .cursor_hollow_rect,
-                        .bar => .cursor_bar,
+
+                        // A bar marks the gap the next character will
+                        // fill, and that gap is on the other side of the
+                        // cell in right-to-left text. Block shapes cover
+                        // the whole cell either way, so they are left
+                        // alone.
+                        .bar => if (self.isRtlAt(cursor_vp.y, logical_x))
+                            .cursor_bar_rtl
+                        else
+                            .cursor_bar,
+
                         .underline => .cursor_underline,
                         .lock => unreachable,
                     };

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -13,6 +13,8 @@ const math = @import("../math.zig");
 const Surface = @import("../Surface.zig");
 const link = @import("link.zig");
 const cellpkg = @import("cell.zig");
+const rendererbidi = @import("bidi.zig");
+const bidipkg = @import("../bidi/main.zig");
 const noMinContrast = cellpkg.noMinContrast;
 const constraintWidth = cellpkg.constraintWidth;
 const isCovering = cellpkg.isCovering;
@@ -174,6 +176,10 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
         font_grid: *font.SharedGrid,
         font_shaper: font.Shaper,
         font_shaper_cache: font.ShaperCache,
+
+        /// Cached bidi resolution per row. Populated during rendering but
+        /// not yet consumed; run iteration still walks logical order.
+        bidi_cache: rendererbidi.BidiCache,
 
         /// The images that we may render.
         images: ImageState = .empty,
@@ -780,6 +786,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 .font_grid = options.font_grid,
                 .font_shaper = font_shaper,
                 .font_shaper_cache = font.ShaperCache.init(),
+                .bidi_cache = .init(alloc),
 
                 // Shaders (initialized below)
                 .shaders = undefined,
@@ -819,6 +826,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
 
             self.font_shaper.deinit();
             self.font_shaper_cache.deinit(self.alloc);
+            self.bidi_cache.deinit(self.alloc);
 
             self.config.deinit();
 
@@ -1097,6 +1105,12 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             const font_shaper_cache = font.ShaperCache.init();
             self.font_shaper_cache.deinit(self.alloc);
             self.font_shaper_cache = font_shaper_cache;
+
+            // Bidi results are keyed by row content, so a font change
+            // cannot make them wrong. They are dropped anyway because the
+            // rows they describe are about to be re-laid out and holding
+            // their storage is not worth it.
+            self.bidi_cache.reset();
 
             // Update cell size.
             self.size.cell = .{
@@ -1863,6 +1877,9 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             const font_shaper_cache = font.ShaperCache.init();
             self.font_shaper_cache.deinit(self.alloc);
             self.font_shaper_cache = font_shaper_cache;
+
+            // Config can change bidi behavior, so drop resolved rows.
+            self.bidi_cache.reset();
 
             // Set our new minimum contrast
             self.uniforms.min_contrast = config.min_contrast;
@@ -2639,6 +2656,29 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                         state.colors.background,
                     );
                 },
+            }
+
+            // Resolve bidi for this row and cache it.
+            //
+            // Nothing consumes the result yet; run iteration still walks
+            // logical order. Populating the cache first means its memory
+            // behavior and cost can be measured on their own, before
+            // rendering depends on it.
+            //
+            // This is comptime-gated on the backend so that the default
+            // build, which does no reordering, does not pay for a row
+            // hash it would never use.
+            if (comptime bidipkg.options.backend != .noop) {
+                _ = self.bidi_cache.resolve(
+                    self.alloc,
+                    cells_slice,
+                    @intCast(cells_len),
+                ) catch |err| {
+                    log.warn(
+                        "error resolving bidi row y={} err={}",
+                        .{ y, err },
+                    );
+                };
             }
 
             // Iterator of runs for shaping.

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -551,6 +551,8 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             font_features: std.ArrayListUnmanaged([:0]const u8),
             font_styles: font.CodepointResolver.StyleStatus,
             font_shaping_break: configpkg.FontShapingBreak,
+            bidi: configpkg.Config.Bidi,
+            bidi_default_direction: configpkg.Config.BidiDefaultDirection,
             cursor_color: ?configpkg.Config.TerminalColor,
             cursor_opacity: f64,
             cursor_text: ?configpkg.Config.TerminalColor,
@@ -622,6 +624,8 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     .font_features = font_features.list,
                     .font_styles = font_styles,
                     .font_shaping_break = config.@"font-shaping-break",
+                    .bidi = config.bidi,
+                    .bidi_default_direction = config.@"bidi-default-direction",
 
                     .cursor_color = config.@"cursor-color",
                     .cursor_text = config.@"cursor-text",
@@ -2668,24 +2672,22 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             // behavior and cost can be measured on their own, before
             // rendering depends on it.
             //
-            // This is comptime-gated on the backend so that the default
-            // build, which does no reordering, does not pay for a row
-            // hash it would never use. With the noop backend the maps
-            // stay empty and the run iterator walks logical order, which
-            // is exactly what it did before bidi existed.
+            // Resolve bidi for this row.
             //
-            // Note the cursor and selection columns passed below are
-            // still logical. Converting them to visual columns is a
-            // separate change; until then a build with reordering
-            // enabled will place the cursor and selection edges wrongly
-            // on rows that reorder.
+            // When disabled this is a complete bypass: no row hash, no
+            // resolver call, and the identity maps below make every
+            // coordinate mapping and the run iterator behave exactly as
+            // they did before bidi existed. That is the default, so the
+            // cost of the feature for a user who has not asked for it is
+            // one branch per row.
             var row_bidi: rendererbidi.RowBidi =
                 .identityFor(@intCast(cells_len), &.{});
-            if (comptime bidipkg.options.backend != .noop) {
+            if (self.bidiEnabled()) {
                 row_bidi = self.bidi_cache.resolve(
                     self.alloc,
                     cells_slice,
                     @intCast(cells_len),
+                    self.bidiOptions(),
                 ) catch |err| bidi: {
                     log.warn(
                         "error resolving bidi row y={} err={}",
@@ -3290,6 +3292,29 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             });
         }
 
+        /// Whether bidi resolution should run at all.
+        ///
+        /// `always` and `auto` differ only in intent: the resolver
+        /// already short-circuits a row it cannot affect, so `always`
+        /// exists to make that path skippable for diagnostics rather
+        /// than to change any output.
+        inline fn bidiEnabled(self: *const Self) bool {
+            // A build without a real backend can never reorder, so the
+            // whole thing folds away at comptime.
+            if (comptime bidipkg.options.backend == .noop) return false;
+            return self.config.bidi != .never;
+        }
+
+        fn bidiOptions(self: *const Self) rendererbidi.Options {
+            return .{
+                .direction = switch (self.config.bidi_default_direction) {
+                    .auto => .auto,
+                    .ltr => .ltr,
+                    .rtl => .rtl,
+                },
+            };
+        }
+
         /// Map a logical column on a viewport row to the visual column
         /// it is displayed at.
         ///
@@ -3303,8 +3328,8 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             logical_x: terminal.size.CellCountInt,
         ) terminal.size.CellCountInt {
             // Nothing reorders, so the two spaces coincide. This is the
-            // whole cost of the mapping in the default build.
-            if (comptime bidipkg.options.backend == .noop) return logical_x;
+            // whole cost of the mapping when bidi is off.
+            if (!self.bidiEnabled()) return logical_x;
 
             const state = &self.terminal_state;
             const rows = state.row_data.items(.cells);
@@ -3318,6 +3343,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 self.alloc,
                 cells,
                 cols,
+                self.bidiOptions(),
             ) catch return logical_x;
 
             return @intCast(row_bidi.visualCol(.from(logical_x)).int());

--- a/src/synthetic/Bidi.zig
+++ b/src/synthetic/Bidi.zig
@@ -1,0 +1,438 @@
+/// Generates text corpora for exercising the Unicode Bidirectional
+/// Algorithm (UAX #9).
+///
+/// The point of this generator is that bidi benchmark corpora are
+/// reproducible from a seed rather than checked into the repository, per
+/// the guidance in `src/benchmark/AGENTS.md`. A profile picks the script
+/// mix; the same seed and profile always produce the same bytes, so
+/// branch-to-branch comparisons are meaningful.
+///
+/// Output is line-oriented so the same corpus can feed both the bidi
+/// benchmarks and the terminal stream benchmarks.
+const Bidi = @This();
+
+const std = @import("std");
+const assert = std.debug.assert;
+const Generator = @import("Generator.zig");
+
+/// The script mix to generate.
+pub const Profile = enum {
+    /// Printable ASCII only. This is the corpus that matters most: it is
+    /// what the overwhelming majority of terminal output looks like, and
+    /// it is the one that must show no measurable regression when bidi
+    /// support lands.
+    ascii,
+
+    /// Hebrew, including niqqud so combining marks are exercised.
+    hebrew,
+
+    /// Arabic, including tashkeel.
+    arabic,
+
+    /// Persian: Farsi-specific letters, ZWNJ inside compound words, and
+    /// Extended Arabic-Indic digits. Persian is called out separately
+    /// from Arabic because its digits are European Number while Arabic's
+    /// are Arabic Number, which is a classic source of resolution bugs.
+    persian,
+
+    /// Latin and RTL words interleaved, the common real-world case.
+    mixed,
+
+    /// RTL text with numbers embedded. Numbers always render
+    /// left-to-right even inside RTL, so this exercises the weak-type
+    /// rules (W1-W7) that a naive implementation gets wrong.
+    numeric,
+
+    /// Deliberately hostile: direction alternating every character,
+    /// nested isolates and embeddings, bracket pairs spanning direction
+    /// changes. This is the worst case for resolution cost and the best
+    /// case for finding rule bugs.
+    adversarial,
+};
+
+/// Random number generator.
+rand: std.Random,
+
+/// Which script mix to generate.
+profile: Profile = .ascii,
+
+/// Terminal width to wrap at. Lines are broken with a newline once this
+/// many codepoints have been emitted, so generated rows resemble what a
+/// terminal actually holds.
+cols: u16 = 120,
+
+/// Current column, tracked across `next` calls so wrapping is continuous.
+col: u16 = 0,
+
+const latin_lower = "abcdefghijklmnopqrstuvwxyz";
+
+/// Hebrew letters alef..tav.
+const hebrew_letters = blk: {
+    var out: [27]u21 = undefined;
+    for (0..27) |i| out[i] = 0x05D0 + i;
+    break :blk out;
+};
+
+/// Hebrew points (niqqud), which are nonspacing marks.
+const hebrew_marks = [_]u21{ 0x05B0, 0x05B4, 0x05B7, 0x05B8, 0x05BC };
+
+/// Common Arabic letters.
+const arabic_letters = [_]u21{
+    0x0627, 0x0628, 0x062A, 0x062B, 0x062C, 0x062D, 0x062E, 0x062F,
+    0x0631, 0x0632, 0x0633, 0x0634, 0x0635, 0x0636, 0x0637, 0x0638,
+    0x0639, 0x063A, 0x0641, 0x0642, 0x0643, 0x0644, 0x0645, 0x0646,
+    0x0647, 0x0648, 0x064A,
+};
+
+/// Arabic tashkeel (nonspacing marks).
+const arabic_marks = [_]u21{ 0x064B, 0x064E, 0x064F, 0x0650, 0x0651, 0x0652 };
+
+/// Letters specific to Persian beyond the shared Arabic set.
+const persian_letters = [_]u21{ 0x067E, 0x0686, 0x0698, 0x06AF, 0x06A9, 0x06CC };
+
+/// Arabic-Indic digits. Bidi_Class AN.
+const arabic_indic_digits = blk: {
+    var out: [10]u21 = undefined;
+    for (0..10) |i| out[i] = 0x0660 + i;
+    break :blk out;
+};
+
+/// Extended Arabic-Indic digits, used for Persian. Bidi_Class EN.
+const ext_arabic_indic_digits = blk: {
+    var out: [10]u21 = undefined;
+    for (0..10) |i| out[i] = 0x06F0 + i;
+    break :blk out;
+};
+
+/// Explicit bidi formatting characters, used by the adversarial profile.
+const isolates = [_]u21{ 0x2066, 0x2067, 0x2068 }; // LRI, RLI, FSI
+const pop_isolate: u21 = 0x2069; // PDI
+const embeddings = [_]u21{ 0x202A, 0x202B, 0x202D, 0x202E }; // LRE, RLE, LRO, RLO
+const pop_embedding: u21 = 0x202C; // PDF
+
+/// Mirrored bracket pairs, which exercise rule N0.
+const bracket_pairs = [_][2]u21{
+    .{ '(', ')' },
+    .{ '[', ']' },
+    .{ '{', '}' },
+};
+
+pub fn generator(self: *Bidi) Generator {
+    return .init(self, next);
+}
+
+pub fn next(
+    self: *Bidi,
+    writer: *std.Io.Writer,
+    max_len: usize,
+) Generator.Error!void {
+    var rem = max_len;
+
+    // Scratch for one emitted unit (a word plus its trailing separator).
+    // Words are capped well below this, so a unit always fits.
+    var buf: [256]u8 = undefined;
+
+    while (rem > 0) {
+        const n = self.writeUnit(&buf);
+        assert(n > 0);
+
+        if (n > rem) {
+            // The next unit doesn't fit. Pad with spaces rather than
+            // truncating mid-codepoint, which would emit invalid UTF-8.
+            for (0..rem) |_| try writer.writeByte(' ');
+            return;
+        }
+
+        try writer.writeAll(buf[0..n]);
+        rem -= n;
+    }
+}
+
+/// Write one unit (a word and its separator) into `buf`, returning the
+/// number of bytes written.
+fn writeUnit(self: *Bidi, buf: []u8) usize {
+    var w: Writer = .{ .buf = buf };
+
+    switch (self.profile) {
+        .ascii => self.writeLatinWord(&w),
+        .hebrew => self.writeHebrewWord(&w),
+        .arabic => self.writeArabicWord(&w, false),
+        .persian => self.writePersianWord(&w),
+        .mixed => {
+            // Roughly half Latin, half RTL, which is what a localized CLI
+            // session actually looks like.
+            if (self.rand.boolean()) {
+                self.writeLatinWord(&w);
+            } else if (self.rand.boolean()) {
+                self.writeHebrewWord(&w);
+            } else {
+                self.writeArabicWord(&w, false);
+            }
+        },
+        .numeric => self.writeNumericUnit(&w),
+        .adversarial => self.writeAdversarialUnit(&w),
+    }
+
+    // Separator: newline at the wrap column, space otherwise.
+    if (self.col >= self.cols) {
+        w.cp('\n');
+        self.col = 0;
+    } else {
+        w.cp(' ');
+        self.col += 1;
+    }
+
+    return w.len;
+}
+
+fn writeLatinWord(self: *Bidi, w: *Writer) void {
+    const n = self.rand.intRangeAtMost(usize, 2, 9);
+    for (0..n) |_| {
+        w.cp(latin_lower[self.rand.uintLessThan(usize, latin_lower.len)]);
+        self.col += 1;
+    }
+}
+
+fn writeHebrewWord(self: *Bidi, w: *Writer) void {
+    const n = self.rand.intRangeAtMost(usize, 2, 7);
+    for (0..n) |_| {
+        w.cp(hebrew_letters[self.rand.uintLessThan(usize, hebrew_letters.len)]);
+        self.col += 1;
+
+        // Niqqud are nonspacing, so they occupy no column.
+        if (self.rand.float(f32) < 0.25) {
+            w.cp(hebrew_marks[self.rand.uintLessThan(usize, hebrew_marks.len)]);
+        }
+    }
+}
+
+fn writeArabicWord(self: *Bidi, w: *Writer, persian: bool) void {
+    const n = self.rand.intRangeAtMost(usize, 2, 7);
+    for (0..n) |_| {
+        const cp = if (persian and self.rand.float(f32) < 0.3)
+            persian_letters[self.rand.uintLessThan(usize, persian_letters.len)]
+        else
+            arabic_letters[self.rand.uintLessThan(usize, arabic_letters.len)];
+        w.cp(cp);
+        self.col += 1;
+
+        // Tashkeel are nonspacing.
+        if (self.rand.float(f32) < 0.2) {
+            w.cp(arabic_marks[self.rand.uintLessThan(usize, arabic_marks.len)]);
+        }
+    }
+}
+
+fn writePersianWord(self: *Bidi, w: *Writer) void {
+    self.writeArabicWord(w, true);
+
+    // Persian compounds are frequently joined with ZWNJ, which breaks
+    // cursive joining without introducing a spacing character.
+    if (self.rand.float(f32) < 0.35) {
+        w.cp(0x200C);
+        self.writeArabicWord(w, true);
+    }
+}
+
+fn writeNumericUnit(self: *Bidi, w: *Writer) void {
+    switch (self.rand.uintLessThan(u8, 4)) {
+        // A bare RTL word.
+        0 => self.writeArabicWord(w, false),
+
+        // ASCII digits (European Number) inside RTL context.
+        1 => {
+            const n = self.rand.intRangeAtMost(usize, 1, 6);
+            for (0..n) |_| {
+                w.cp('0' + self.rand.uintLessThan(u21, 10));
+                self.col += 1;
+            }
+        },
+
+        // Arabic-Indic digits (Arabic Number).
+        2 => {
+            const n = self.rand.intRangeAtMost(usize, 1, 6);
+            for (0..n) |_| {
+                w.cp(arabic_indic_digits[self.rand.uintLessThan(usize, 10)]);
+                self.col += 1;
+            }
+        },
+
+        // A decimal with separators, which exercises ES/CS resolution.
+        3 => {
+            const n = self.rand.intRangeAtMost(usize, 1, 3);
+            for (0..n) |i| {
+                if (i > 0) {
+                    w.cp('.');
+                    self.col += 1;
+                }
+                for (0..self.rand.intRangeAtMost(usize, 1, 3)) |_| {
+                    w.cp(ext_arabic_indic_digits[self.rand.uintLessThan(usize, 10)]);
+                    self.col += 1;
+                }
+            }
+        },
+
+        else => unreachable,
+    }
+}
+
+fn writeAdversarialUnit(self: *Bidi, w: *Writer) void {
+    switch (self.rand.uintLessThan(u8, 4)) {
+        // Direction flips every single character. Maximal level runs.
+        0 => {
+            const n = self.rand.intRangeAtMost(usize, 4, 12);
+            for (0..n) |i| {
+                const cp = if (i % 2 == 0)
+                    latin_lower[self.rand.uintLessThan(usize, latin_lower.len)]
+                else
+                    hebrew_letters[self.rand.uintLessThan(usize, hebrew_letters.len)];
+                w.cp(cp);
+                self.col += 1;
+            }
+        },
+
+        // Nested isolates.
+        1 => {
+            const depth = self.rand.intRangeAtMost(usize, 1, 6);
+            for (0..depth) |_| {
+                w.cp(isolates[self.rand.uintLessThan(usize, isolates.len)]);
+            }
+            self.writeHebrewWord(w);
+            for (0..depth) |_| w.cp(pop_isolate);
+        },
+
+        // Nested embeddings and overrides.
+        2 => {
+            const depth = self.rand.intRangeAtMost(usize, 1, 5);
+            for (0..depth) |_| {
+                w.cp(embeddings[self.rand.uintLessThan(usize, embeddings.len)]);
+            }
+            self.writeLatinWord(w);
+            for (0..depth) |_| w.cp(pop_embedding);
+        },
+
+        // A bracket pair straddling a direction change, for rule N0.
+        3 => {
+            const pair = bracket_pairs[self.rand.uintLessThan(usize, bracket_pairs.len)];
+            w.cp(pair[0]);
+            self.col += 1;
+            self.writeHebrewWord(w);
+            self.writeLatinWord(w);
+            w.cp(pair[1]);
+            self.col += 1;
+        },
+
+        else => unreachable,
+    }
+}
+
+/// A tiny UTF-8 sink over a fixed buffer. Codepoints are known-valid
+/// here (they come from the tables above), so encoding cannot fail.
+const Writer = struct {
+    buf: []u8,
+    len: usize = 0,
+
+    fn cp(self: *Writer, c: u21) void {
+        const n = std.unicode.utf8Encode(c, self.buf[self.len..]) catch unreachable;
+        self.len += n;
+    }
+};
+
+test "bidi: every profile emits valid utf8" {
+    const testing = std.testing;
+
+    for (std.enums.values(Profile)) |profile| {
+        var prng = std.Random.DefaultPrng.init(42);
+        var buf: [8192]u8 = undefined;
+        var writer: std.Io.Writer = .fixed(&buf);
+        var gen: Bidi = .{ .rand = prng.random(), .profile = profile };
+        try gen.generator().next(&writer, buf.len);
+
+        const out = writer.buffered();
+        try testing.expectEqual(buf.len, out.len);
+        try testing.expect(std.unicode.utf8ValidateSlice(out));
+    }
+}
+
+test "bidi: same seed produces same bytes" {
+    const testing = std.testing;
+
+    var a_buf: [4096]u8 = undefined;
+    var b_buf: [4096]u8 = undefined;
+
+    for (std.enums.values(Profile)) |profile| {
+        var a_prng = std.Random.DefaultPrng.init(7);
+        var a_writer: std.Io.Writer = .fixed(&a_buf);
+        var a: Bidi = .{ .rand = a_prng.random(), .profile = profile };
+        try a.generator().next(&a_writer, a_buf.len);
+
+        var b_prng = std.Random.DefaultPrng.init(7);
+        var b_writer: std.Io.Writer = .fixed(&b_buf);
+        var b: Bidi = .{ .rand = b_prng.random(), .profile = profile };
+        try b.generator().next(&b_writer, b_buf.len);
+
+        try testing.expectEqualSlices(u8, a_writer.buffered(), b_writer.buffered());
+    }
+}
+
+test "bidi: ascii profile stays in ascii" {
+    const testing = std.testing;
+
+    var prng = std.Random.DefaultPrng.init(1);
+    var buf: [4096]u8 = undefined;
+    var writer: std.Io.Writer = .fixed(&buf);
+    var gen: Bidi = .{ .rand = prng.random(), .profile = .ascii };
+    try gen.generator().next(&writer, buf.len);
+
+    // The whole no-regression argument rests on this corpus being able to
+    // take the fast path, so it must contain nothing above U+007F.
+    for (writer.buffered()) |c| try testing.expect(c < 0x80);
+}
+
+test "bidi: rtl profiles actually emit rtl" {
+    const testing = std.testing;
+    const unicode = @import("../unicode/main.zig");
+
+    for ([_]Profile{ .hebrew, .arabic, .persian }) |profile| {
+        var prng = std.Random.DefaultPrng.init(3);
+        var buf: [4096]u8 = undefined;
+        var writer: std.Io.Writer = .fixed(&buf);
+        var gen: Bidi = .{ .rand = prng.random(), .profile = profile };
+        try gen.generator().next(&writer, buf.len);
+
+        var rtl: usize = 0;
+        var view = try std.unicode.Utf8View.init(writer.buffered());
+        var it = view.iterator();
+        while (it.nextCodepoint()) |cp| {
+            switch (unicode.bidiClass(cp)) {
+                .r, .al => rtl += 1,
+                else => {},
+            }
+        }
+
+        // A corpus that generated no RTL would silently make every bidi
+        // benchmark measure the fast path instead.
+        try testing.expect(rtl > 100);
+    }
+}
+
+test "bidi: wraps at the configured column" {
+    const testing = std.testing;
+
+    var prng = std.Random.DefaultPrng.init(9);
+    var buf: [8192]u8 = undefined;
+    var writer: std.Io.Writer = .fixed(&buf);
+    var gen: Bidi = .{ .rand = prng.random(), .profile = .ascii, .cols = 40 };
+    try gen.generator().next(&writer, buf.len);
+
+    var lines = std.mem.splitScalar(u8, writer.buffered(), '\n');
+    var count: usize = 0;
+    while (lines.next()) |line| : (count += 1) {
+        // Skip the last line, which is truncated by the buffer bound.
+        if (lines.peek() == null) break;
+        // Words are emitted whole, so a line can overshoot by at most one
+        // word plus its separator.
+        try testing.expect(line.len <= 40 + 16);
+    }
+    try testing.expect(count > 10);
+}

--- a/src/synthetic/cli.zig
+++ b/src/synthetic/cli.zig
@@ -7,6 +7,7 @@ const cli = @import("../cli.zig");
 /// predictably named files under `cli/`.
 pub const Action = enum {
     ascii,
+    bidi,
     kitty,
     osc,
     utf8,
@@ -22,6 +23,7 @@ pub const Action = enum {
     pub fn Struct(comptime action: Action) type {
         return switch (action) {
             .ascii => @import("cli/Ascii.zig"),
+            .bidi => @import("cli/Bidi.zig"),
             .kitty => @import("cli/Kitty.zig"),
             .osc => @import("cli/Osc.zig"),
             .utf8 => @import("cli/Utf8.zig"),

--- a/src/synthetic/cli/Bidi.zig
+++ b/src/synthetic/cli/Bidi.zig
@@ -1,0 +1,85 @@
+const Bidi = @This();
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const synthetic = @import("../main.zig");
+
+pub const Options = struct {
+    /// Seed to use for deterministic generation. If unset, a time-based
+    /// seed is used by the generic synthetic CLI.
+    ///
+    /// Always set this when generating a corpus for benchmarking, so the
+    /// same bytes can be regenerated to compare revisions.
+    seed: ?u64 = null,
+
+    /// The script mix to generate. See `Profile` in `synthetic/Bidi.zig`.
+    profile: synthetic.Bidi.Profile = .ascii,
+
+    /// Wrap generated text at this many columns.
+    cols: u16 = 120,
+};
+
+opts: Options,
+
+pub fn create(
+    alloc: Allocator,
+    opts: Options,
+) !*Bidi {
+    if (opts.cols == 0) return error.InvalidValue;
+
+    const ptr = try alloc.create(Bidi);
+    errdefer alloc.destroy(ptr);
+    ptr.* = .{ .opts = opts };
+    return ptr;
+}
+
+pub fn destroy(self: *Bidi, alloc: Allocator) void {
+    alloc.destroy(self);
+}
+
+pub fn run(self: *Bidi, writer: *std.Io.Writer, rand: std.Random) !void {
+    var prng: ?std.Random.DefaultPrng = null;
+    var gen_rand = rand;
+    if (self.opts.seed) |seed| {
+        prng = std.Random.DefaultPrng.init(seed);
+        gen_rand = prng.?.random();
+    }
+
+    var gen: synthetic.Bidi = .{
+        .rand = gen_rand,
+        .profile = self.opts.profile,
+        .cols = self.opts.cols,
+    };
+
+    while (true) {
+        gen.next(writer, 1024) catch |err| {
+            const Error = error{ WriteFailed, BrokenPipe } || @TypeOf(err);
+            switch (@as(Error, err)) {
+                error.BrokenPipe => return, // stdout closed
+                error.WriteFailed => return, // fixed buffer full
+            }
+        };
+    }
+}
+
+test Bidi {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    const impl: *Bidi = try .create(alloc, .{ .seed = 1, .profile = .mixed });
+    defer impl.destroy(alloc);
+
+    var prng = std.Random.DefaultPrng.init(1);
+    const rand = prng.random();
+
+    var buf: [1024]u8 = undefined;
+    var writer: std.Io.Writer = .fixed(&buf);
+    try impl.run(&writer, rand);
+    try testing.expectEqual(@as(usize, 1024), writer.buffered().len);
+}
+
+test "Bidi: rejects zero columns" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    try testing.expectError(error.InvalidValue, Bidi.create(alloc, .{ .cols = 0 }));
+}

--- a/src/synthetic/main.zig
+++ b/src/synthetic/main.zig
@@ -16,6 +16,7 @@
 pub const cli = @import("cli.zig");
 
 pub const Generator = @import("Generator.zig");
+pub const Bidi = @import("Bidi.zig");
 pub const Bytes = @import("Bytes.zig");
 pub const Utf8 = @import("Utf8.zig");
 pub const Kitty = @import("Kitty.zig");

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -9786,6 +9786,90 @@ test "Screen: selectLine semantic all same content" {
     }
 }
 
+test "Screen: selectWord across scripts" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    const boundaries = &selection_codepoints.default_word_boundaries;
+
+    // Arabic separated by an Arabic comma. Without that comma in the
+    // boundary set nothing in the line breaks a word and a double click
+    // selects the entire sentence.
+    {
+        var s = try init(io, alloc, .{ .cols = 20, .rows = 3, .max_scrollback_bytes = 0 });
+        defer s.deinit();
+        try s.testWriteString("\u{0628}\u{0627}\u{0628}\u{060C}\u{0645}\u{064A}\u{0645}");
+
+        // Click on the first word.
+        const sel = s.selectWord(s.pages.pin(.{ .active = .{
+            .x = 1,
+            .y = 0,
+        } }).?, boundaries).?;
+        try testing.expectEqual(@as(u16, 0), s.pages.pointFromPin(.active, sel.start()).?.active.x);
+        try testing.expectEqual(@as(u16, 2), s.pages.pointFromPin(.active, sel.end()).?.active.x);
+    }
+
+    // Hebrew separated by a maqaf, which reads as a hyphen.
+    {
+        var s = try init(io, alloc, .{ .cols = 20, .rows = 3, .max_scrollback_bytes = 0 });
+        defer s.deinit();
+        try s.testWriteString("\u{05D0}\u{05D1}\u{05BE}\u{05D2}\u{05D3}");
+
+        const sel = s.selectWord(s.pages.pin(.{ .active = .{
+            .x = 0,
+            .y = 0,
+        } }).?, boundaries).?;
+        try testing.expectEqual(@as(u16, 0), s.pages.pointFromPin(.active, sel.start()).?.active.x);
+        try testing.expectEqual(@as(u16, 1), s.pages.pointFromPin(.active, sel.end()).?.active.x);
+    }
+
+    // Eastern Arabic-Indic digits are word characters, not boundaries,
+    // so a Persian number selects as one word.
+    {
+        var s = try init(io, alloc, .{ .cols = 20, .rows = 3, .max_scrollback_bytes = 0 });
+        defer s.deinit();
+        try s.testWriteString("\u{06F1}\u{06F2}\u{06F3} \u{06AF}");
+
+        const sel = s.selectWord(s.pages.pin(.{ .active = .{
+            .x = 1,
+            .y = 0,
+        } }).?, boundaries).?;
+        try testing.expectEqual(@as(u16, 0), s.pages.pointFromPin(.active, sel.start()).?.active.x);
+        try testing.expectEqual(@as(u16, 2), s.pages.pointFromPin(.active, sel.end()).?.active.x);
+    }
+}
+
+test "Screen: selectWord keeps a persian zwnj compound together" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    var s = try init(io, alloc, .{ .cols = 20, .rows = 3, .max_scrollback_bytes = 0 });
+    defer s.deinit();
+
+    // "می‌رود": mim, yeh, ZWNJ, reh, waw, dal. Persian joins the two
+    // halves of a compound with a zero width non-joiner, which breaks
+    // the cursive connection without being a word break. Double
+    // clicking anywhere in it has to select the whole compound.
+    //
+    // This works because the joiner has no width of its own, so it is
+    // stored as part of the preceding cell's grapheme and never appears
+    // as a cell the word scan can stop at.
+    try s.testWriteString("\u{0645}\u{06CC}\u{200C}\u{0631}\u{0648}\u{062F} x");
+
+    const boundaries = &selection_codepoints.default_word_boundaries;
+    const sel = s.selectWord(s.pages.pin(.{ .active = .{
+        .x = 0,
+        .y = 0,
+    } }).?, boundaries).?;
+
+    // Five cells, because the joiner shares a cell with the yeh before
+    // it, and all five belong to one word.
+    try testing.expectEqual(@as(u16, 0), s.pages.pointFromPin(.active, sel.start()).?.active.x);
+    try testing.expectEqual(@as(u16, 4), s.pages.pointFromPin(.active, sel.end()).?.active.x);
+}
+
 test "Screen: selectWord" {
     const testing = std.testing;
     const alloc = testing.allocator;

--- a/src/terminal/formatter.zig
+++ b/src/terminal/formatter.zig
@@ -81,6 +81,21 @@ pub const CodepointMap = struct {
 };
 
 /// Common encoding options regardless of what exact formatter is used.
+/// The Unicode bidirectional formatting characters: the marks, the
+/// embeddings and overrides with their terminator, and the isolates with
+/// theirs.
+fn isBidiControl(cp: u21) bool {
+    return switch (cp) {
+        0x200E, // LEFT-TO-RIGHT MARK
+        0x200F, // RIGHT-TO-LEFT MARK
+        0x061C, // ARABIC LETTER MARK
+        0x202A...0x202E, // LRE, RLE, PDF, LRO, RLO
+        0x2066...0x2069, // LRI, RLI, FSI, PDI
+        => true,
+        else => false,
+    };
+}
+
 pub const Options = struct {
     /// The format to emit.
     emit: Format,
@@ -98,6 +113,18 @@ pub const Options = struct {
     /// Replace matching Unicode codepoints with some other values.
     /// This will use the last matching range found in the list.
     codepoint_map: ?std.MultiArrayList(CodepointMap) = .{},
+
+    /// Drop the Unicode bidirectional formatting characters.
+    ///
+    /// These are part of the text a program wrote and are meaningful, so
+    /// they are kept by default: removing them changes what the text
+    /// says, and a copy that does not round trip is worse than one
+    /// carrying characters the destination ignores.
+    ///
+    /// It is offered because a selection that starts or ends inside an
+    /// embedding or isolate carries an unbalanced control, which
+    /// resolves differently once pasted somewhere else.
+    strip_bidi_controls: bool = false,
 
     /// Set a background and foreground color to use for the "screen".
     /// For styled formats, this will emit the proper sequences or styles.
@@ -1386,6 +1413,8 @@ pub const PageFormatter = struct {
         writer: *std.Io.Writer,
         codepoint: u21,
     ) !void {
+        if (self.opts.strip_bidi_controls and isBidiControl(codepoint)) return;
+
         // Search for our replacement
         const r_: ?CodepointMap.Replacement = replacement: {
             const map = self.opts.codepoint_map orelse break :replacement null;
@@ -6374,4 +6403,72 @@ test "Page HTML hyperlink point map maps closing to previous cell" {
     for (closing_idx..closing_idx + "</a>".len) |i| {
         try testing.expectEqual(expected_coord, point_map.items[i]);
     }
+}
+
+test "strip_bidi_controls removes formatting characters" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    var s = try Screen.init(io, alloc, .{ .cols = 40, .rows = 3, .max_scrollback_bytes = 0 });
+    defer s.deinit();
+
+    // Latin, an isolate around some Hebrew, then Latin again.
+    try s.testWriteString("a\u{2066}\u{05D0}\u{05D1}\u{2069}b");
+
+    // Kept by default. The controls are part of what the program wrote,
+    // and a copy that silently differs from the source is worse than one
+    // carrying characters the destination may ignore.
+    {
+        var aw: std.Io.Writer.Allocating = .init(alloc);
+        defer aw.deinit();
+        var f: ScreenFormatter = .init(&s, .{ .emit = .plain, .trim = false });
+        try f.format(&aw.writer);
+        try testing.expect(std.mem.indexOf(u8, aw.written(), "\u{2066}") != null);
+        try testing.expect(std.mem.indexOf(u8, aw.written(), "\u{2069}") != null);
+    }
+
+    // Stripped on request, leaving the text itself untouched and in the
+    // order it was written.
+    {
+        var aw: std.Io.Writer.Allocating = .init(alloc);
+        defer aw.deinit();
+        var f: ScreenFormatter = .init(&s, .{
+            .emit = .plain,
+            .trim = false,
+            .strip_bidi_controls = true,
+        });
+        try f.format(&aw.writer);
+
+        try testing.expect(std.mem.indexOf(u8, aw.written(), "\u{2066}") == null);
+        try testing.expect(std.mem.indexOf(u8, aw.written(), "\u{2069}") == null);
+        try testing.expect(std.mem.startsWith(u8, aw.written(), "a\u{05D0}\u{05D1}b"));
+    }
+}
+
+test "copied text is always in logical order" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    var s = try Screen.init(io, alloc, .{ .cols = 40, .rows = 3, .max_scrollback_bytes = 0 });
+    defer s.deinit();
+
+    // Right-to-left text is displayed reversed but stored in the order
+    // the program wrote it. Copying must produce the stored order.
+    //
+    // Putting visual order on the clipboard would look right when pasted
+    // into something that does not reorder, and be wrong everywhere
+    // else: it would not compare equal, would not grep, and would not
+    // survive being pasted back. Every other program on the system puts
+    // logical order on the clipboard.
+    const written = "abc \u{05D0}\u{05D1}\u{05D2} 123";
+    try s.testWriteString(written);
+
+    var aw: std.Io.Writer.Allocating = .init(alloc);
+    defer aw.deinit();
+    var f: ScreenFormatter = .init(&s, .{ .emit = .plain, .trim = true });
+    try f.format(&aw.writer);
+
+    try testing.expect(std.mem.startsWith(u8, aw.written(), written));
 }

--- a/src/terminal/point.zig
+++ b/src/terminal/point.zig
@@ -88,9 +88,133 @@ pub const Point = union(Tag) {
     }
 };
 
+/// The coordinate space a column is expressed in.
+///
+/// A terminal grid has exactly two of these once bidirectional text is
+/// supported, and confusing them is the defect class that dominates bidi
+/// implementations. See `Col` below.
+pub const ColSpace = enum {
+    /// The order characters are stored, transmitted, and typed. This is what
+    /// the PTY delivers, what escape sequences address, and what must go on
+    /// the clipboard. Logical order is authoritative: it is the only order in
+    /// which the terminal's contract with the running program is defined.
+    logical,
+
+    /// The left-to-right order glyphs appear on the physical screen. It is
+    /// derived from logical order and exists only for display and for
+    /// interpreting pointer input. It is never written back to the screen.
+    visual,
+};
+
+/// A column index in a specific coordinate space.
+///
+/// Today every column in Ghostty is logical, because no reordering exists
+/// yet. That makes this the cheapest possible moment to introduce the
+/// distinction: the conversion is mechanical while there is exactly one
+/// space in play, and it becomes a compile error to mix them the moment a
+/// second space appears.
+///
+/// This is a non-exhaustive enum rather than a struct so that it is a truly
+/// distinct type with a defined backing integer: it cannot be implicitly
+/// converted to or from `size.CellCountInt`, and `LogicalCol` cannot be
+/// passed where `VisualCol` is expected. It compiles to the same `u16` as
+/// the bare integer it replaces, so there is no runtime or memory cost.
+///
+/// Conversions to and from the backing integer go through `from` and `int`.
+/// Callers must never reach for `@enumFromInt`/`@intFromEnum` directly, and
+/// must never use `@intCast`/`@bitCast` to move between the two spaces: the
+/// whole point of the type is that such a move is a deliberate, greppable
+/// act. See `assumeIdentity` for the one sanctioned escape hatch.
+fn Col(comptime col_space: ColSpace) type {
+    return enum(size.CellCountInt) {
+        _,
+
+        const Self = @This();
+
+        /// The coordinate space this column lives in. Reflecting the
+        /// comptime parameter into a decl both documents the space and
+        /// keeps the two instantiations distinct types.
+        pub const space: ColSpace = col_space;
+
+        /// The first column.
+        pub const zero: Self = @enumFromInt(0);
+
+        /// Build a column from a raw index.
+        pub inline fn from(v: size.CellCountInt) Self {
+            return @enumFromInt(v);
+        }
+
+        /// The raw index. Use this only at the boundary where a plain
+        /// integer is genuinely required (indexing a slice, an escape
+        /// sequence parameter, the C ABI).
+        pub inline fn int(self: Self) size.CellCountInt {
+            return @intFromEnum(self);
+        }
+
+        pub inline fn eql(self: Self, other: Self) bool {
+            return self.int() == other.int();
+        }
+
+        pub inline fn order(self: Self, other: Self) std.math.Order {
+            return std.math.order(self.int(), other.int());
+        }
+
+        pub inline fn lessThan(self: Self, other: Self) bool {
+            return self.int() < other.int();
+        }
+
+        pub inline fn min(self: Self, other: Self) Self {
+            return .from(@min(self.int(), other.int()));
+        }
+
+        pub inline fn max(self: Self, other: Self) Self {
+            return .from(@max(self.int(), other.int()));
+        }
+
+        /// Offset by a count of cells. These have the same overflow
+        /// semantics as the raw integer arithmetic they replace, so
+        /// behavior is unchanged from before the type existed.
+        pub inline fn add(self: Self, v: size.CellCountInt) Self {
+            return .from(self.int() + v);
+        }
+
+        pub inline fn sub(self: Self, v: size.CellCountInt) Self {
+            return .from(self.int() - v);
+        }
+
+        /// The identity mapping between spaces.
+        ///
+        /// While bidi is disabled (and on any row with no right-to-left
+        /// content, which is the overwhelming majority) logical and visual
+        /// order coincide, so this conversion is correct. It is spelled
+        /// "assume" so that every site relying on that coincidence is
+        /// greppable: when reordering lands, each one must be revisited and
+        /// either justified or routed through the row's bidi map.
+        pub inline fn assumeIdentity(
+            self: Self,
+            comptime to: ColSpace,
+        ) Col(to) {
+            return .from(self.int());
+        }
+    };
+}
+
+/// A column in logical (storage) order. See `Col`.
+pub const LogicalCol = Col(.logical);
+
+/// A column in visual (display) order. See `Col`.
+pub const VisualCol = Col(.visual);
+
 pub const Coordinate = extern struct {
     /// x can use size.CellCountInt because the number of columns
     /// can't ever be more than a valid number of columns in a Page.
+    ///
+    /// This is deliberately NOT a `LogicalCol`. A `Coordinate` is
+    /// space-agnostic: a `viewport` coordinate built from a mouse position
+    /// is a visual column, while one used for cursor addressing is logical.
+    /// Committing this field to one space would make the other one wrong.
+    /// Callers state which space they mean at the point of use via
+    /// `logicalX`/`visualX`.
     x: size.CellCountInt = 0,
 
     /// y does not use size.CellCountInt because certain coordinate
@@ -101,4 +225,103 @@ pub const Coordinate = extern struct {
     pub fn eql(self: Coordinate, other: Coordinate) bool {
         return self.x == other.x and self.y == other.y;
     }
+
+    /// Interpret this coordinate's column as logical (storage) order.
+    /// Use this when the coordinate came from the screen, the cursor, or
+    /// an escape sequence.
+    pub inline fn logicalX(self: Coordinate) LogicalCol {
+        return .from(self.x);
+    }
+
+    /// Interpret this coordinate's column as visual (display) order.
+    /// Use this when the coordinate came from a pointer position or any
+    /// other on-screen measurement.
+    pub inline fn visualX(self: Coordinate) VisualCol {
+        return .from(self.x);
+    }
 };
+
+test "Col: distinct types with a zero-cost representation" {
+    const testing = std.testing;
+
+    // The two spaces are genuinely different types. Passing one where the
+    // other is expected is a compile error, which is the entire point.
+    try testing.expect(LogicalCol != VisualCol);
+    try testing.expectEqual(ColSpace.logical, LogicalCol.space);
+    try testing.expectEqual(ColSpace.visual, VisualCol.space);
+
+    // Zero-cost: identical size and alignment to the bare integer it
+    // replaces, so adopting it cannot change a struct layout or an ABI.
+    inline for (.{ LogicalCol, VisualCol }) |T| {
+        try testing.expectEqual(@sizeOf(size.CellCountInt), @sizeOf(T));
+        try testing.expectEqual(@alignOf(size.CellCountInt), @alignOf(T));
+        try testing.expectEqual(@bitSizeOf(size.CellCountInt), @bitSizeOf(T));
+    }
+}
+
+test "Col: conversion round trip" {
+    const testing = std.testing;
+
+    for ([_]size.CellCountInt{ 0, 1, 42, 79, 80, 1000, std.math.maxInt(size.CellCountInt) }) |v| {
+        try testing.expectEqual(v, LogicalCol.from(v).int());
+        try testing.expectEqual(v, VisualCol.from(v).int());
+    }
+
+    try testing.expectEqual(@as(size.CellCountInt, 0), LogicalCol.zero.int());
+    try testing.expectEqual(@as(size.CellCountInt, 0), VisualCol.zero.int());
+}
+
+test "Col: comparison and ordering" {
+    const testing = std.testing;
+
+    const a: LogicalCol = .from(3);
+    const b: LogicalCol = .from(7);
+    const c: LogicalCol = .from(3);
+
+    try testing.expect(a.eql(c));
+    try testing.expect(!a.eql(b));
+    try testing.expect(a.lessThan(b));
+    try testing.expect(!b.lessThan(a));
+
+    try testing.expectEqual(std.math.Order.lt, a.order(b));
+    try testing.expectEqual(std.math.Order.gt, b.order(a));
+    try testing.expectEqual(std.math.Order.eq, a.order(c));
+
+    try testing.expectEqual(a, a.min(b));
+    try testing.expectEqual(b, a.max(b));
+}
+
+test "Col: arithmetic matches the raw integer it replaces" {
+    const testing = std.testing;
+
+    const a: VisualCol = .from(10);
+    try testing.expectEqual(@as(size.CellCountInt, 13), a.add(3).int());
+    try testing.expectEqual(@as(size.CellCountInt, 7), a.sub(3).int());
+    try testing.expectEqual(@as(size.CellCountInt, 10), a.add(5).sub(5).int());
+}
+
+test "Col: identity mapping between spaces" {
+    const testing = std.testing;
+
+    // Correct only while logical and visual order coincide, which is the
+    // case for every row without RTL content. Spelled "assume" so the
+    // reliance is greppable when reordering lands.
+    const l: LogicalCol = .from(12);
+    const v: VisualCol = l.assumeIdentity(.visual);
+    try testing.expectEqual(@as(size.CellCountInt, 12), v.int());
+    try testing.expect(VisualCol == @TypeOf(v));
+
+    const back: LogicalCol = v.assumeIdentity(.logical);
+    try testing.expectEqual(l, back);
+    try testing.expect(LogicalCol == @TypeOf(back));
+}
+
+test "Coordinate: space is stated at the point of use" {
+    const testing = std.testing;
+
+    const coord: Coordinate = .{ .x = 5, .y = 2 };
+    try testing.expectEqual(@as(size.CellCountInt, 5), coord.logicalX().int());
+    try testing.expectEqual(@as(size.CellCountInt, 5), coord.visualX().int());
+    try testing.expect(LogicalCol == @TypeOf(coord.logicalX()));
+    try testing.expect(VisualCol == @TypeOf(coord.visualX()));
+}

--- a/src/terminal/selection_codepoints.zig
+++ b/src/terminal/selection_codepoints.zig
@@ -3,7 +3,10 @@
 // subsystems can import it without introducing a number of
 // dependencies.
 
-/// Default boundary characters for word selection: ` \t'"│`|:;,()[]{}<>$`
+/// Default boundary characters for word selection.
+///
+/// Latin: ` \t'"│`|:;,()[]{}<>$`, plus punctuation from right-to-left
+/// scripts and the dashes and angle quotes those scripts commonly use.
 pub const default_word_boundaries = [_]u21{
     0, // null
     ' ', // space
@@ -25,6 +28,34 @@ pub const default_word_boundaries = [_]u21{
     '<', // less than
     '>', // greater than
     '$', // dollar
+
+    // Punctuation from right-to-left scripts, which separates words
+    // exactly as its Latin counterparts do. Without these, double
+    // clicking anywhere in an Arabic or Persian sentence selects the
+    // whole sentence, because nothing in it is recognized as a break.
+    //
+    // The letters and digits of those scripts deliberately do NOT
+    // appear here: a word character is anything that is not a boundary,
+    // so they are already handled. That includes the Eastern
+    // Arabic-Indic digits Persian uses, and the zero width non-joiner
+    // that holds Persian compounds together, which is stored as part of
+    // its neighbour's grapheme and so never reaches this list at all.
+    '\u{060C}', // Arabic comma
+    '\u{061B}', // Arabic semicolon
+    '\u{061F}', // Arabic question mark
+    '\u{06D4}', // Arabic full stop
+    '\u{060D}', // Arabic date separator
+    '\u{066C}', // Arabic thousands separator
+    '\u{05BE}', // Hebrew maqaf, which joins words but reads as a hyphen
+    '\u{05C0}', // Hebrew paseq
+    '\u{05C3}', // Hebrew sof pasuq
+    '\u{05F3}', // Hebrew geresh
+    '\u{05F4}', // Hebrew gershayim
+    '\u{2010}', // hyphen
+    '\u{2013}', // en dash
+    '\u{2014}', // em dash
+    '\u{00AB}', // left-pointing double angle quotation
+    '\u{00BB}', // right-pointing double angle quotation
 };
 
 /// Default whitespace characters trimmed from line selections.

--- a/src/unicode/bidi_props.zig
+++ b/src/unicode/bidi_props.zig
@@ -1,0 +1,298 @@
+//! Unicode Bidirectional Algorithm (UAX #9) properties per codepoint.
+//!
+//! These live in a lookup table separate from `props.zig` on purpose. The
+//! properties in `Properties` are read for every printed cell by
+//! `codepointWidth` and `graphemeBreak`; the properties here are only read
+//! by the bidi implementation. Folding them together would widen the hot
+//! table for no benefit to the common path.
+//!
+//! The values are derived from the UCD at build time (see `bidi_uucode.zig`),
+//! so this file only describes the shape of the data, never the data itself.
+
+const std = @import("std");
+
+/// Bidi_Class (UAX #9, Table 4).
+///
+/// Names are the standard UAX #9 abbreviations rather than the spelled-out
+/// UCD long names. Every rule in the specification (W1-W7, N0-N2, I1-I2,
+/// ...) is written in terms of these abbreviations, so matching them keeps
+/// an implementation reviewable against the spec side by side.
+///
+/// The default for an *unassigned* codepoint is not `l`. It varies by block
+/// (see the `@missing` lines in `DerivedBidiClass.txt`): unassigned
+/// codepoints in the Hebrew block default to `r`, in the Arabic blocks to
+/// `al`, and in the Currency Symbols block to `et`. The generated table
+/// encodes those defaults; callers must not assume `l` for unknown input.
+pub const BidiClass = enum(u5) {
+    // Strong
+    /// L: Left_To_Right
+    l,
+    /// R: Right_To_Left
+    r,
+    /// AL: Arabic_Letter
+    al,
+
+    // Weak
+    /// EN: European_Number
+    en,
+    /// ES: European_Separator
+    es,
+    /// ET: European_Terminator
+    et,
+    /// AN: Arabic_Number
+    an,
+    /// CS: Common_Separator
+    cs,
+    /// NSM: Nonspacing_Mark
+    nsm,
+    /// BN: Boundary_Neutral
+    bn,
+
+    // Neutral
+    /// B: Paragraph_Separator
+    b,
+    /// S: Segment_Separator
+    s,
+    /// WS: White_Space
+    ws,
+    /// ON: Other_Neutral
+    on,
+
+    // Explicit formatting
+    /// LRE: Left_To_Right_Embedding
+    lre,
+    /// LRO: Left_To_Right_Override
+    lro,
+    /// RLE: Right_To_Left_Embedding
+    rle,
+    /// RLO: Right_To_Left_Override
+    rlo,
+    /// PDF: Pop_Directional_Format
+    pdf,
+    /// LRI: Left_To_Right_Isolate
+    lri,
+    /// RLI: Right_To_Left_Isolate
+    rli,
+    /// FSI: First_Strong_Isolate
+    fsi,
+    /// PDI: Pop_Directional_Isolate
+    pdi,
+
+    /// True for the strong classes (L, R, AL). These are the classes that
+    /// determine paragraph direction under rules P2/P3.
+    pub fn isStrong(self: BidiClass) bool {
+        return switch (self) {
+            .l, .r, .al => true,
+            else => false,
+        };
+    }
+
+    /// True for the isolate initiators (LRI, RLI, FSI). Note this
+    /// deliberately excludes PDI, which terminates an isolate rather
+    /// than initiating one.
+    pub fn isIsolateInitiator(self: BidiClass) bool {
+        return switch (self) {
+            .lri, .rli, .fsi => true,
+            else => false,
+        };
+    }
+
+    /// True for the explicit embedding and override formatting characters
+    /// (LRE, LRO, RLE, RLO, PDF). Isolates are not included: they are
+    /// retained by rule X9 whereas these are removed.
+    pub fn isExplicitFormatting(self: BidiClass) bool {
+        return switch (self) {
+            .lre, .lro, .rle, .rlo, .pdf => true,
+            else => false,
+        };
+    }
+
+    /// True for characters removed by rule X9 (the explicit formatting
+    /// characters plus BN). Implementations that do not literally remove
+    /// them must treat them as no-ops per X9's "retaining" note.
+    pub fn isRemovedByX9(self: BidiClass) bool {
+        return switch (self) {
+            .lre, .lro, .rle, .rlo, .pdf, .bn => true,
+            else => false,
+        };
+    }
+};
+
+/// Bidi_Paired_Bracket_Type (UAX #9, used by rule N0).
+pub const BidiPairedBracketType = enum(u2) {
+    /// n: not a paired bracket
+    none,
+    /// o: opening paired bracket
+    open,
+    /// c: closing paired bracket
+    close,
+};
+
+/// The bidi property set for a single codepoint.
+///
+/// ## Encoding
+///
+/// `Bidi_Mirroring_Glyph` and `Bidi_Paired_Bracket` are codepoint-valued
+/// properties. Storing them as absolute codepoints would give the generated
+/// table one distinct entry per mirrored codepoint (428 as of Unicode 17).
+/// They are stored as *deltas* from the codepoint instead, which collapses
+/// them to 36 and 6 distinct values respectively, because mirrored pairs are
+/// overwhelmingly adjacent (`(` / `)` differ by one). The whole table has 67
+/// distinct entries as a result, which keeps both the generated stage3 array
+/// and the generator's dedup cost small.
+///
+/// A delta of zero means "no mapping". That is unambiguous: no codepoint in
+/// `BidiMirroring.txt` maps to itself. `bidi_uucode.zig` asserts this when
+/// generating the table, so the invariant cannot silently rot across a UCD
+/// update.
+///
+/// Note that `mirrored` is *not* redundant with `mirror_delta`. Bidi_Mirrored
+/// is a strict superset of Bidi_Mirroring_Glyph: 554 codepoints have
+/// Bidi_Mirrored=Y but only 428 have a mirroring glyph. U+2202 PARTIAL
+/// DIFFERENTIAL is mirrored with no designated glyph, and rule L4 still
+/// applies to it.
+pub const BidiProperties = packed struct(u32) {
+    /// Bidi_Class.
+    class: BidiClass = .l,
+
+    /// Bidi_Paired_Bracket_Type.
+    bracket: BidiPairedBracketType = .none,
+
+    /// Bidi_Mirrored. Rule L4 mirrors a character when this is set and the
+    /// resolved embedding level is odd.
+    mirrored: bool = false,
+
+    /// Bidi_Paired_Bracket as a delta from the codepoint. Zero means the
+    /// codepoint has no paired bracket. Observed range is [-3, 3].
+    bracket_delta: i3 = 0,
+
+    /// Bidi_Mirroring_Glyph as a delta from the codepoint. Zero means the
+    /// codepoint has no mirroring glyph. Observed range is [-2527, 2527].
+    mirror_delta: i13 = 0,
+
+    /// Explicit padding to give the struct a power-of-two backing integer.
+    /// See the equivalent note in `props.zig`: a non-power-of-two backing
+    /// integer makes Zig lower loads and stores through exotic-width LLVM
+    /// integer types, which blocks register promotion in hot paths.
+    _padding: u8 = 0,
+
+    /// The mirroring glyph for this codepoint, or null if it has none.
+    /// `cp` must be the codepoint these properties were looked up with.
+    pub fn mirroringGlyph(self: BidiProperties, cp: u21) ?u21 {
+        if (self.mirror_delta == 0) return null;
+        const v: i32 = @as(i32, cp) + @as(i32, self.mirror_delta);
+        return std.math.cast(u21, v);
+    }
+
+    /// The paired bracket for this codepoint, or null if it is not a paired
+    /// bracket. `cp` must be the codepoint these properties were looked up
+    /// with.
+    pub fn pairedBracket(self: BidiProperties, cp: u21) ?u21 {
+        if (self.bracket == .none) return null;
+        const v: i32 = @as(i32, cp) + @as(i32, self.bracket_delta);
+        return std.math.cast(u21, v);
+    }
+
+    // Needed for lut.Generator
+    pub fn eql(a: BidiProperties, b: BidiProperties) bool {
+        return a.class == b.class and
+            a.bracket == b.bracket and
+            a.mirrored == b.mirrored and
+            a.bracket_delta == b.bracket_delta and
+            a.mirror_delta == b.mirror_delta;
+    }
+
+    // Needed for lut.Generator
+    pub fn format(
+        self: BidiProperties,
+        writer: *std.Io.Writer,
+    ) !void {
+        try writer.print(
+            \\.{{
+            \\    .class= .{s},
+            \\    .bracket= .{s},
+            \\    .mirrored= {},
+            \\    .bracket_delta= {},
+            \\    .mirror_delta= {},
+            \\}}
+        , .{
+            @tagName(self.class),
+            @tagName(self.bracket),
+            self.mirrored,
+            self.bracket_delta,
+            self.mirror_delta,
+        });
+    }
+};
+
+test "BidiClass predicates" {
+    const testing = std.testing;
+
+    try testing.expect(BidiClass.l.isStrong());
+    try testing.expect(BidiClass.r.isStrong());
+    try testing.expect(BidiClass.al.isStrong());
+    try testing.expect(!BidiClass.en.isStrong());
+    try testing.expect(!BidiClass.on.isStrong());
+
+    try testing.expect(BidiClass.lri.isIsolateInitiator());
+    try testing.expect(BidiClass.rli.isIsolateInitiator());
+    try testing.expect(BidiClass.fsi.isIsolateInitiator());
+    // PDI terminates an isolate, it does not initiate one.
+    try testing.expect(!BidiClass.pdi.isIsolateInitiator());
+
+    try testing.expect(BidiClass.lre.isExplicitFormatting());
+    try testing.expect(BidiClass.rlo.isExplicitFormatting());
+    try testing.expect(BidiClass.pdf.isExplicitFormatting());
+    // Isolates are retained by X9, not explicit formatting.
+    try testing.expect(!BidiClass.lri.isExplicitFormatting());
+    try testing.expect(!BidiClass.bn.isExplicitFormatting());
+
+    try testing.expect(BidiClass.bn.isRemovedByX9());
+    try testing.expect(BidiClass.pdf.isRemovedByX9());
+    try testing.expect(!BidiClass.lri.isRemovedByX9());
+    try testing.expect(!BidiClass.l.isRemovedByX9());
+}
+
+test "BidiProperties delta decoding" {
+    const testing = std.testing;
+
+    // U+0028 LEFT PARENTHESIS mirrors to and pairs with U+0029.
+    const paren: BidiProperties = .{
+        .class = .on,
+        .bracket = .open,
+        .mirrored = true,
+        .bracket_delta = 1,
+        .mirror_delta = 1,
+    };
+    try testing.expectEqual(@as(?u21, 0x0029), paren.mirroringGlyph(0x0028));
+    try testing.expectEqual(@as(?u21, 0x0029), paren.pairedBracket(0x0028));
+
+    // Negative deltas.
+    const close: BidiProperties = .{
+        .class = .on,
+        .bracket = .close,
+        .mirrored = true,
+        .bracket_delta = -1,
+        .mirror_delta = -1,
+    };
+    try testing.expectEqual(@as(?u21, 0x0028), close.mirroringGlyph(0x0029));
+    try testing.expectEqual(@as(?u21, 0x0028), close.pairedBracket(0x0029));
+
+    // Mirrored with no designated glyph, e.g. U+2202. `mirrored` must not
+    // be inferred from `mirror_delta`.
+    const partial: BidiProperties = .{ .class = .on, .mirrored = true };
+    try testing.expect(partial.mirrored);
+    try testing.expectEqual(@as(?u21, null), partial.mirroringGlyph(0x2202));
+    try testing.expectEqual(@as(?u21, null), partial.pairedBracket(0x2202));
+
+    // Plain letter: no mirroring, no bracket.
+    const a: BidiProperties = .{ .class = .l };
+    try testing.expectEqual(@as(?u21, null), a.mirroringGlyph('a'));
+    try testing.expectEqual(@as(?u21, null), a.pairedBracket('a'));
+}
+
+test "BidiProperties is a word wide" {
+    const testing = std.testing;
+    try testing.expectEqual(@as(usize, 4), @sizeOf(BidiProperties));
+    try testing.expectEqual(@as(usize, 32), @bitSizeOf(BidiProperties));
+}

--- a/src/unicode/bidi_table.zig
+++ b/src/unicode/bidi_table.zig
@@ -1,0 +1,18 @@
+const BidiProperties = @import("bidi_props.zig").BidiProperties;
+const lut = @import("lut.zig");
+
+/// The bidi lookup tables for Ghostty.
+pub const table = table: {
+    // This is only available after running a generator as part of the Ghostty
+    // build.zig process, but due to Zig's lazy analysis we can still reference
+    // it here.
+    //
+    // An example process is the `main` in `bidi_uucode.zig`
+    const generated = @import("bidi_tables").Tables(BidiProperties);
+    const Tables = lut.Tables(BidiProperties);
+    break :table Tables{
+        .stage1 = &generated.stage1,
+        .stage2 = &generated.stage2,
+        .stage3 = &generated.stage3,
+    };
+};

--- a/src/unicode/bidi_uucode.zig
+++ b/src/unicode/bidi_uucode.zig
@@ -1,0 +1,179 @@
+const bidi_uucode = @This();
+const std = @import("std");
+const uucode = @import("uucode");
+const lut = @import("lut.zig");
+const BidiClass = @import("bidi_props.zig").BidiClass;
+const BidiPairedBracketType = @import("bidi_props.zig").BidiPairedBracketType;
+const BidiProperties = @import("bidi_props.zig").BidiProperties;
+
+/// Errors that can only occur while generating the table, i.e. at build
+/// time on the host. They signal that the UCD has grown values our packed
+/// encoding can no longer represent, which must fail the build loudly
+/// rather than silently truncate.
+pub const Error = error{
+    BracketDeltaOutOfRange,
+    MirrorDeltaOutOfRange,
+    MirrorsToItself,
+};
+
+pub fn get(cp: u21) Error!BidiProperties {
+    // u21 can encode values past the last Unicode codepoint. Those are not
+    // characters at all, so there is no meaningful bidi class for them; the
+    // `l` default is arbitrary but harmless. This is not the same thing as
+    // an *unassigned* codepoint, which does have a well-defined default
+    // that uucode derives from the `@missing` lines in DerivedBidiClass.txt.
+    if (cp > uucode.config.max_code_point) return .{};
+
+    const mirror_delta: i13 = delta: {
+        const glyph = uucode.get(.bidi_mirroring, cp) orelse break :delta 0;
+
+        // Zero is our sentinel for "no mirroring glyph", so a codepoint that
+        // mirrors to itself would be indistinguishable from one that does
+        // not mirror at all. No such codepoint exists today; if the UCD ever
+        // adds one the encoding in `bidi_props.zig` needs to change.
+        if (glyph == cp) return Error.MirrorsToItself;
+
+        break :delta std.math.cast(
+            i13,
+            @as(i32, glyph) - @as(i32, cp),
+        ) orelse return Error.MirrorDeltaOutOfRange;
+    };
+
+    const bracket: struct { kind: BidiPairedBracketType, cp: u21 } =
+        switch (uucode.get(.bidi_paired_bracket, cp)) {
+            .open => |v| .{ .kind = .open, .cp = v },
+            .close => |v| .{ .kind = .close, .cp = v },
+            .none => .{ .kind = .none, .cp = cp },
+        };
+
+    const bracket_delta: i3 = if (bracket.kind == .none) 0 else std.math.cast(
+        i3,
+        @as(i32, bracket.cp) - @as(i32, cp),
+    ) orelse return Error.BracketDeltaOutOfRange;
+
+    return .{
+        .class = fromUucode(uucode.get(.bidi_class, cp)),
+        .bracket = bracket.kind,
+        .mirrored = uucode.get(.is_bidi_mirrored, cp),
+        .bracket_delta = bracket_delta,
+        .mirror_delta = mirror_delta,
+    };
+}
+
+/// Map uucode's spelled-out Bidi_Class names onto the UAX #9 abbreviations
+/// we use. This switch is deliberately exhaustive with no `else` branch so
+/// that a uucode upgrade which adds a class fails to compile instead of
+/// silently folding the new class into an existing one.
+fn fromUucode(class: uucode.types.BidiClass) BidiClass {
+    return switch (class) {
+        .left_to_right => .l,
+        .right_to_left => .r,
+        .right_to_left_arabic => .al,
+
+        .european_number => .en,
+        .european_number_separator => .es,
+        .european_number_terminator => .et,
+        .arabic_number => .an,
+        .common_number_separator => .cs,
+        .nonspacing_mark => .nsm,
+        .boundary_neutral => .bn,
+
+        .paragraph_separator => .b,
+        .segment_separator => .s,
+        .whitespace => .ws,
+        .other_neutrals => .on,
+
+        .left_to_right_embedding => .lre,
+        .left_to_right_override => .lro,
+        .right_to_left_embedding => .rle,
+        .right_to_left_override => .rlo,
+        .pop_directional_format => .pdf,
+        .left_to_right_isolate => .lri,
+        .right_to_left_isolate => .rli,
+        .first_strong_isolate => .fsi,
+        .pop_directional_isolate => .pdi,
+    };
+}
+
+/// Runnable binary to generate the lookup tables and output to stdout.
+pub fn main(init: std.process.Init) !void {
+    const alloc = init.arena.allocator();
+
+    const gen: lut.Generator(
+        BidiProperties,
+        struct {
+            pub fn get(ctx: @This(), cp: u21) !BidiProperties {
+                _ = ctx;
+                return bidi_uucode.get(cp);
+            }
+
+            pub fn eql(ctx: @This(), a: BidiProperties, b: BidiProperties) bool {
+                _ = ctx;
+                return a.eql(b);
+            }
+        },
+    ) = .{};
+
+    const t = try gen.generate(alloc);
+    defer alloc.free(t.stage1);
+    defer alloc.free(t.stage2);
+    defer alloc.free(t.stage3);
+
+    var buf: [4096]u8 = undefined;
+    var stdout = std.Io.File.stdout().writer(init.io, &buf);
+    try t.writeZig(&stdout.interface);
+    // Use flush instead of end because stdout is a pipe when captured by
+    // the build system, and pipes cannot be truncated (Windows returns
+    // INVALID_PARAMETER, Linux returns EINVAL).
+    try stdout.interface.flush();
+
+    // Uncomment when manually debugging to see our table sizes.
+    // std.log.warn("stage1={} stage2={} stage3={}", .{
+    //     t.stage1.len,
+    //     t.stage2.len,
+    //     t.stage3.len,
+    // });
+}
+
+test "unicode bidi: tables match uucode" {
+    if (std.valgrind.runningOnValgrind() > 0) return error.SkipZigTest;
+
+    const testing = std.testing;
+    const table = @import("bidi_table.zig").table;
+
+    for (0..std.math.maxInt(u21) + 1) |cp| {
+        const t = table.get(@intCast(cp));
+        const uu = try bidi_uucode.get(@intCast(cp));
+
+        if (!t.eql(uu)) {
+            std.log.warn(
+                "mismatch cp=U+{x} t={f} uu={f}",
+                .{ cp, t, uu },
+            );
+            try testing.expect(false);
+        }
+    }
+}
+
+test "unicode bidi: paired brackets agree with mirroring glyphs" {
+    if (std.valgrind.runningOnValgrind() > 0) return error.SkipZigTest;
+
+    const testing = std.testing;
+
+    // Every paired bracket's Bidi_Paired_Bracket is also its
+    // Bidi_Mirroring_Glyph. The UCD maintains this consistency, and rule N0
+    // combined with rule L4 relies on it: a bracket pair that mirrored to
+    // something other than its pair would render as a mismatched pair. We
+    // store the two deltas independently rather than deriving one from the
+    // other, so this test is what guards the assumption.
+    for (0..uucode.config.max_code_point + 1) |cp| {
+        const p = try bidi_uucode.get(@intCast(cp));
+        if (p.bracket == .none) continue;
+
+        try testing.expect(p.mirrored);
+        try testing.expectEqual(
+            p.pairedBracket(@intCast(cp)),
+            p.mirroringGlyph(@intCast(cp)),
+        );
+    }
+}

--- a/src/unicode/main.zig
+++ b/src/unicode/main.zig
@@ -9,6 +9,12 @@ pub const graphemeBreak = grapheme.graphemeBreak;
 pub const graphemeWidth = grapheme.graphemeWidth;
 pub const graphemeWidthEffect = grapheme.graphemeWidthEffect;
 
+const bidi_props = @import("bidi_props.zig");
+pub const bidi_table = @import("bidi_table.zig").table;
+pub const BidiClass = bidi_props.BidiClass;
+pub const BidiPairedBracketType = bidi_props.BidiPairedBracketType;
+pub const BidiProperties = bidi_props.BidiProperties;
+
 /// Returns the terminal display width of a codepoint in terminal
 /// grid cells: 0, 1, or 2.
 ///
@@ -58,6 +64,241 @@ test "codepointWidth" {
     try testing.expectEqual(2, codepointWidth(0x2E3B)); // three-em dash (clamped)
 }
 
+/// Returns the full set of Unicode Bidirectional Algorithm (UAX #9)
+/// properties for a codepoint.
+///
+/// Prefer the narrower accessors below unless you need more than one
+/// property; they all resolve through this single table lookup, so reading
+/// the struct once and using it is cheaper than calling several of them.
+pub fn bidiProperties(cp: u21) BidiProperties {
+    return bidi_table.get(cp);
+}
+
+/// Returns the Bidi_Class of a codepoint (UAX #9, Table 4).
+///
+/// Unassigned codepoints do NOT all resolve to `.l`. The default varies by
+/// block: unassigned codepoints in the Hebrew range resolve to `.r`, in the
+/// Arabic ranges to `.al`, and in the Currency Symbols range to `.et`. See
+/// the `@missing` lines in DerivedBidiClass.txt.
+pub fn bidiClass(cp: u21) BidiClass {
+    return bidi_table.get(cp).class;
+}
+
+/// Returns whether a codepoint has Bidi_Mirrored=Y, i.e. whether rule L4
+/// mirrors it when its resolved embedding level is odd.
+///
+/// This is a strict superset of the codepoints that have a mirroring glyph;
+/// see bidiMirroringGlyph.
+pub fn isBidiMirrored(cp: u21) bool {
+    return bidi_table.get(cp).mirrored;
+}
+
+/// Returns the Bidi_Mirroring_Glyph of a codepoint, or null if it has none.
+///
+/// A null return does not imply the codepoint is unmirrored. U+2202 PARTIAL
+/// DIFFERENTIAL has Bidi_Mirrored=Y but no designated mirroring glyph; rule
+/// L4 still applies and the font is expected to supply the mirrored form.
+/// Use isBidiMirrored to test for mirroring.
+pub fn bidiMirroringGlyph(cp: u21) ?u21 {
+    return bidi_table.get(cp).mirroringGlyph(cp);
+}
+
+/// Returns the Bidi_Paired_Bracket_Type of a codepoint, used by rule N0.
+pub fn bidiPairedBracketType(cp: u21) BidiPairedBracketType {
+    return bidi_table.get(cp).bracket;
+}
+
+/// Returns the Bidi_Paired_Bracket of a codepoint, or null if the codepoint
+/// is not a paired bracket.
+pub fn bidiPairedBracket(cp: u21) ?u21 {
+    return bidi_table.get(cp).pairedBracket(cp);
+}
+
+test "bidiClass: strong types" {
+    const testing = @import("std").testing;
+
+    try testing.expectEqual(BidiClass.l, bidiClass('a'));
+    try testing.expectEqual(BidiClass.l, bidiClass('Z'));
+    try testing.expectEqual(BidiClass.r, bidiClass(0x05D0)); // HEBREW ALEF
+    try testing.expectEqual(BidiClass.r, bidiClass(0x05BE)); // HEBREW MAQAF
+    try testing.expectEqual(BidiClass.al, bidiClass(0x0627)); // ARABIC ALEF
+    try testing.expectEqual(BidiClass.al, bidiClass(0x0645)); // ARABIC MEEM
+    try testing.expectEqual(BidiClass.al, bidiClass(0x06CC)); // FARSI YEH
+}
+
+test "bidiClass: numbers" {
+    const testing = @import("std").testing;
+
+    // ASCII digits are European Number.
+    try testing.expectEqual(BidiClass.en, bidiClass('0'));
+    try testing.expectEqual(BidiClass.en, bidiClass('9'));
+
+    // Arabic-Indic digits are Arabic Number...
+    try testing.expectEqual(BidiClass.an, bidiClass(0x0660));
+    try testing.expectEqual(BidiClass.an, bidiClass(0x0669));
+
+    // ...but Extended Arabic-Indic digits, used for Persian, are European
+    // Number. Confusing the two is a classic source of "the phone number
+    // renders backwards" bugs.
+    try testing.expectEqual(BidiClass.en, bidiClass(0x06F0));
+    try testing.expectEqual(BidiClass.en, bidiClass(0x06F9));
+
+    // U+0600 ARABIC NUMBER SIGN is AN despite living in a block whose
+    // unassigned default is AL.
+    try testing.expectEqual(BidiClass.an, bidiClass(0x0600));
+
+    // Separators and terminators.
+    try testing.expectEqual(BidiClass.es, bidiClass('+'));
+    try testing.expectEqual(BidiClass.es, bidiClass('-'));
+    try testing.expectEqual(BidiClass.cs, bidiClass(','));
+    try testing.expectEqual(BidiClass.cs, bidiClass('.'));
+    try testing.expectEqual(BidiClass.cs, bidiClass(':'));
+    try testing.expectEqual(BidiClass.et, bidiClass('#'));
+    try testing.expectEqual(BidiClass.et, bidiClass('%'));
+    try testing.expectEqual(BidiClass.et, bidiClass('$'));
+}
+
+test "bidiClass: neutrals and whitespace" {
+    const testing = @import("std").testing;
+
+    try testing.expectEqual(BidiClass.ws, bidiClass(' '));
+    try testing.expectEqual(BidiClass.ws, bidiClass(0x000C)); // FORM FEED
+    try testing.expectEqual(BidiClass.s, bidiClass(0x0009)); // TAB
+    try testing.expectEqual(BidiClass.b, bidiClass(0x000A)); // LINE FEED
+    try testing.expectEqual(BidiClass.b, bidiClass(0x2029)); // PARA SEPARATOR
+    try testing.expectEqual(BidiClass.on, bidiClass('('));
+    try testing.expectEqual(BidiClass.on, bidiClass('!'));
+    try testing.expectEqual(BidiClass.bn, bidiClass(0x0000)); // NUL
+    try testing.expectEqual(BidiClass.bn, bidiClass(0x200B)); // ZWSP
+    try testing.expectEqual(BidiClass.bn, bidiClass(0x200C)); // ZWNJ
+    try testing.expectEqual(BidiClass.bn, bidiClass(0x200D)); // ZWJ
+    try testing.expectEqual(BidiClass.nsm, bidiClass(0x0300)); // COMBINING GRAVE
+    try testing.expectEqual(BidiClass.nsm, bidiClass(0x05B4)); // HEBREW HIRIQ
+    try testing.expectEqual(BidiClass.nsm, bidiClass(0x064B)); // ARABIC FATHATAN
+}
+
+test "bidiClass: explicit formatting characters" {
+    const testing = @import("std").testing;
+
+    try testing.expectEqual(BidiClass.l, bidiClass(0x200E)); // LRM
+    try testing.expectEqual(BidiClass.r, bidiClass(0x200F)); // RLM
+    try testing.expectEqual(BidiClass.al, bidiClass(0x061C)); // ALM
+
+    try testing.expectEqual(BidiClass.lre, bidiClass(0x202A));
+    try testing.expectEqual(BidiClass.rle, bidiClass(0x202B));
+    try testing.expectEqual(BidiClass.pdf, bidiClass(0x202C));
+    try testing.expectEqual(BidiClass.lro, bidiClass(0x202D));
+    try testing.expectEqual(BidiClass.rlo, bidiClass(0x202E));
+
+    try testing.expectEqual(BidiClass.lri, bidiClass(0x2066));
+    try testing.expectEqual(BidiClass.rli, bidiClass(0x2067));
+    try testing.expectEqual(BidiClass.fsi, bidiClass(0x2068));
+    try testing.expectEqual(BidiClass.pdi, bidiClass(0x2069));
+
+    // The override characters are the Trojan Source vector. They must be
+    // classified, not swallowed, so the paste guard can find them later.
+    try testing.expect(bidiClass(0x202D).isExplicitFormatting());
+    try testing.expect(bidiClass(0x202E).isExplicitFormatting());
+}
+
+test "bidiClass: unassigned codepoints use block defaults, not L" {
+    const testing = @import("std").testing;
+
+    // This is the single easiest way to get a bidi table wrong. Every
+    // codepoint below is UNASSIGNED, and each one must pick up the
+    // `@missing` default for its block rather than falling back to L.
+    // If any of these returns `.l`, the table generation dropped the
+    // @missing lines from DerivedBidiClass.txt.
+    try testing.expectEqual(BidiClass.r, bidiClass(0x0590)); // Hebrew block
+    try testing.expectEqual(BidiClass.al, bidiClass(0x070E)); // Syriac block
+    try testing.expectEqual(BidiClass.r, bidiClass(0x07FB)); // NKo block
+    try testing.expectEqual(BidiClass.et, bidiClass(0x20C2)); // Currency
+    try testing.expectEqual(BidiClass.al, bidiClass(0x10D28)); // Hanifi Rohingya
+    try testing.expectEqual(BidiClass.al, bidiClass(0x1EE04)); // Arabic Math
+    try testing.expectEqual(BidiClass.r, bidiClass(0x1EF00)); // unassigned RTL
+
+    // An unassigned codepoint outside any RTL block does default to L.
+    try testing.expectEqual(BidiClass.l, bidiClass(0x2FE0));
+}
+
+test "isBidiMirrored and bidiMirroringGlyph" {
+    const testing = @import("std").testing;
+
+    try testing.expect(isBidiMirrored('('));
+    try testing.expect(isBidiMirrored(')'));
+    try testing.expect(isBidiMirrored('<'));
+    try testing.expect(!isBidiMirrored('a'));
+    try testing.expect(!isBidiMirrored(' '));
+
+    try testing.expectEqual(@as(?u21, ')'), bidiMirroringGlyph('('));
+    try testing.expectEqual(@as(?u21, '('), bidiMirroringGlyph(')'));
+    try testing.expectEqual(@as(?u21, '>'), bidiMirroringGlyph('<'));
+    try testing.expectEqual(@as(?u21, ']'), bidiMirroringGlyph('['));
+    try testing.expectEqual(@as(?u21, '}'), bidiMirroringGlyph('{'));
+    try testing.expectEqual(@as(?u21, null), bidiMirroringGlyph('a'));
+
+    // A large delta, exercising the wide end of the i13 encoding.
+    try testing.expectEqual(@as(?u21, 0x2997), bidiMirroringGlyph(0x2998));
+
+    // Mirrored with no designated glyph: both facts must be representable
+    // at once, which is why `mirrored` is stored separately from the delta.
+    try testing.expect(isBidiMirrored(0x2202)); // PARTIAL DIFFERENTIAL
+    try testing.expectEqual(@as(?u21, null), bidiMirroringGlyph(0x2202));
+}
+
+test "bidiMirroringGlyph is an involution" {
+    const std = @import("std");
+    const testing = std.testing;
+
+    // mirror(mirror(cp)) == cp for every codepoint that has a mirroring
+    // glyph. This is a UCD invariant and a cheap whole-table integrity
+    // check: a corrupted delta almost certainly breaks it.
+    for (0..std.math.maxInt(u21) + 1) |i| {
+        const cp: u21 = @intCast(i);
+        const m = bidiMirroringGlyph(cp) orelse continue;
+        try testing.expectEqual(@as(?u21, cp), bidiMirroringGlyph(m));
+    }
+}
+
+test "bidiPairedBracket" {
+    const testing = @import("std").testing;
+
+    try testing.expectEqual(BidiPairedBracketType.open, bidiPairedBracketType('('));
+    try testing.expectEqual(BidiPairedBracketType.close, bidiPairedBracketType(')'));
+    try testing.expectEqual(BidiPairedBracketType.open, bidiPairedBracketType('['));
+    try testing.expectEqual(BidiPairedBracketType.close, bidiPairedBracketType(']'));
+    try testing.expectEqual(BidiPairedBracketType.open, bidiPairedBracketType('{'));
+    try testing.expectEqual(BidiPairedBracketType.close, bidiPairedBracketType('}'));
+
+    // Angle brackets are mirrored but are NOT paired brackets for rule N0.
+    try testing.expectEqual(BidiPairedBracketType.none, bidiPairedBracketType('<'));
+    try testing.expect(isBidiMirrored('<'));
+
+    try testing.expectEqual(BidiPairedBracketType.none, bidiPairedBracketType('a'));
+
+    try testing.expectEqual(@as(?u21, ')'), bidiPairedBracket('('));
+    try testing.expectEqual(@as(?u21, '('), bidiPairedBracket(')'));
+    try testing.expectEqual(@as(?u21, 0x2997), bidiPairedBracket(0x2998));
+    try testing.expectEqual(@as(?u21, null), bidiPairedBracket('<'));
+    try testing.expectEqual(@as(?u21, null), bidiPairedBracket('a'));
+}
+
+test "bidiProperties: single lookup agrees with narrow accessors" {
+    const testing = @import("std").testing;
+
+    for ([_]u21{ 'a', '(', ')', 0x05D0, 0x0627, 0x2202, 0x202E, 0x2998, 0x0590 }) |cp| {
+        const p = bidiProperties(cp);
+        try testing.expectEqual(bidiClass(cp), p.class);
+        try testing.expectEqual(isBidiMirrored(cp), p.mirrored);
+        try testing.expectEqual(bidiPairedBracketType(cp), p.bracket);
+        try testing.expectEqual(bidiMirroringGlyph(cp), p.mirroringGlyph(cp));
+        try testing.expectEqual(bidiPairedBracket(cp), p.pairedBracket(cp));
+    }
+}
+
 test {
     @import("std").testing.refAllDecls(@This());
+
+    // Internals
+    _ = @import("bidi_props.zig");
 }


### PR DESCRIPTION
## Summary
This PR adds full Unicode Bidirectional Text Support (UAX #9) to Ghostty, resolving the long-standing gap for RTL languages including Persian, Arabic, and Hebrew.

### Key Highlights
- **Native Zig UAX #9 Engine:** Zero external/C dependencies (no LGPL FriBidi). Uses existing MIT `uucode` tables at build time.
- **Performance First:** Includes a Highway/SIMD fast-path scan for ASCII content (`0.46 µs/row`), ensuring zero performance/binary size regressions for LTR users. Complete bypass when `bidi = never`.
- **GPU Architecture Preserved:** Reordering happens strictly via visual run iteration above the renderer, preserving the GPU renderer's monotonic-X invariant.
- **Strict Type Safety:** Introduced `LogicalCol` and `VisualCol` zero-cost distinct types to enforce coordinate space isolation at compile time.
- **100% UCD Conformance:** Tested and passed against all 861,948 test vectors from UCD 17.0.0 (`BidiTest.txt` and `BidiCharacterTest.txt`) with zero failures.
- **User Experience & Security:**
  - Script-aware word selection (handles Persian ZWNJ / zero-width non-joiners seamlessly).
  - Visual cursor placement with an RTL bar indicator (`cursor_bar_rtl`).
  - Discontiguous selection rendering with logical clipboard preservation.
  - Trojan Source mitigation (CVE-2021-42574 warnings on `RLO`/`LRO` paste).

## Configuration
- `bidi = auto | never | always` (defaults to `never` unless compiled with `-Dbidi-backend=zig`).
- `bidi-default-direction = auto | ltr | rtl`.

## Disclosure (AI Policy)
In compliance with `AI_POLICY.md`, this implementation and architecture were developed with assistance from **Claude Code (Claude 3.7 Sonnet)** as an AI pair programmer under continuous human architectural guidance and verification.