### PR TITLE
macOS: show/search description when subtitle missing in CommandPalette

### DIFF
--- a/macos/Sources/Features/Command Palette/CommandPalette.swift
+++ b/macos/Sources/Features/Command Palette/CommandPalette.swift
@@ -79,6 +79,7 @@ struct CommandPaletteView: View {
             let filtered = options.filter {
                 $0.title.matchedIndices(for: query) != nil ||
                 ($0.subtitle?.matchedIndices(for: query) != nil) ||
+                ($0.description?.matchedIndices(for: query) != nil) ||
                 colorMatchScore(for: $0.leadingColor, query: query) > 0
             }
 
@@ -401,7 +402,7 @@ private struct CommandRow: View {
                 VStack(alignment: .leading, spacing: 2) {
                     highlightedTitle
 
-                    if let subtitle = option.subtitle {
+                    if let subtitle = option.subtitle ?? option.description {
                         highlightedSubtitle(subtitle)
                             .font(.caption)
                             .foregroundStyle(.secondary)


### PR DESCRIPTION
<img width="1125" height="552" alt="image" src="https://github.com/user-attachments/assets/09866c9b-d5c4-422f-860b-de4de4cca055" />
