### PR TITLE
macOS: show cancel update option when its actually cancellable

### DIFF
--- a/macos/Sources/Features/Command Palette/TerminalCommandPalette.swift
+++ b/macos/Sources/Features/Command Palette/TerminalCommandPalette.swift
@@ -84,35 +84,39 @@ struct TerminalCommandPaletteView: View {
     private var updateOptions: [CommandOption] {
         var options: [CommandOption] = []
 
-        guard let updateViewModel, updateViewModel.state.isInstallable else {
+        guard let updateViewModel else {
             return options
         }
 
-        // We override the update available one only because we want to properly
-        // convey it'll go all the way through.
-        let title: String
-        if case .updateAvailable = updateViewModel.state {
-            title = "Update Ghostty and Restart"
-        } else {
-            title = updateViewModel.text
+        if updateViewModel.state.isInstallable {
+            // We override the update available one only because we want to properly
+            // convey it'll go all the way through.
+            let title: String
+            if case .updateAvailable = updateViewModel.state {
+                title = "Update Ghostty and Restart"
+            } else {
+                title = updateViewModel.text
+            }
+
+            options.append(CommandOption(
+                title: title,
+                description: updateViewModel.description,
+                leadingIcon: updateViewModel.iconName ?? "shippingbox.fill",
+                badge: updateViewModel.badge,
+                emphasis: true
+            ) {
+                (NSApp.delegate as? AppDelegate)?.updateController.viewModel.state.confirm()
+            })
         }
 
-        options.append(CommandOption(
-            title: title,
-            description: updateViewModel.description,
-            leadingIcon: updateViewModel.iconName ?? "shippingbox.fill",
-            badge: updateViewModel.badge,
-            emphasis: true
-        ) {
-            (NSApp.delegate as? AppDelegate)?.updateController.viewModel.state.confirm()
-        })
-
-        options.append(CommandOption(
-            title: "Cancel or Skip Update",
-            description: "Dismiss the current update process"
-        ) {
-            updateViewModel.state.cancel()
-        })
+        if updateViewModel.state.isCancellable {
+            options.append(CommandOption(
+                title: "Cancel or Skip Update",
+                description: "Dismiss the current update process"
+            ) {
+                updateViewModel.state.cancel()
+            })
+        }
 
         return options
     }

--- a/macos/Sources/Features/Update/UpdateViewModel.swift
+++ b/macos/Sources/Features/Update/UpdateViewModel.swift
@@ -205,20 +205,34 @@ enum UpdateState: Equatable {
         }
     }
 
+    var isCancellable: Bool {
+        cancelAction != nil
+    }
+
     func cancel() {
+        cancelAction?()
+    }
+
+    private var cancelAction: (() -> Void)? {
         switch self {
+        case .idle:
+            nil
+        case .permissionRequest:
+            nil
         case .checking(let checking):
-            checking.cancel()
+            checking.cancel
         case .updateAvailable(let available):
-            available.reply(.dismiss)
+            { available.reply(.dismiss) }
         case .downloading(let downloading):
-            downloading.cancel()
+            downloading.cancel
         case .notFound(let notFound):
-            notFound.acknowledgement()
+            notFound.acknowledgement
         case .error(let err):
-            err.dismiss()
-        default:
-            break
+            err.dismiss
+        case .extracting:
+            nil
+        case .installing:
+            nil
         }
     }
 


### PR DESCRIPTION
`extracting` and `installing` state aren't cancellable by us.

> Recommend reviewing with whitespace hidden