### PR TITLE
config: limit command translations to GTK

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -8749,9 +8749,16 @@ pub const RepeatableCommand = struct {
         try self.value.ensureUnusedCapacity(alloc, inputpkg.command.defaults.len);
         try self.value_c.ensureUnusedCapacity(alloc, inputpkg.command.defaults.len);
         for (inputpkg.command.defaults) |cmd| {
-            const translated = cmd.translated();
-            self.value.appendAssumeCapacity(translated);
-            self.value_c.appendAssumeCapacity(try translated.cval(alloc));
+            // Translation is currently a GTK-only feature. In particular,
+            // translating these shared strings for the embedded runtime gives
+            // the macOS app a localized command palette in an otherwise
+            // unlocalized UI.
+            const localized = if (comptime build_config.app_runtime == .gtk)
+                cmd.translated()
+            else
+                cmd;
+            self.value.appendAssumeCapacity(localized);
+            self.value_c.appendAssumeCapacity(try localized.cval(alloc));
         }
     }
 


### PR DESCRIPTION
Fixes #13614

Only translate the shared default commands when building the GTK runtime.  macOS now use the source strings until we do broader localization.