### PR TITLE
renderer/metal: dispatch iOS first display on main

### DIFF
--- a/src/renderer/Metal.zig
+++ b/src/renderer/Metal.zig
@@ -167,6 +167,33 @@ pub fn loopEnter(self: *Metal) void {
         @ptrCast(&displayCallback),
         @ptrCast(renderer),
     );
+
+    // The iOS sublayer has bounds before the callback is registered, so it
+    // won't request a display automatically. loopEnter runs on the renderer
+    // thread, so dispatch the Core Animation mutation to the main queue.
+    if (comptime builtin.os.tag == .ios) {
+        var block = SetNeedsDisplayBlock.init(.{
+            .layer = self.layer.layer.value,
+        }, &setNeedsDisplayCallback);
+        macos.dispatch.dispatch_async(
+            @ptrCast(macos.dispatch.queue.getMain()),
+            @ptrCast(&block),
+        );
+    }
+}
+
+const SetNeedsDisplayBlock = objc.Block(struct {
+    layer: objc.c.id,
+}, .{}, void);
+
+fn setNeedsDisplayCallback(
+    block: *const SetNeedsDisplayBlock.Context,
+) callconv(.c) void {
+    objc.Object.fromId(block.layer).msgSend(
+        void,
+        objc.sel("setNeedsDisplay"),
+        .{},
+    );
 }
 
 fn displayCallback(renderer: *Renderer) align(8) void {


### PR DESCRIPTION
## Summary

On iOS, the embedded Metal sublayer already has bounds before its display callback is registered, so it does not request the first display automatically. Trigger that display after callback registration, dispatching `setNeedsDisplay` to the main queue because `loopEnter` runs on the renderer thread.

This uses the existing Objective-C block and GCD helpers already used by `IOSurfaceLayer.setSurface` and changes no other rendering behavior.

## Reproduction

Opening an embedded Ghostty terminal on iOS Simulator with `CA_DEBUG_TRANSACTIONS=1` and `CA_ASSERT_MAIN_THREAD_TRANSACTIONS=1` aborts on the `renderer` thread. The stack reaches `CA::Transaction::push` through `CALayer setNeedsDisplayInRect:`.

## Validation

- `zig fmt --check src/renderer/Metal.zig`
- `git diff --check`
- Built the universal Apple `GhosttyKit.xcframework` with Zig 0.16.0, compiling macOS universal, iOS arm64, and iOS arm64 Simulator slices.
- Confirmed both iOS archives contain `renderer.Metal.setNeedsDisplayCallback`.

## AI assistance

OpenAI Codex inspected the code, implemented the change, ran the validation above, and drafted this description. The reproduction evidence and scope were supplied by the contributor.
