### PR TITLE
surface: use id instead of intFromPtr

### DIFF
--- a/src/App.zig
+++ b/src/App.zig
@@ -476,8 +476,8 @@ pub fn performAllAction(
         // are logged but processing continues.
         .surface => for (self.surfaces.items) |surface| {
             _ = surface.core().performBindingAction(action) catch |err| {
-                log.warn("error performing binding action on surface ptr={X} err={}", .{
-                    @intFromPtr(surface),
+                log.warn("error performing binding action on surface id={x} err={}", .{
+                    surface.core().id,
                     err,
                 });
             };

--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -841,7 +841,7 @@ pub fn deinit(self: *Surface) void {
     self.alloc.destroy(self.renderer_state.mutex);
     self.config.deinit();
 
-    log.info("surface closed addr={x}", .{@intFromPtr(self)});
+    log.info("surface closed id={x}", .{self.id});
 }
 
 /// Close this surface. This will trigger the runtime to start the

--- a/src/apprt/gtk/class/command_palette.zig
+++ b/src/apprt/gtk/class/command_palette.zig
@@ -581,10 +581,8 @@ const Command = extern struct {
 
         const priv = self.private();
         priv.data = .{
-            .jump = .{
-                // TODO: Replace with surface id whenever Ghostty adds one
-                .sort_key = @intFromPtr(surface),
-            },
+            // Surface should be initialized at this point.
+            .jump = .{ .sort_key = surface.core().?.id },
         };
         priv.data.jump.surface.set(surface);
 


### PR DESCRIPTION
intFromPtr was always a hack that we had to use before we had stable surface IDs, and it was always slightly unsafe. Let's do it properly this time.