### PR TITLE
core: transfer long key encoding buffer

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -3244,17 +3244,15 @@ fn encodeKey(
         );
         defer alloc_writer.deinit();
 
-        // This results in a double allocation but this is such an unlikely
-        // path the performance impact is unimportant.
         try input.key_encode.encode(
             &alloc_writer.writer,
             event,
             encoding_opts,
         );
-        break :req try termio.Message.WriteReq.init(
-            self.alloc,
-            alloc_writer.writer.buffered(),
-        );
+        break :req .{ .alloc = .{
+            .alloc = self.alloc,
+            .data = try alloc_writer.toOwnedSlice(),
+        } };
     };
 
     // Copy the encoded data into the inspector event if we have one.


### PR DESCRIPTION
The long-preedit fallback introduced in e95b1707c intentionally allocated twice. The encoder wrote into an oversized caller-owned buffer and returned only the written subslice, so transferring it required manually shrinking the allocation or tracking its original capacity. The copy kept that rare path simple.

The key encoder moved to std.Io.Writer.Allocating in 44496df899. Its toOwnedSlice method handles shrinking and ownership transfer, remapping when the allocator supports it and falling back to an allocation and copy when it does not. Use it directly for WriteReq.alloc to remove the guaranteed second allocation while preserving cleanup on failure.