### PR TITLE
renderer/metal: clear callback before layer release

### DIFF
--- a/src/renderer/metal/IOSurfaceLayer.zig
+++ b/src/renderer/metal/IOSurfaceLayer.zig
@@ -40,6 +40,10 @@ pub fn init() !IOSurfaceLayer {
 }
 
 pub fn release(self: *IOSurfaceLayer) void {
+    // The layer may be retained by the view after we release our reference.
+    // Clear the callback first so that a later display pass can't access the
+    // renderer that owned this wrapper after it has been freed.
+    self.setDisplayCallback(null, null);
     self.layer.release();
 }
 


### PR DESCRIPTION
Fixes https://github.com/ghostty-org/ghostty/discussions/13242

Clear the IOSurfaceLayer display callback when releasing the wrapper. The host view can retain the backing layer beyond renderer teardown. This prevents a later Core Animation display pass from invoking the callback with a freed renderer context.

This doesn't happen the way Ghostty GUI uses our renderer, but it is possible for folks using ghostty-internal and its straightforward and easy for us to fix it.