### PR TITLE
macos: handle missing CoreText display names

### DIFF
--- a/pkg/macos/text/font.zig
+++ b/pkg/macos/text/font.zig
@@ -156,7 +156,7 @@ pub const Font = opaque {
         return @ptrFromInt(@intFromPtr(c.CTFontCopyFamilyName(@ptrCast(self))));
     }
 
-    pub fn copyDisplayName(self: *Font) *foundation.String {
+    pub fn copyDisplayName(self: *Font) ?*foundation.String {
         return @ptrFromInt(@intFromPtr(c.CTFontCopyDisplayName(@ptrCast(self))));
     }
 

--- a/src/font/DeferredFace.zig
+++ b/src/font/DeferredFace.zig
@@ -184,7 +184,8 @@ pub fn name(self: DeferredFace, buf: []u8) ![]const u8 {
         .coretext_harfbuzz,
         .coretext_noshape,
         => if (self.ct) |ct| {
-            const display_name = ct.font.copyDisplayName();
+            const display_name = ct.font.copyDisplayName() orelse
+                return self.familyName(buf);
             return display_name.cstringPtr(.utf8) orelse unsupported: {
                 // "NULL if the internal storage of theString does not allow
                 // this to be returned efficiently." In this case, we need


### PR DESCRIPTION
Fixes https://github.com/ghostty-org/ghostty/discussions/13262

CTFontCopyDisplayName can return null.