### PR TITLE
terminal: color reset should set override to null, not default

### DIFF
--- a/src/terminal/color.zig
+++ b/src/terminal/color.zig
@@ -350,7 +350,7 @@ pub const DynamicRGB = struct {
     }
 
     pub fn reset(self: *DynamicRGB) void {
-        self.override = self.default;
+        self.override = null;
     }
 };
 

--- a/src/terminal/stream_terminal.zig
+++ b/src/terminal/stream_terminal.zig
@@ -1673,6 +1673,9 @@ test "OSC 11 set and reset background color" {
     var s: Stream = .init(.{ .allocator = testing.allocator, .handler = .init(&t) });
     defer s.deinit();
 
+    const default: color.RGB = .{ .r = 0x10, .g = 0x20, .b = 0x30 };
+    t.colors.background.default = default;
+
     // Set background to green
     s.nextSlice("\x1b]11;rgb:00/ff/00\x1b\\");
     const bg = t.colors.background.get().?;
@@ -1682,7 +1685,13 @@ test "OSC 11 set and reset background color" {
 
     // Reset background
     s.nextSlice("\x1b]111\x1b\\");
-    try testing.expect(t.colors.background.get() == null);
+    try testing.expectEqual(default, t.colors.background.get().?);
+    try testing.expectEqual(null, t.colors.background.override);
+
+    // A reset color continues to follow later configuration changes.
+    const updated: color.RGB = .{ .r = 0x40, .g = 0x50, .b = 0x60 };
+    t.colors.background.default = updated;
+    try testing.expectEqual(updated, t.colors.background.get().?);
 }
 
 test "OSC 12 set and reset cursor color" {


### PR DESCRIPTION
#12755

Reset previously copied the active default into the override. This is wrong, a reset should unset the override and defer back to the default.

Reset foreground, background, and cursor colors now resolve through the current default while explicit OSC overrides remain unchanged across configuration updates.

Set a configured background in the OSC 11 regression, assert OSC 111 clears its override, then change the default to verify the reset color follows it.