### PR TITLE
libghostty-vt: spacer-tail handling needs to respect slow runtime safety

### DIFF
--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -1558,7 +1558,7 @@ fn printCell(
 
                 // So integrity checks pass. We fix this up later so we don't
                 // need to do this without safety checks.
-                if (comptime std.debug.runtime_safety) {
+                if (comptime build_options.slow_runtime_safety) {
                     cell.wide = .narrow;
                 }
 


### PR DESCRIPTION
Debug libghostty-vt dependencies embedded in ReleaseFast or ReleaseSmall binaries no longer panic when narrow text overwrites the tail of a wide glyph.

Replace the root module's std.debug.runtime_safety gate with build_options.slow_runtime_safety so mixed optimization modes use the dependency's safety configuration consistently.