### PR TITLE
core: avoid allocating for pwd change actions

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -1073,9 +1073,10 @@ pub fn handleMessage(self: *Surface, msg: Message) !void {
         .pwd_change => |w| {
             defer w.deinit();
 
-            // We always allocate for this because we need to null-terminate.
-            const str = try self.alloc.dupeZ(u8, w.slice());
-            defer self.alloc.free(str);
+            var stack = std.heap.stackFallback(256, self.alloc);
+            const alloc = stack.get();
+            const str = try alloc.dupeZ(u8, w.slice());
+            defer alloc.free(str);
 
             _ = try self.rt_app.performAction(
                 .{ .surface = self },


### PR DESCRIPTION
Surface.handleMessage allocated a null-terminated copy for every working directory update. OSC 7 values fit within the parser's 2 KiB fixed buffer, so use stack-fallback storage sized for that bound and its terminator.

The message type does not enforce the OSC bound, so an oversized future producer still falls back to the heap. performAction already borrows the value only for the duration of the call, preserving its existing lifetime.