### PR TITLE
build: default dependencies to lib-vt mode to avoid Xcode requirements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,6 +86,7 @@ jobs:
       - build-bench
       - build-dist
       - build-dist-lib-vt
+      - build-example-zig-vt-macos-no-sdk
       - build-examples-zig
       - build-examples-cmake
       - build-examples-cmake-windows
@@ -238,6 +239,38 @@ jobs:
         run: |
           cd example/${{ matrix.dir }}
           nix develop -c zig build
+
+  build-example-zig-vt-macos-no-sdk:
+    name: Example zig-vt (macOS, no SDK)
+    runs-on: namespace-profile-ghostty-macos-tahoe
+    needs: test
+    env:
+      ZIG_LOCAL_CACHE_DIR: /Users/runner/zig/local-cache
+      ZIG_GLOBAL_CACHE_DIR: /Users/runner/zig/global-cache
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Cache
+        uses: namespacelabs/nscloud-cache-action@c5f8dab7560444c4bf8dbc64f1b203431873c547 # v1.6.1
+        with:
+          cache: |
+            xcode
+          path: |
+            /Users/runner/zig
+
+      # TODO(tahoe): https://github.com/NixOS/nix/issues/13342
+      - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          determinate: true
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
+        with:
+          name: ghostty
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+
+      - name: Build Example without SDK
+        working-directory: example/zig-vt
+        run: nix develop -c env DEVELOPER_DIR=/nonexistent zig build
 
   build-examples-cmake:
     strategy:

--- a/build.zig
+++ b/build.zig
@@ -101,8 +101,10 @@ pub fn build(b: *std.Build) !void {
     if (config.emit_webdata) webdata.install();
 
     // Ghostty bench tools
-    const bench = try buildpkg.GhosttyBench.init(b, &deps);
-    if (config.emit_bench) bench.install();
+    if (config.emit_bench) {
+        const bench = try buildpkg.GhosttyBench.init(b, &deps);
+        bench.install();
+    }
 
     // Ghostty dist tarball
     const dist = try buildpkg.GhosttyDist.init(b, &config);

--- a/src/build/Config.zig
+++ b/src/build/Config.zig
@@ -73,11 +73,15 @@ pub fn init(b: *std.Build, appVersion: []const u8, libVersion: []const u8) !Conf
     // Setup our standard Zig target and optimize options, i.e.
     // `-Doptimize` and `-Dtarget`.
     const optimize = b.standardOptimizeOption(.{});
+
+    // Default dependency builds to libghostty-vt-only mode. Consumers can
+    // still explicitly disable this to request the full Ghostty build.
+    const is_dep = b.dep_prefix.len > 0;
     const emit_lib_vt = b.option(
         bool,
         "emit-lib-vt",
         "Set defaults for a libghostty-vt-only build (disables xcframework, macOS app, and docs).",
-    ) orelse false;
+    ) orelse is_dep;
     const target = target: {
         var result = b.standardTargetOptions(.{});
 
@@ -113,10 +117,6 @@ pub fn init(b: *std.Build, appVersion: []const u8, libVersion: []const u8) !Conf
 
         break :target result;
     };
-
-    // Detect if Ghostty is a dependency of another project.
-    // dep_prefix is non-empty when this build is running as a dependency.
-    const is_dep = b.dep_prefix.len > 0;
 
     // This is set to true when we're building a system package. For now
     // this is trivially detected using the "system_package_mode" bool


### PR DESCRIPTION
Related to #10651

Default Ghostty dependency builds to libghostty-vt-only mode and avoid initializing anything that would trigger broader dependency requirements.

The impact of this is that Zig consumers can import ghostty-vt without requiring Xcode on macOS.