### PR TITLE
macOS: hide settings menu icon on macOS 27

### DIFF
--- a/macos/Sources/Helpers/Extensions/NSMenuItem+Extension.swift
+++ b/macos/Sources/Helpers/Extensions/NSMenuItem+Extension.swift
@@ -7,5 +7,10 @@ extension NSMenuItem {
         if #available(macOS 26, *) {
             image = NSImage(systemSymbolName: symbol, accessibilityDescription: title)
         }
+#if compiler(>=6.4)
+        if #available(macOS 27.0, *) {
+            preferredImageVisibility = .automatic
+        }
+#endif
     }
 }


### PR DESCRIPTION
Settings appears to be somehow special and it's not hidden previously.

This would require building with Xcode 27 tho.

<img width="704" height="364" alt="image" src="https://github.com/user-attachments/assets/2cb23a01-6840-40a2-b794-6a8e914aaa7d" />
