### PR TITLE
macOS: fix unsupported action falls through wrong handling

### DIFF
--- a/macos/Sources/Ghostty/Ghostty.App.swift
+++ b/macos/Sources/Ghostty/Ghostty.App.swift
@@ -670,18 +670,12 @@ extension Ghostty {
             case GHOSTTY_ACTION_PRESENT_TERMINAL:
                 return presentTerminal(app, target: target)
 
-            case GHOSTTY_ACTION_TOGGLE_TAB_OVERVIEW:
-                fallthrough
-            case GHOSTTY_ACTION_TOGGLE_WINDOW_DECORATIONS:
-                fallthrough
-            case GHOSTTY_ACTION_SIZE_LIMIT:
-                fallthrough
-            case GHOSTTY_ACTION_QUIT_TIMER:
-                fallthrough
             case GHOSTTY_ACTION_SHOW_CHILD_EXITED:
                 return showChildExited(app, target: target, v: action.action.child_exited)
+
             case GHOSTTY_ACTION_COPY_TITLE_TO_CLIPBOARD:
                 return copyTitleToClipboard(app, target: target)
+
             default:
                 Ghostty.logger.warning("unknown action action=\(action.tag.rawValue, privacy: .public)")
                 return false


### PR DESCRIPTION
There're won't be any visible errors, but `keybind=cmd+r=toggle_tab_overview/toggle_window_decorations/size_limit/quit_time` shouldn't go to `showChildExited`

## AI Disclosure

Found by Claude during another quest, but I changed on myself.