### PR TITLE
apprt: move command palette support check into zig

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -416,11 +416,13 @@ typedef struct {
   ghostty_input_mods_e mods;
 } ghostty_input_trigger_s;
 
+// input.Command
 typedef struct {
   const char* action_key;
   const char* action;
   const char* title;
   const char* description;
+  bool supported;
 } ghostty_command_s;
 
 typedef enum {

--- a/macos/Sources/Ghostty/Ghostty.Command.swift
+++ b/macos/Sources/Ghostty/Ghostty.Command.swift
@@ -17,24 +17,14 @@ extension Ghostty {
         let actionKey: String
 
         /// True if this can be performed on this target.
-        var isSupported: Bool {
-            !Self.unsupportedActionKeys.contains(actionKey)
-        }
-
-        /// Unsupported action keys, because they either don't make sense in the context of our
-        /// target platform or they just aren't implemented yet.
-        static let unsupportedActionKeys: [String] = [
-            "toggle_tab_overview",
-            "toggle_window_decorations",
-            "prompt_window_title",
-            "show_gtk_inspector",
-        ]
+        let isSupported: Bool
 
         init(cValue: ghostty_command_s) {
             self.title = String(cString: cValue.title)
             self.description = String(cString: cValue.description)
             self.action = String(cString: cValue.action)
             self.actionKey = String(cString: cValue.action_key)
+            self.isSupported = cValue.supported
         }
     }
 }

--- a/src/apprt/command.zig
+++ b/src/apprt/command.zig
@@ -1,0 +1,46 @@
+//! Whether the apprt for this build implements a given binding action.
+//! Command palettes use this to hide commands that would do nothing.
+//!
+//! Each apprt owns its own table:
+//!
+//!   * macOS, iOS: `embedded/command.zig`
+//!   * GTK: `gtk/command.zig`
+
+const build_config = @import("../build_config.zig");
+const Action = @import("../input/Binding.zig").Action;
+
+/// Mirrors the runtime selection in `apprt.zig`.
+const impl = switch (build_config.artifact) {
+    .exe => switch (build_config.app_runtime) {
+        .none => all,
+        .gtk => @import("gtk/command.zig"),
+    },
+    .lib => @import("embedded/command.zig"),
+    .wasm_module => all,
+};
+
+/// No apprt means no command palette, so nothing to hide.
+const all = struct {
+    fn supported(_: Action) bool {
+        return true;
+    }
+};
+
+/// Returns true if the apprt this build targets implements `action`.
+/// Actions the core handles itself are supported everywhere.
+pub fn supported(action: Action) bool {
+    return impl.supported(action);
+}
+
+comptime {
+    // Analyze every table, not just ours, so a new action is a compile
+    // error for all apprts at once. The `&` is required: `_ = f` resolves
+    // the decl without analyzing its body.
+    _ = &@import("embedded/command.zig").supported;
+    _ = &@import("gtk/command.zig").supported;
+}
+
+test {
+    _ = @import("embedded/command.zig");
+    _ = @import("gtk/command.zig");
+}

--- a/src/apprt/embedded/command.zig
+++ b/src/apprt/embedded/command.zig
@@ -1,0 +1,123 @@
+//! The binding actions the macOS and iOS apps implement. See
+//! `apprt/command.zig`.
+//!
+//! Actions still pending work in Swift go in `false`.
+
+const std = @import("std");
+const Action = @import("../../input/Binding.zig").Action;
+
+/// Returns true if the Apple apps implement `action`.
+pub fn supported(action: Action) bool {
+    return switch (action) {
+        // No case in the action dispatch in `Ghostty.App.swift`.
+        .move_tab_to_new_window,
+        .toggle_tab_overview,
+        .show_gtk_inspector,
+        .show_on_screen_keyboard,
+        .toggle_window_decorations,
+        .prompt_window_title,
+        .set_window_title,
+        => false,
+
+        // Implemented, or handled by the core with no apprt involvement.
+        .ignore,
+        .unbind,
+        .csi,
+        .esc,
+        .text,
+        .cursor_key,
+        .reset,
+        .copy_to_clipboard,
+        .paste_from_clipboard,
+        .paste_from_selection,
+        .copy_url_to_clipboard,
+        .copy_title_to_clipboard,
+        .increase_font_size,
+        .decrease_font_size,
+        .reset_font_size,
+        .set_font_size,
+        .search,
+        .search_selection,
+        .navigate_search,
+        .start_search,
+        .end_search,
+        .clear_screen,
+        .select_all,
+        .scroll_to_top,
+        .scroll_to_bottom,
+        .scroll_to_selection,
+        .scroll_to_row,
+        .scroll_page_up,
+        .scroll_page_down,
+        .scroll_page_fractional,
+        .scroll_page_lines,
+        .adjust_selection,
+        .jump_to_prompt,
+        .write_scrollback_file,
+        .write_screen_file,
+        .write_selection_file,
+        .new_window,
+        .new_tab,
+        .previous_tab,
+        .next_tab,
+        .last_tab,
+        .goto_tab,
+        .move_tab,
+        .prompt_surface_title,
+        .prompt_tab_title,
+        .set_surface_title,
+        .set_tab_title,
+        .new_split,
+        .goto_split,
+        .goto_window,
+        .toggle_split_zoom,
+        .toggle_readonly,
+        .resize_split,
+        .equalize_splits,
+        .reset_window_size,
+        .inspector,
+        .open_config,
+        .reload_config,
+        .close_surface,
+        .close_tab,
+        .close_window,
+        .close_all_windows,
+        .toggle_maximize,
+        .toggle_fullscreen,
+        .toggle_window_float_on_top,
+        .toggle_secure_input,
+        .toggle_mouse_reporting,
+        .toggle_command_palette,
+        .toggle_quick_terminal,
+        .toggle_visibility,
+        .toggle_background_opacity,
+        .check_for_updates,
+        .undo,
+        .redo,
+        .end_key_sequence,
+        .activate_key_table,
+        .activate_key_table_once,
+        .deactivate_key_table,
+        .deactivate_all_key_tables,
+        .quit,
+        .crash,
+        => true,
+    };
+}
+
+test "GTK-only actions are unsupported" {
+    const testing = std.testing;
+    try testing.expect(!supported(.show_gtk_inspector));
+    try testing.expect(!supported(.show_on_screen_keyboard));
+    try testing.expect(!supported(.toggle_tab_overview));
+    try testing.expect(!supported(.toggle_window_decorations));
+    try testing.expect(!supported(.move_tab_to_new_window));
+}
+
+test "macOS-only and core actions are supported" {
+    const testing = std.testing;
+    try testing.expect(supported(.toggle_secure_input));
+    try testing.expect(supported(.check_for_updates));
+    try testing.expect(supported(.undo));
+    try testing.expect(supported(.{ .copy_to_clipboard = .mixed }));
+}

--- a/src/apprt/gtk/class/command_palette.zig
+++ b/src/apprt/gtk/class/command_palette.zig
@@ -8,6 +8,7 @@ const gobject = @import("gobject");
 const gtk = @import("gtk");
 
 const input = @import("../../../input.zig");
+const command_support = @import("../command.zig");
 const gresource = @import("../build/gresource.zig");
 const key = @import("../key.zig");
 const WeakRef = @import("../weak_ref.zig").WeakRef;
@@ -191,7 +192,7 @@ pub const CommandPalette = extern struct {
         for (cfg.@"command-palette-entry".value.items) |command| {
             // Filter out actions that are not implemented or don't make sense
             // for GTK.
-            if (!isActionSupportedOnGtk(command.action)) continue;
+            if (!command_support.supported(command.action)) continue;
 
             const cmd = Command.new(config, command) catch |err| {
                 log.warn("failed to create command: {}", .{err});
@@ -204,22 +205,6 @@ pub const CommandPalette = extern struct {
                 continue;
             };
         }
-    }
-
-    /// Check if an action is supported on GTK.
-    fn isActionSupportedOnGtk(action: input.Binding.Action) bool {
-        return switch (action) {
-            .close_all_windows,
-            .toggle_secure_input,
-            .check_for_updates,
-            .redo,
-            .undo,
-            .reset_window_size,
-            .toggle_window_float_on_top,
-            => false,
-
-            else => true,
-        };
     }
 
     /// Collect jump commands for all surfaces across all windows.

--- a/src/apprt/gtk/command.zig
+++ b/src/apprt/gtk/command.zig
@@ -1,0 +1,122 @@
+//! The binding actions the GTK app implements. See `apprt/command.zig`.
+//!
+//! Actions still pending work in GTK go in `false`.
+
+const std = @import("std");
+const Action = @import("../../input/Binding.zig").Action;
+
+/// Returns true if the GTK app implements `action`.
+pub fn supported(action: Action) bool {
+    return switch (action) {
+        // In the "Unimplemented" prong of `class/application.zig`.
+        .reset_window_size,
+        .close_all_windows,
+        .toggle_window_float_on_top,
+        .toggle_secure_input,
+        .toggle_visibility,
+        .toggle_background_opacity,
+        .check_for_updates,
+        .undo,
+        .redo,
+        => false,
+
+        // Implemented, or handled by the core with no apprt involvement.
+        .ignore,
+        .unbind,
+        .csi,
+        .esc,
+        .text,
+        .cursor_key,
+        .reset,
+        .copy_to_clipboard,
+        .paste_from_clipboard,
+        .paste_from_selection,
+        .copy_url_to_clipboard,
+        .copy_title_to_clipboard,
+        .increase_font_size,
+        .decrease_font_size,
+        .reset_font_size,
+        .set_font_size,
+        .search,
+        .search_selection,
+        .navigate_search,
+        .start_search,
+        .end_search,
+        .clear_screen,
+        .select_all,
+        .scroll_to_top,
+        .scroll_to_bottom,
+        .scroll_to_selection,
+        .scroll_to_row,
+        .scroll_page_up,
+        .scroll_page_down,
+        .scroll_page_fractional,
+        .scroll_page_lines,
+        .adjust_selection,
+        .jump_to_prompt,
+        .write_scrollback_file,
+        .write_screen_file,
+        .write_selection_file,
+        .new_window,
+        .new_tab,
+        .previous_tab,
+        .next_tab,
+        .last_tab,
+        .goto_tab,
+        .move_tab,
+        .move_tab_to_new_window,
+        .toggle_tab_overview,
+        .prompt_surface_title,
+        .prompt_tab_title,
+        .prompt_window_title,
+        .set_surface_title,
+        .set_tab_title,
+        .set_window_title,
+        .new_split,
+        .goto_split,
+        .goto_window,
+        .toggle_split_zoom,
+        .toggle_readonly,
+        .resize_split,
+        .equalize_splits,
+        .inspector,
+        .show_gtk_inspector,
+        .show_on_screen_keyboard,
+        .open_config,
+        .reload_config,
+        .close_surface,
+        .close_tab,
+        .close_window,
+        .toggle_maximize,
+        .toggle_fullscreen,
+        .toggle_window_decorations,
+        .toggle_mouse_reporting,
+        .toggle_command_palette,
+        .toggle_quick_terminal,
+        .end_key_sequence,
+        .activate_key_table,
+        .activate_key_table_once,
+        .deactivate_key_table,
+        .deactivate_all_key_tables,
+        .quit,
+        .crash,
+        => true,
+    };
+}
+
+test "macOS-only actions are unsupported" {
+    const testing = std.testing;
+    try testing.expect(!supported(.check_for_updates));
+    try testing.expect(!supported(.toggle_secure_input));
+    try testing.expect(!supported(.toggle_window_float_on_top));
+    try testing.expect(!supported(.undo));
+    try testing.expect(!supported(.redo));
+}
+
+test "GTK-only and core actions are supported" {
+    const testing = std.testing;
+    try testing.expect(supported(.show_gtk_inspector));
+    try testing.expect(supported(.toggle_tab_overview));
+    try testing.expect(supported(.move_tab_to_new_window));
+    try testing.expect(supported(.{ .copy_to_clipboard = .mixed }));
+}

--- a/src/input/command.zig
+++ b/src/input/command.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const assert = @import("../quirks.zig").inlineAssert;
 const Allocator = std.mem.Allocator;
 const Action = @import("Binding.zig").Action;
+const apprt_command = @import("../apprt/command.zig");
 const i18n = @import("../os/i18n.zig");
 
 /// A command is a named binding action that can be executed from
@@ -27,6 +28,10 @@ pub const Command = struct {
         action: [*:0]const u8,
         title: [*:0]const u8,
         description: [*:0]const u8,
+
+        /// False if this build's apprt doesn't implement the action, so
+        /// performing it would do nothing. Palettes should hide these.
+        supported: bool,
     };
 
     pub fn clone(self: *const Command, alloc: Allocator) Allocator.Error!Command {
@@ -53,6 +58,7 @@ pub const Command = struct {
             .action = std.fmt.comptimePrint("{f}", .{self.action}),
             .title = self.title,
             .description = self.description,
+            .supported = apprt_command.supported(self.action),
         };
     }
 
@@ -74,6 +80,7 @@ pub const Command = struct {
             .action = action.ptr,
             .title = self.title,
             .description = self.description,
+            .supported = apprt_command.supported(self.action),
         };
     }
 


### PR DESCRIPTION
Raised during conversation in #10999.

* Added two command files for macOS and GTK to check whether an action is supported. So new action added in the future will have to update these two to avoid drifting.

* Fixes the entries both lists were missing:
  * macOS: `show_on_screen_keyboard`, `move_tab_to_new_window`
  * GTK: `toggle_background_opacity`, `toggle_visibility`

## AI Disclosure

Claude implemented this, i reviewed and **tested on macOS**, gtk part looks simple enough.