### PR TITLE
macos: sync appearance when new windows are created

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -1159,6 +1159,8 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
         }
 
         super.showWindow(sender)
+
+        syncAppearance()
     }
 
     // Shows the "+" button in the tab bar, responds to that click.


### PR DESCRIPTION
For new windows to get their appearance synced, we need to call `syncAppearance` after `super.showWindow(sender)`. All previous calls to `syncAppearance` on `TerminalWindow` will be ignored because the window needs to have `isVisible` set to `true`.

This regression was introduced by: 5368adcd29754939e6c283198ef6b1c122293815 

It added `.dropFirst()` to the `focusedSurface` appearance publishers in `TerminalController.swift` which removes the initial call of the subscription.

Fixes https://github.com/ghostty-org/ghostty/issues/13324

(landed on the same fix as @rasitakyol found here: https://github.com/ghostty-org/ghostty/pull/13341)