### PR TITLE
macOS: fix window sizing after dragging a split into a window

### DIFF
--- a/macos/Sources/Features/Terminal/TerminalController.swift
+++ b/macos/Sources/Features/Terminal/TerminalController.swift
@@ -344,13 +344,14 @@ class TerminalController: BaseTerminalController, TabGroupCloseCoordinator.Contr
         confirmUndo: Bool = true,
         inheritBackgroundOpacity: Bool? = nil
     ) -> TerminalController {
+        // Calculate the target frame based on the tree's view bounds
+        // before moving into the new window
+        let treeSize: CGSize? = tree.root?.viewBounds()
+
         let c = TerminalController.init(ghostty, withSurfaceTree: tree)
         if let inheritBackgroundOpacity {
             c.isBackgroundOpaque = inheritBackgroundOpacity
         }
-
-        // Calculate the target frame based on the tree's view bounds
-        let treeSize: CGSize? = tree.root?.viewBounds()
 
         c.scheduleInitialPresentation {
             c.showWindow(self)


### PR DESCRIPTION
Regression from [#13601](https://github.com/ghostty-org/ghostty/issues/13601), but I don't see why it matters. But the surface's bounds changes after window's created.