### PR TITLE
macOS: fix quit alert missing when hidden

### DIFF
--- a/macos/Sources/App/macOS/AppDelegate.swift
+++ b/macos/Sources/App/macOS/AppDelegate.swift
@@ -380,17 +380,6 @@ class AppDelegate: NSObject,
             return .terminateNow
         }
 
-        // This probably isn't fully safe. The isEmpty check above is aspirational, it doesn't
-        // quite work with SwiftUI because windows are retained on close. So instead we check
-        // if there are any that are visible. I'm guessing this breaks under certain scenarios.
-        //
-        // NOTE(mitchellh): I don't think we need this check at all anymore. I'm keeping it
-        // here because I don't want to remove it in a patch release cycle but we should
-        // target removing it soon.
-        if (windows.allSatisfy { !$0.isVisible }) {
-            return .terminateNow
-        }
-
         // If the user is shutting down, restarting, or logging out, we don't confirm quit.
         why: if let event = NSAppleEventManager.shared().currentAppleEvent {
             // If all Ghostty windows are in the background (i.e. you Cmd-Q from the Cmd-Tab

--- a/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
@@ -639,6 +639,16 @@ class QuickTerminalController: BaseTerminalController {
         terminalViewContainer?.ghosttyConfigDidChange(ghostty.config, preferredBackgroundColor: nil)
     }
 
+    override func confirmCloseAsync(messageText: String, informativeText: String, confirmButtonTitle: String = "Close") async -> NSApplication.ModalResponse? {
+
+        let waitTime = visible ? 0 : 0.25
+        animateIn()
+
+        try? await Task.sleep(for: .seconds(waitTime))
+
+        return await super.confirmCloseAsync(messageText: messageText, informativeText: informativeText, confirmButtonTitle: confirmButtonTitle)
+    }
+
     private func showNoNewTabAlert() {
         guard let window else { return }
         let alert = NSAlert()

--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -1254,7 +1254,7 @@ class BaseTerminalController: NSWindowController,
     /// Check whether window should be closed without showing an alert
     func windowCanBeClosedWithoutConfirmation() -> Bool {
         // We must have a window. Is it even possible not to?
-        guard let window = self.window else { return true }
+        guard window != nil else { return true }
 
         // If we have no surfaces, close.
         if surfaceTree.isEmpty { return true }


### PR DESCRIPTION
Fixes https://github.com/ghostty-org/ghostty/discussions/13685.

Removed presumably deprecated check introduced in 8f1a014afd9c6724b767b2fbf65d27d26b3c01e5 for update pill
> I checked for auto update as well, it works as before this, and for manual updates we're not confirming anyway, so I think its safe to remove it now.

Each BaseTerminalController already has quit check and confirming code added in that review windows pr. It didn't cover QT before, overriding it to animate in for showing alert.

[#5450](https://github.com/ghostty-org/ghostty/issues/5450) stays fixed.



https://github.com/user-attachments/assets/dbf36f16-e3ce-4f6a-bc25-367fe48739b9

