### PR TITLE
config: add gtk-drag-handle option

### DIFF
--- a/src/apprt/gtk/class/surface.zig
+++ b/src/apprt/gtk/class/surface.zig
@@ -2328,6 +2328,8 @@ pub const Surface = extern struct {
         const priv = self.private();
         const config = if (priv.config) |c| c.get() else return;
 
+        priv.drag_handle.setVisible(if (config.@"gtk-drag-handle") 1 else 0);
+
         // resize-overlay-duration
         {
             const ms = config.@"resize-overlay-duration".asMilliseconds();

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -3638,6 +3638,11 @@ else
 /// Available since: 1.1.0
 @"gtk-opengl-debug": bool = builtin.mode == .Debug,
 
+/// If `true` (default), show the top drag handle overlay on terminal surfaces.
+///
+/// Set this to `false` to hide the top drag handle overlay.
+@"gtk-drag-handle": bool = true,
+
 /// If `true`, the Ghostty GTK application will run in single-instance mode:
 /// each new `ghostty` process launched will result in a new window if there is
 /// already a running process.


### PR DESCRIPTION
This adds the `gtk-drag-handle` configuration option for GTK.

The option is boolean and defaults to `true`. Setting `gtk-drag-handle = false` hides the top drag handle overlay on terminal surfaces and disables dragging from that handle.

The setting applies during startup and configuration reloads.

Testing:

- Set `gtk-drag-handle = false`.
- Reloaded the running application.
- Confirmed that the top drag handle disappeared.
- Verified with `zig build`.

This code was written with assistance from GPT 5.6 Sol and manually reviewed.