### PR TITLE
gtk/wayland: clean up blur regions

### DIFF
--- a/src/apprt/gtk/winproto/wayland.zig
+++ b/src/apprt/gtk/winproto/wayland.zig
@@ -306,7 +306,7 @@ pub const Window = struct {
         }
 
         const wl_region = try compositor.createRegion();
-        errdefer if (wl_region) |r| r.destroy();
+        defer wl_region.destroy();
         for (region.slices.items) |s| wl_region.add(
             @intCast(s.x),
             @intCast(s.y),
@@ -315,6 +315,7 @@ pub const Window = struct {
         );
 
         bg.setBlurRegion(wl_region);
+        self.blur_region.deinit(self.globals.alloc);
         self.blur_region = region;
     }
 


### PR DESCRIPTION
Fix two resource leaks when the Wayland background blur region changes.

Temporary `wl_region` objects were destroyed only after an error. They are now always destroyed after the blur request. The previous cached blur region is also released before its replacement.

This change does not alter protocol selection or add new Wayland protocols.

Testing:

- Verified blur on KDE Plasma 6.7.4 with GTK 4.22.4.
- Verified with `zig build -Doptimize=ReleaseFast`.

This code was written with assistance from GPT 5.6 Sol and manually reviewed.