### PR TITLE
build: fix Linux Android SDK fallback path

### DIFF
--- a/pkg/android-ndk/build.zig
+++ b/pkg/android-ndk/build.zig
@@ -143,9 +143,8 @@ fn findNDKPath(b: *std.Build) ?[]const u8 {
         &.{
             home,
             switch (builtin.os.tag) {
-                .linux => "Android/sdk",
+                .linux, .windows => "Android/Sdk",
                 .macos => "Library/Android/Sdk",
-                .windows => "Android/Sdk",
                 else => return null,
             },
         },


### PR DESCRIPTION
Use the standard `~/Android/Sdk` capitalization for the Linux SDK fallback.

This lets NDK discovery work when neither `ANDROID_NDK_HOME` nor an `SDK` environment variable is set.