### PR TITLE
macOS: remove unused menu validations

### DIFF
--- a/macos/Sources/Features/Update/UpdateController.swift
+++ b/macos/Sources/Features/Update/UpdateController.swift
@@ -59,7 +59,7 @@ class UpdateController {
     /// Check for updates.
     ///
     /// This is typically connected to a menu item action.
-    @objc func checkForUpdates() {
+    func checkForUpdates() {
         // If we're already idle, then just check for updates immediately.
         if viewModel.state == .idle {
             updater.checkForUpdates()
@@ -99,17 +99,6 @@ class UpdateController {
         DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(100)) { [weak self] in
             self?.updater.checkForUpdates()
         }
-    }
-
-    /// Validate the check for updates menu item.
-    ///
-    /// - Parameter item: The menu item to validate
-    /// - Returns: Whether the menu item should be enabled
-    func validateMenuItem(_ item: NSMenuItem) -> Bool {
-        if item.action == #selector(checkForUpdates) {
-            return updater.canCheckForUpdates
-        }
-        return true
     }
 }
 


### PR DESCRIPTION
UpdateController isn't the target of any menu item, we don't need add menu validation here.