### PR TITLE
gtk: free hotkeys memory on app teardown

### DIFF
--- a/src/apprt/gtk/winproto/wayland/Hotkeys.zig
+++ b/src/apprt/gtk/winproto/wayland/Hotkeys.zig
@@ -82,7 +82,8 @@ pub fn init(alloc: Allocator, app_id: [:0]const u8) Allocator.Error!Hotkeys {
 /// Must leave the entries in a valid empty state: clear may still be
 /// called after deinit during application teardown.
 pub fn deinit(self: *Hotkeys) void {
-    self.clear();
+    for (self.entries.items) |*entry| entry.deinit();
+    self.entries.clearAndFree(self.alloc);
     self.alloc.free(self.app_id);
 }
 


### PR DESCRIPTION
In debug builds the DebugAllocator throws an error about leaked memory when you close Ghostty, if you have global keybinds in your config with a Wayland compositor that supports the vicinae-hotkey protocol. The cause is the `Hotkeys.entries` array list never actually being freed. Not really a problem because the list should be kept around until app teardown anyway, but not getting an error every time would be nice (even if you need a somewhat specific setup for this to even happen right now).

To fix this free the array list memory in Hotkeys.deinit with `ArrayList.clearAndFree`. As the existing comment on `deinit` already mentions, we can't use `ArrayList.deinit` because it leaves the list in an invalid state and `Hotkeys.clear` might still get called and use it.