### PR TITLE
config: fix open_config when the config directory is a symlink

### DIFF
--- a/src/config/edit.zig
+++ b/src/config/edit.zig
@@ -27,9 +27,19 @@ pub fn openPath(alloc_gpa: Allocator) ![:0]const u8 {
     // Get the path we should open
     const config_path = try configPath(alloc_arena);
 
-    // Create config directory recursively.
+    // Create config directory recursively, unless it is already there.
+    //
+    // The existence check is not just an optimization. When a component
+    // already exists, `createDirPath` verifies that it is a directory without
+    // following symlinks, deliberately, so that a dangling symlink cannot
+    // cause an infinite loop. A config directory symlinked into a dotfiles
+    // repository therefore fails with `error.NotDir` even though it is a
+    // perfectly good directory.
     if (std.fs.path.dirname(config_path)) |config_dir| {
-        try std.Io.Dir.cwd().createDirPath(global.io(), config_dir);
+        const cwd = std.Io.Dir.cwd();
+        cwd.access(global.io(), config_dir, .{}) catch {
+            try cwd.createDirPath(global.io(), config_dir);
+        };
     }
 
     // Try to create file and go on if it already exists


### PR DESCRIPTION
Fixes #13714.

`open_config` does nothing when the Ghostty configuration *directory* is a symlink, which is what you get by keeping your config in a dotfiles repository. No dialog, no editor, and the only trace is `error getting config file path: error.NotDir` on stderr.

### Cause

`openPath` creates the config directory before opening the file. When a path component already exists, `createDirPath` checks that it is a directory **without following symlinks** — `filePathKind` uses `statx` with `AT.SYMLINK_NOFOLLOW`, deliberately, so that a dangling symlink cannot cause an infinite loop. A symlink pointing at a perfectly good directory therefore reports kind `.sym_link` rather than `.directory`, and the call returns `error.NotDir` before anything reaches `xdg-open`.

This is not present in 1.3.1. It arrived with the Zig 0.16 migration in e8525c0fd, which substituted `std.fs.cwd().makePath` for `std.Io.Dir.cwd().createDirPath`. The migration is a faithful one-for-one change; the trap is that the two functions differ on exactly this edge case, because `makePath` checked with `statFile`, which follows symlinks.

### Fix

Skip the creation when the directory is already reachable. `access` follows symlinks, so the case that used to fail is now the case that needs no work, and a genuine failure to create still propagates from the unchanged `createDirPath` call.

### Why skipping is safe

`access` succeeding means the directory exists and is reachable, so there is nothing to create. `access` failing runs the original `createDirPath` under `try`, exactly as before.

There is one case where behaviour differs and it is worth stating: if the config-directory path exists but is **not** a directory, `access` succeeds, creation is skipped, and the failure surfaces one line later from `createFileAbsolute` instead. Both report an error; only the origin moves. That case is also unreachable in practice — with `$XDG_CONFIG_HOME/ghostty` as a regular file, Ghostty panics during startup long before any keybinding runs, and that panic reproduces on unmodified `main`, so it is a separate matter and out of scope here.

### Worth knowing before merging

**The Zig-side regression is transient.** 0.16.0 was never released; `main` builds against a beta snapshot. On Zig master the API has been renamed back to `makePath` and the existing-component check follows symlinks again, so this will most likely stop reproducing at the next Zig bump. The guard is cheap and correct against either Zig, but you may reasonably prefer to wait — I would rather say so than have you find out afterwards.

**`writeConfigTemplate` has the identical problem.** `Config.zig` takes `dirname` of the config file, i.e. the same symlinked directory, so a user with a symlinked config directory and no config file yet cannot get a template written either. I have deliberately not touched it here — happy to add it to this PR, or leave it for a separate one, whichever you prefer. Three other `createDirPath` sites are only affected if their own directories are symlinks, which is speculative, so I have left those alone.

### Testing

Reproduced on unmodified `main` with `ln -s ~/dotfiles/ghostty ~/.config/ghostty`. After the fix, `Ctrl+,` opens the editor and the log shows `mailbox message=open_config` with no error. `zig build test` passes; `zig fmt --check` clean.

Environment: Ubuntu 26.04, GNOME on Wayland, GTK 4.22.4, libadwaita 1.9.0.

---

**AI disclosure per `AI_POLICY.md`:** I diagnosed and patched this with Claude Code; I verified the reproduction on my own machine and reviewed and edited this description.
