### PR TITLE
build: stop building Ghostty.xcframework for iOS

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -50,7 +50,7 @@ dependencies:
 ### macOS
 
 Building the Ghostty macOS app requires that Xcode, the macOS SDK,
-the iOS SDK, and Metal Toolchain are all installed.
+and Metal Toolchain are all installed.
 
 A common issue is that the incorrect version of Xcode is either
 installed or selected. Use the `xcode-select` command to

--- a/macos/build.nu
+++ b/macos/build.nu
@@ -4,7 +4,7 @@
 # to avoid Nix shell interference (NIX_LDFLAGS, NIX_CFLAGS_COMPILE, etc.).
 
 def main [
-    --scheme: string = "Ghostty"       # Xcode scheme (Ghostty, Ghostty-iOS, DockTilePlugin)
+    --scheme: string = "Ghostty"       # Xcode scheme (Ghostty, DockTilePlugin)
     --configuration: string = "Debug"  # Build configuration (Debug, Release, ReleaseLocal)
     --action: string = "build"         # xcodebuild action (build, test, clean, etc.)
 ] {

--- a/nix/devShell.nix
+++ b/nix/devShell.nix
@@ -222,8 +222,7 @@ in
       '')
       + (lib.optionalString stdenv.hostPlatform.isDarwin ''
         # On macOS, we unset the macOS SDK env vars that Nix sets up because
-        # we rely on a system installation. Nix only provides a macOS SDK
-        # and we need iOS too.
+        # we rely on a system installation. Nix only provides a macOS SDK.
         unset SDKROOT
         unset DEVELOPER_DIR
 

--- a/src/build/Config.zig
+++ b/src/build/Config.zig
@@ -106,6 +106,17 @@ pub fn init(b: *std.Build, appVersion: []const u8, libVersion: []const u8) !Conf
             result = b.resolveTargetQuery(query);
         }
 
+        // The full Ghostty build no longer supports iOS; Fail early
+        // with a clear message rather than partway through the build.
+        if (result.result.os.tag == .ios and !emit_lib_vt) {
+            std.log.err(
+                "iOS is not a supported target for the full Ghostty build; " ++
+                    "only libghostty-vt supports iOS (-Demit-lib-vt)",
+                .{},
+            );
+            return error.UnsupportedTarget;
+        }
+
         // If we have no minimum OS version, we set the default based on
         // our tag. Not all tags have a minimum so this may be null.
         if (result.query.os_version_min == null) {
@@ -731,13 +742,6 @@ pub fn osVersionMin(tag: std.Target.Os.Tag) ?std.Target.Query.OsVersion {
             .patch = 0,
         } },
 
-        // The full Ghostty path compiles metal shaders that require iOS 14.
-        .ios => .{ .semver = .{
-            .major = 14,
-            .minor = 0,
-            .patch = 0,
-        } },
-
         // This should never happen currently. If we add a new target then
         // we should add a new case here.
         else => null,
@@ -748,7 +752,8 @@ pub fn osVersionMin(tag: std.Target.Os.Tag) ?std.Target.Query.OsVersion {
 ///
 /// This should only be used for Darwin targets.
 pub fn osVersionMinLibVt(tag: std.Target.Os.Tag) ?std.Target.Query.OsVersion {
-    // lib-vt has no newer deployment target requirement.
+    // lib-vt is the only thing we still build for iOS, so its deployment
+    // target lives here rather than in osVersionMin.
     if (tag == .ios) return .{ .semver = .{ .major = 13, .minor = 0, .patch = 0 } };
     return osVersionMin(tag);
 }

--- a/src/build/GhosttyXCFramework.zig
+++ b/src/build/GhosttyXCFramework.zig
@@ -24,35 +24,6 @@ pub fn init(
         Config.genericMacOSTarget(b, null),
     ));
 
-    // iOS
-    const ios = try GhosttyLib.initStatic(b, &try deps.retarget(
-        b,
-        b.resolveTargetQuery(.{
-            .cpu_arch = .aarch64,
-            .os_tag = .ios,
-            .os_version_min = Config.osVersionMin(.ios),
-            .abi = null,
-        }),
-    ));
-
-    // iOS Simulator
-    const ios_sim = try GhosttyLib.initStatic(b, &try deps.retarget(
-        b,
-        b.resolveTargetQuery(.{
-            .cpu_arch = .aarch64,
-            .os_tag = .ios,
-            .os_version_min = Config.osVersionMin(.ios),
-            .abi = .simulator,
-
-            // We force the Apple CPU model because the simulator
-            // doesn't support the generic CPU model as of Zig 0.14 due
-            // to missing "altnzcv" instructions, which is false. This
-            // surely can't be right but we can fix this if/when we get
-            // back to running simulator builds.
-            .cpu_model = .{ .explicit = &std.Target.aarch64.cpu.apple_a17 },
-        }),
-    ));
-
     // Generate a headers directory with only ghostty.h and the module
     // map. We can't use include/ directly because it also contains the
     // libghostty-vt headers under include/ghostty/, which would trigger
@@ -74,16 +45,6 @@ pub fn init(
                     .library = macos_universal.output,
                     .headers = headers,
                     .dsym = macos_universal.dsym,
-                },
-                .{
-                    .library = ios.output,
-                    .headers = headers,
-                    .dsym = ios.dsym,
-                },
-                .{
-                    .library = ios_sim.output,
-                    .headers = headers,
-                    .dsym = ios_sim.dsym,
                 },
             },
 

--- a/src/build/MetallibStep.zig
+++ b/src/build/MetallibStep.zig
@@ -24,20 +24,10 @@ output: LazyPath,
 pub fn create(b: *std.Build, opts: Options) ?*MetallibStep {
     const sdk = switch (opts.target.result.os.tag) {
         .macos => "macosx",
-        .ios => switch (opts.target.result.abi) {
-            // The iOS simulator uses the same SDK for Metal as the device,
-            // but the minimum version tag causes different behaviors.
-            .simulator => "iphoneos",
-            else => "iphoneos",
-        },
         else => return null,
     };
     const platform_version_arg = switch (opts.target.result.os.tag) {
         .macos => "-mmacos-version-min",
-        .ios => switch (opts.target.result.abi) {
-            .simulator => "-mios-simulator-version-min",
-            else => "-mios-version-min",
-        },
         else => null,
     };
 
@@ -47,7 +37,6 @@ pub fn create(b: *std.Build, opts: Options) ?*MetallibStep {
         b.fmt("{f}", .{v.semver})
     else switch (opts.target.result.os.tag) {
         .macos => "10.14",
-        .ios => "11.0",
         else => unreachable,
     };
 


### PR DESCRIPTION
Depends on https://github.com/ghostty-org/ghostty/pull/13759.

**Removing iOS for `Ghostty.xcframework` will affect other [awesome-libghostty](https://github.com/Uzaaft/awesome-libghostty) projects**, so I separated it.


### AI Disclosure

Claude ran the check and did the changes, I reviewed it. 