### PR TITLE
github: remove the issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,0 @@
-blank_issues_enabled: false
-contact_links:
-  - name: Features, Bug Reports, Questions
-    url: https://github.com/ghostty-org/ghostty/discussions/new/choose
-    about: Our preferred starting point if you have any questions or suggestions about configuration, features or behavior.

--- a/.github/ISSUE_TEMPLATE/preapproved.md
+++ b/.github/ISSUE_TEMPLATE/preapproved.md
@@ -1,9 +1,0 @@
----
-name: Pre-Discussed and Approved Topics
-about: |-
-  Only for topics already discussed and approved in the GitHub Discussions section.
----
-
-**DO NOT OPEN A NEW ISSUE. PLEASE USE THE DISCUSSIONS SECTION.**
-
-**I DIDN'T READ THE ABOVE LINE. PLEASE CLOSE THIS ISSUE.**


### PR DESCRIPTION
They're not needed anymore since the "New issue" button is now inaccessible to non-maintainers anyway.