### PR TITLE
config: flush autogenerated config template

### DIFF
--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -4121,6 +4121,7 @@ fn writeConfigTemplate(path: []const u8) !void {
         @embedFile("./config-template"),
         .{ .path = path },
     );
+    try writer.flush();
 }
 
 /// Load configurations from the default configuration files. The default


### PR DESCRIPTION
Fixes #13774

Simple one-line fix: added the missing flush to the function.

- `zig build` passed
- `zig build test` passed
- Confirmed template appears after fix in `~/Library/Application Support/com.mitchellh.ghostty/config.ghostty`

---
**AI Disclosure**

As mentioned before - I used OpenAI Codex (Sol 5.6 high):
a) to see if the template still exists & a function exists that tries to use the template
b) find the moment in history this behavior changed.
Additionally:
c) reviewing my work and draft a commit message matching your preferred style

I implemented the change, ran the build/test, manually verified the behavior, and understand the fix.