### PR TITLE
macOS: avoid holding SurfaceView when sending notifications

### DIFF
--- a/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
@@ -1787,20 +1787,22 @@ extension Ghostty {
 
             // Note the callback may be executed on a background thread as documented
             // so we need @MainActor since we're reading/writing view state.
-            Task { @MainActor in
+            // We use [weak self] here because we don't want to extend the surface's
+            // lifetime when a notification is triggered right before the surface closes.
+            Task { @MainActor [weak self] in
                 do {
                     try await UNUserNotificationCenter.current().add(request)
 
                     // We need to keep track of this notification so we can remove it
                     // under certain circumstances
-                    notificationIdentifiers.insert(uuid)
+                    self?.notificationIdentifiers.insert(uuid)
 
                     // If we're focused then we schedule to remove the notification
                     // after a few seconds. If we gain focus we automatically remove it
                     // in focusDidChange.
-                    if self.focused {
+                    if self?.focused == true {
                         try await Task.sleep(for: .seconds(3))
-                        notificationIdentifiers.remove(uuid)
+                        self?.notificationIdentifiers.remove(uuid)
                         UNUserNotificationCenter.current()
                             .removeDeliveredNotifications(withIdentifiers: [uuid])
                     }


### PR DESCRIPTION
We shouldn't hold a closing surface view when sending notifications. This happens rarely, but it's the right thing to do.

### AI Disclosure

Found by Claude when judging other branches, I applied the changes myself.