### PR TITLE
macos: fix build with Xcode 16.4 / macOS 15 SDK

### DIFF
--- a/macos/Sources/Features/Custom App Icon/DockTilePlugin.swift
+++ b/macos/Sources/Features/Custom App Icon/DockTilePlugin.swift
@@ -68,6 +68,10 @@ class DockTilePlugin: NSObject, NSDockTilePlugIn {
 
 private extension NSDockTile {
     func setIcon(_ newIcon: NSImage?) {
+        // The icon value crosses an isolation boundary into the main
+        // actor. NSImage isn't Sendable but is only used on the main
+        // thread after this point, so transfer it unsafely.
+        nonisolated(unsafe) let newIcon = newIcon
         // Update the Dock tile on the main thread.
         DispatchQueue.main.async {
             guard let newIcon else {

--- a/macos/Sources/Features/Terminal/TerminalViewContainer.swift
+++ b/macos/Sources/Features/Terminal/TerminalViewContainer.swift
@@ -8,7 +8,9 @@ class TerminalViewContainer: NSView {
 
     /// Combined glass effect and inactive tint overlay view
     private(set) var glassEffectView: NSView?
+#if compiler(>=6.2)
     private var derivedConfig: DerivedConfig?
+#endif
 
     var windowThemeFrameView: NSView? {
         window?.contentView?.superview
@@ -75,10 +77,12 @@ class TerminalViewContainer: NSView {
     }
 
     func ghosttyConfigDidChange(_ config: Ghostty.Config, preferredBackgroundColor: NSColor?) {
+#if compiler(>=6.2)
         let newValue = DerivedConfig(config: config, preferredBackgroundColor: preferredBackgroundColor, cornerRadius: windowCornerRadius)
         guard newValue != derivedConfig else { return }
         derivedConfig = newValue
         DispatchQueue.main.async(execute: updateGlassEffectIfNeeded)
+#endif // compiler(>=6.2)
     }
 }
 
@@ -250,6 +254,7 @@ extension TerminalViewContainer {
 #endif // compiler(>=6.2)
     }
 
+#if compiler(>=6.2)
     struct DerivedConfig: Equatable {
         let style: BackportNSGlassStyle
         let backgroundColor: NSColor
@@ -270,4 +275,5 @@ extension TerminalViewContainer {
             self.cornerRadius = cornerRadius
         }
     }
+#endif // compiler(>=6.2)
 }

--- a/macos/Sources/Ghostty/Surface View/SurfaceView.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView.swift
@@ -336,136 +336,151 @@ extension Ghostty {
 
         var body: some View {
             GeometryReader { geo in
-                HStack(spacing: 4) {
-                    BackportSelectionTextField(
-                        "Search",
-                        text: $searchState.needle.text,
-                        selection: $searchState.needle.selection
-                    )
-                    .textFieldStyle(.plain)
-                    .frame(width: 180)
-                    .padding(.leading, 8)
-                    .padding(.trailing, 50)
-                    .padding(.vertical, 6)
-                    .background(Color.primary.opacity(0.1))
-                    .cornerRadius(6)
-                    .focused($isSearchFieldFocused)
-                    .overlay(alignment: .trailing) {
-                        if let selected = searchState.selected {
-                            Text("\(selected + 1)/\(searchState.total, default: "?")")
-                                .font(.caption)
-                                .foregroundColor(.secondary)
-                                .monospacedDigit()
-                                .padding(.trailing, 8)
-                        } else if let total = searchState.total {
-                            Text("-/\(total)")
-                                .font(.caption)
-                                .foregroundColor(.secondary)
-                                .monospacedDigit()
-                                .padding(.trailing, 8)
-                        }
-                    }
-                    .onChange(of: searchState.needle.text) { _ in
-                        searchState.writePasteboardNeedle()
-                    }
-                    .onReceive(
-                        NotificationCenter.default.publisher(
-                            for: NSApplication.didBecomeActiveNotification
-                        )
-                    ) { _ in
-                        // When the app becomes active, we want to check for external changes
-                        // to our synced needle.
-                        searchState.readPasteboardNeedle()
-                    }
-                    .onSubmit {
-                        _ = surfaceView.navigateSearchToNext()
-                    }
-                    .onExitCommand {
-                        if searchState.needle.text.isEmpty {
-                            onClose()
-                        } else {
-                            Ghostty.moveFocus(to: surfaceView)
-                        }
-                    }
-                    .backport.onKeyPress(.return) { modifiers in
-                        if modifiers.contains(.shift) {
-                            _ = surfaceView.navigateSearchToPrevious()
-                            return .handled
-                        }
-                        return .ignored
-                    }
-
-                    Button(action: {
-                        _ = surfaceView.navigateSearchToNext()
-                    }, label: {
-                        Image(systemName: "chevron.up")
-                    })
-                    .buttonStyle(SearchButtonStyle())
-
-                    Button(action: {
-                        guard let surface = surfaceView.surface else { return }
-                        let action = "navigate_search:previous"
-                        ghostty_surface_binding_action(surface, action, UInt(action.lengthOfBytes(using: .utf8)))
-                    }, label: {
-                        Image(systemName: "chevron.down")
-                    })
-                    .buttonStyle(SearchButtonStyle())
-
-                    Button(action: onClose) {
-                        Image(systemName: "xmark")
-                    }
-                    .buttonStyle(SearchButtonStyle())
-                }
-                .padding(8)
-                .background(.background)
-                .clipShape(clipShape)
-                .shadow(radius: 4)
-                .onAppear {
-                    isSearchFieldFocused = true
-                }
-                .onReceive(NotificationCenter.default.publisher(for: .ghosttySearchFocus)) { notification in
-                    guard notification.object as? SurfaceView === surfaceView else { return }
-                    DispatchQueue.main.async {
+                searchBar
+                    .onAppear {
                         isSearchFieldFocused = true
                     }
-                }
-                .background(
-                    GeometryReader { barGeo in
-                        Color.clear.onAppear {
-                            barSize = barGeo.size
+                    .onReceive(NotificationCenter.default.publisher(for: .ghosttySearchFocus)) { notification in
+                        guard notification.object as? SurfaceView === surfaceView else { return }
+                        DispatchQueue.main.async {
+                            isSearchFieldFocused = true
                         }
                     }
-                )
-                .padding(padding)
-                .offset(dragOffset)
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: corner.alignment)
-                .gesture(
-                    DragGesture()
-                        .onChanged { value in
-                            dragOffset = value.translation
-                        }
-                        .onEnded { value in
-                            let centerPos = centerPosition(for: corner, in: geo.size, barSize: barSize)
-                            let newCenter = CGPoint(
-                                x: centerPos.x + value.translation.width,
-                                y: centerPos.y + value.translation.height
-                            )
-                            let newCorner = closestCorner(to: newCenter, in: geo.size)
-                            withAnimation(.easeOut(duration: 0.2)) {
-                                corner = newCorner
-                                dragOffset = .zero
+                    .background(
+                        GeometryReader { barGeo in
+                            Color.clear.onAppear {
+                                barSize = barGeo.size
                             }
                         }
+                    )
+                    .padding(padding)
+                    .offset(dragOffset)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: corner.alignment)
+                    .gesture(
+                        DragGesture()
+                            .onChanged { value in
+                                dragOffset = value.translation
+                            }
+                            .onEnded { value in
+                                let centerPos = centerPosition(for: corner, in: geo.size, barSize: barSize)
+                                let newCenter = CGPoint(
+                                    x: centerPos.x + value.translation.width,
+                                    y: centerPos.y + value.translation.height
+                                )
+                                let newCorner = closestCorner(to: newCenter, in: geo.size)
+                                withAnimation(.easeOut(duration: 0.2)) {
+                                    corner = newCorner
+                                    dragOffset = .zero
+                                }
+                            }
+                    )
+            }
+        }
+
+        /// The search bar content: text field plus navigation buttons.
+        private var searchBar: some View {
+            HStack(spacing: 4) {
+                searchField
+
+                Button(action: {
+                    _ = surfaceView.navigateSearchToNext()
+                }, label: {
+                    Image(systemName: "chevron.up")
+                })
+                .buttonStyle(SearchButtonStyle())
+
+                Button(action: {
+                    guard let surface = surfaceView.surface else { return }
+                    let action = "navigate_search:previous"
+                    ghostty_surface_binding_action(surface, action, UInt(action.lengthOfBytes(using: .utf8)))
+                }, label: {
+                    Image(systemName: "chevron.down")
+                })
+                .buttonStyle(SearchButtonStyle())
+
+                Button(action: onClose) {
+                    Image(systemName: "xmark")
+                }
+                .buttonStyle(SearchButtonStyle())
+            }
+            .padding(8)
+            .background(.background)
+            .clipShape(clipShape)
+            .shadow(radius: 4)
+        }
+
+        /// The search text field with its syncing and keyboard handling.
+        private var searchField: some View {
+            BackportSelectionTextField(
+                "Search",
+                text: $searchState.needle.text,
+                selection: $searchState.needle.selection
+            )
+            .textFieldStyle(.plain)
+            .frame(width: 180)
+            .padding(.leading, 8)
+            .padding(.trailing, 50)
+            .padding(.vertical, 6)
+            .background(Color.primary.opacity(0.1))
+            .cornerRadius(6)
+            .focused($isSearchFieldFocused)
+            .overlay(alignment: .trailing) {
+                if let selected = searchState.selected {
+                    let totalText = searchState.total.map { String($0) } ?? "?"
+                    Text("\(selected + 1)/\(totalText)")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .monospacedDigit()
+                        .padding(.trailing, 8)
+                } else if let total = searchState.total {
+                    Text("-/\(total)")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .monospacedDigit()
+                        .padding(.trailing, 8)
+                }
+            }
+            .onChange(of: searchState.needle.text) { _ in
+                searchState.writePasteboardNeedle()
+            }
+            .onReceive(
+                NotificationCenter.default.publisher(
+                    for: NSApplication.didBecomeActiveNotification
                 )
+            ) { _ in
+                // When the app becomes active, we want to check for external changes
+                // to our synced needle.
+                searchState.readPasteboardNeedle()
+            }
+            .onSubmit {
+                _ = surfaceView.navigateSearchToNext()
+            }
+            .onExitCommand {
+                if searchState.needle.text.isEmpty {
+                    onClose()
+                } else {
+                    Ghostty.moveFocus(to: surfaceView)
+                }
+            }
+            .backport.onKeyPress(.return) { modifiers in
+                if modifiers.contains(.shift) {
+                    _ = surfaceView.navigateSearchToPrevious()
+                    return .handled
+                }
+                return .ignored
             }
         }
 
         private var clipShape: some Shape {
+#if compiler(>=6.2)
             if #available(macOS 26.0, *) {
                 return ConcentricRectangle(corners: .concentric(minimum: 8), isUniform: true)
             } else {
                 return RoundedRectangle(cornerRadius: 8)
             }
+#else
+            return RoundedRectangle(cornerRadius: 8)
+#endif // compiler(>=6.2)
         }
 
         enum Corner {

--- a/macos/Sources/Helpers/Backport.swift
+++ b/macos/Sources/Helpers/Backport.swift
@@ -104,6 +104,7 @@ enum BackportPointerStyle {
     }
 }
 
+#if compiler(>=6.2)
 enum BackportNSGlassStyle {
     case regular, clear
 
@@ -115,6 +116,7 @@ enum BackportNSGlassStyle {
         }
     }
 }
+#endif // compiler(>=6.2)
 
 /// Backported `TextField` that supports text selection on macOS 26 and up. The `selection`
 /// has no effect on versions below macOS 26.


### PR DESCRIPTION
Swift 6.1.2 in Xcode 16.4 is stricter than the Swift 6.2 toolchain the project builds with. Guard the macOS 26-only glass effect APIs (NSGlassEffectView and ConcentricRectangle) and the Swift 6.2-only string interpolation feature with `#if compiler(>=6.2)` so the app still compiles against the macOS 15 SDK. Older toolchains fall back to a rounded rectangle clip shape and skip the liquid glass overlay.

The search overlay body in SurfaceView timed out the Swift 6.1 type checker, so it is split into `searchBar` and `searchField` computed properties.

DockTilePlugin's `setIcon` captures a task-isolated `NSImage` in a main actor closure, which Swift 6.1 region isolation rejects. The icon is only used on the main thread after the hop, so it is transferred with `nonisolated(unsafe)`.