### PR TITLE
WIP - Fix Window Title Bar transparency issue in GTK.

### DIFF
--- a/src/apprt/gtk/class/application.zig
+++ b/src/apprt/gtk/class/application.zig
@@ -959,6 +959,17 @@ pub const Application = extern struct {
         const headerbar_background = config.@"window-titlebar-background" orelse config.background;
         const headerbar_foreground = config.@"window-titlebar-foreground" orelse config.foreground;
 
+        // Keep the headerbar opaque and driven purely by the system theme.
+        // The `ghostty` window theme overrides `windowhandle` below.
+        if (config.@"gtk-toolbar-style" != .flat) {
+            try writer.writeAll(
+                \\windowhandle {
+                \\  background-color: @headerbar_bg_color;
+                \\}
+                \\
+            );
+        }
+
         switch (window_theme) {
             .ghostty => try writer.print(
                 \\windowhandle {{
@@ -1081,6 +1092,19 @@ pub const Application = extern struct {
             \\}
             \\
         );
+
+        // Keep the headerbar opaque and driven purely by the system theme.
+        // The `flat` toolbar style is excluded because a transparent headerbar
+        // is intentional there. The `ghostty` window theme overrides
+        // `--headerbar-bg-color` below.
+        if (config.@"gtk-toolbar-style" != .flat) {
+            try writer.writeAll(
+                \\windowhandle {
+                \\  background-color: var(--headerbar-bg-color);
+                \\}
+                \\
+            );
+        }
 
         switch (window_theme) {
             .ghostty => try writer.print(


### PR DESCRIPTION
#3190 

### Issue:
- When using a system GTK theme, if the `background-opacity` is set to anything lower than 1, the window title bar becomes completely transparent. 

### Cause:
- Terminal translucency comes from the GL renderer (`background-opacity` baked into the clear-color alpha), not CSS.
- For the desktop to show through it, the GTK top-level must not paint an opaque backdrop. So `Window.syncAppearance` strips libadwaita's built-in `.background` class when `opacity < 1`.
- That strips the backdrop from the whole window, including behind the raised headerbar, which borrows it. Result: transparent titlebar. (`window-theme = ghostty` was unaffected only because it already sets its own windowhandle background.)

### Fix:
Updated the logic in `src/apprt/gtk/class/application.zig` so that the window title bar now always gets its background from the system theme (`--headerbar-bg-color` on `GTK ≥ 4.16`, `@headerbar_bg_color` before), independent of `background-opacity`.

### Tests:
- Manually tested by building the app locally. Build command:

```
env PATH="/var/tmp/bin:$PATH" \
    zig build -Doptimize=ReleaseFast -fno-sys=gtk4-layer-shell \
    --cache-dir /tmp/ghostty-build/cache \
    --global-cache-dir /tmp/ghostty-build/global \
    --prefix /tmp/ghostty-build/out
```

Config in `~/.config/ghostty/config.ghostty`:

```
theme = Catppuccin Mocha

background-opacity = 0.9
```

Results:

Before fix|After fix
-|-
<img width="1803" height="1291" alt="1-before" src="https://github.com/user-attachments/assets/4aad405e-8718-414a-add6-7845739e56bb" />|<img width="1803" height="1291" alt="2-after" src="https://github.com/user-attachments/assets/50ac1333-e42f-4ce2-9a86-9424ad0bc1c1" />

### AI Usage
- I've used @claude to investigate the cause and apply the fix.
- I've tested this manually by building the app on local to validate the fix by AI.


