### PR TITLE
Add Serbian translation

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -192,6 +192,8 @@
 /po/pl.po @ghostty-org/pl_PL
 /po/pt_BR.po @ghostty-org/pt_BR
 /po/ru.po @ghostty-org/ru_RU
+/po/sr.po @ghostty-org/sr_RS
+/po/sr@latin.po @ghostty-org/sr_RS
 /po/tr.po @ghostty-org/tr_TR
 /po/uk.po @ghostty-org/uk_UA
 /po/vi.po @ghostty-org/vi_VN

--- a/po/sr.po
+++ b/po/sr.po
@@ -15,7 +15,6 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 3.9\n"
 
 #: dist/linux/ghostty_nautilus.py:53
 msgid "Open in Ghostty"

--- a/po/sr.po
+++ b/po/sr.po
@@ -26,7 +26,7 @@ msgstr "Отвори у Ghostty-ју"
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:197
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:201
 msgid "Authorize Clipboard Access"
-msgstr "Овласти приступ остави"
+msgstr "Одобри приступ остави"
 
 #: src/apprt/gtk/ui/1.0/clipboard-confirmation-dialog.blp:17
 #: src/apprt/gtk/ui/1.4/clipboard-confirmation-dialog.blp:17

--- a/po/sr.po
+++ b/po/sr.po
@@ -1,0 +1,1100 @@
+# Language SR translations for com.mitchellh.ghostty package.
+# Copyright (C) 2026 "Mitchell Hashimoto, Ghostty contributors"
+# This file is distributed under the same license as the com.mitchellh.ghostty package.
+# Марко Костић <marko.m.kostic@gmail.com>, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: com.mitchellh.ghostty\n"
+"Report-Msgid-Bugs-To: m@mitchellh.com\n"
+"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"PO-Revision-Date: 2026-08-15 10:28+0200\n"
+"Last-Translator: Марко Костић <marko.m.kostic@gmail.com>\n"
+"Language-Team: Language SR\n"
+"Language: sr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.9\n"
+
+#: dist/linux/ghostty_nautilus.py:53
+msgid "Open in Ghostty"
+msgstr "Отвори у Ghostty-ју"
+
+#: src/apprt/gtk/ui/1.0/clipboard-confirmation-dialog.blp:12
+#: src/apprt/gtk/ui/1.4/clipboard-confirmation-dialog.blp:12
+#: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:197
+#: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:201
+msgid "Authorize Clipboard Access"
+msgstr "Овласти приступ остави"
+
+#: src/apprt/gtk/ui/1.0/clipboard-confirmation-dialog.blp:17
+#: src/apprt/gtk/ui/1.4/clipboard-confirmation-dialog.blp:17
+msgid "Deny"
+msgstr "Одбиј"
+
+#: src/apprt/gtk/ui/1.0/clipboard-confirmation-dialog.blp:18
+#: src/apprt/gtk/ui/1.4/clipboard-confirmation-dialog.blp:18
+msgid "Allow"
+msgstr "Дозволи"
+
+#: src/apprt/gtk/ui/1.4/clipboard-confirmation-dialog.blp:92
+msgid "Remember choice for this split"
+msgstr "Запамти избор за ову разделу"
+
+#: src/apprt/gtk/ui/1.4/clipboard-confirmation-dialog.blp:93
+msgid "Reload configuration to show this prompt again"
+msgstr "Поново учитај поставке да би се овај упит поново приказао"
+
+#: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
+#: src/apprt/gtk/ui/1.5/title-dialog.blp:8
+#: src/apprt/gtk/class/application.zig:2263
+msgid "Cancel"
+msgstr "Откажи"
+
+#: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:8
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:90
+#: src/apprt/gtk/ui/1.3/surface-child-exited.blp:17
+msgid "Close"
+msgstr "Затвори"
+
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:6
+msgid "Configuration Errors"
+msgstr "Грешке у поставкама"
+
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:8
+msgid ""
+"One or more configuration errors were found. Please review the errors below, "
+"and either reload your configuration or ignore these errors."
+msgstr ""
+"Пронађена је једна или више грешака у поставкама. Прегледајте грешке испод, "
+"и поново учитајте своје поставке или занемарите ове грешке."
+
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:12
+msgid "Ignore"
+msgstr "Занемари"
+
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:13
+#: src/apprt/gtk/ui/1.2/surface.blp:439 src/apprt/gtk/ui/1.5/window.blp:318
+msgid "Reload Configuration"
+msgstr "Поново учитај поставке"
+
+#: src/apprt/gtk/ui/1.2/debug-warning.blp:7
+#: src/apprt/gtk/ui/1.3/debug-warning.blp:6
+msgid ""
+"⚠️ You're running a debug build of Ghostty! Performance will be degraded."
+msgstr "⚠️ Покрећете издање Ghostty-ја за отклањање грешака! Перформансе биће смањене."
+
+#: src/apprt/gtk/ui/1.5/inspector-window.blp:5
+msgid "Ghostty: Terminal Inspector"
+msgstr "Ghostty: инспектор терминала"
+
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:29
+msgid "Find…"
+msgstr "Нађи…"
+
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:69
+msgid "Previous Match"
+msgstr "Претходно поклапање"
+
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:79
+msgid "Next Match"
+msgstr "Следеће поклапање"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:7
+msgid "Oh, no."
+msgstr "О, не."
+
+#: src/apprt/gtk/ui/1.2/surface.blp:8
+msgid "Unable to acquire an OpenGL context for rendering."
+msgstr "Није било могуће обезбедити OpenGL контекст за исцртавање."
+
+#: src/apprt/gtk/ui/1.2/surface.blp:101
+msgid ""
+"This terminal is in read-only mode. You can still view, select, and scroll "
+"through the content, but no input events will be sent to the running "
+"application."
+msgstr ""
+"Овај терминал је у режиму само за читање. И даље можете прегледати, бирати и "
+"помицати садржај, али догађаји уноса неће бити послати покренутом програму."
+
+#: src/apprt/gtk/ui/1.2/surface.blp:112
+msgid "Read-only"
+msgstr "Само за читање"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:316 src/apprt/gtk/ui/1.5/window.blp:203
+msgid "Copy"
+msgstr "Копирај"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:321 src/apprt/gtk/ui/1.5/window.blp:208
+msgid "Paste"
+msgstr "Убаци"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:326
+msgid "Notify on Next Command Finish"
+msgstr "Обавести када се следећа наредба заврши"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:333 src/apprt/gtk/ui/1.5/window.blp:281
+msgid "Clear"
+msgstr "Очисти"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:338 src/apprt/gtk/ui/1.5/window.blp:286
+msgid "Reset"
+msgstr "Врати"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:345 src/apprt/gtk/ui/1.5/window.blp:250
+msgid "Split"
+msgstr "Раздели"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:348 src/apprt/gtk/ui/1.5/window.blp:253
+msgid "Change Title…"
+msgstr "Промени наслов…"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:353 src/apprt/gtk/ui/1.5/window.blp:180
+#: src/apprt/gtk/ui/1.5/window.blp:258 src/input/command.zig:487
+msgid "Split Up"
+msgstr "Раздели нагоре"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:359 src/apprt/gtk/ui/1.5/window.blp:185
+#: src/apprt/gtk/ui/1.5/window.blp:263 src/input/command.zig:492
+msgid "Split Down"
+msgstr "Раздели доле"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:365 src/apprt/gtk/ui/1.5/window.blp:190
+#: src/apprt/gtk/ui/1.5/window.blp:268 src/input/command.zig:477
+msgid "Split Left"
+msgstr "Раздели лево"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:195
+#: src/apprt/gtk/ui/1.5/window.blp:273 src/input/command.zig:482
+msgid "Split Right"
+msgstr "Раздели десно"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:377
+msgid "Close Split"
+msgstr "Затвори разделу"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:383
+msgid "Tab"
+msgstr "Језичак"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:386 src/apprt/gtk/ui/1.5/window.blp:232
+#: src/apprt/gtk/ui/1.5/window.blp:339 src/input/command.zig:464
+msgid "Change Tab Title…"
+msgstr "Промени наслов језичка…"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:391 src/apprt/gtk/ui/1.5/window.blp:60
+#: src/apprt/gtk/ui/1.5/window.blp:110 src/apprt/gtk/ui/1.5/window.blp:237
+#: src/input/command.zig:427
+msgid "New Tab"
+msgstr "Нови језичак"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/input/command.zig:613
+msgid "Close Tab"
+msgstr "Затвори језичак"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:403
+msgid "Window"
+msgstr "Прозор"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:406 src/apprt/gtk/ui/1.5/window.blp:215
+msgid "Change Window Title…"
+msgstr "Промени наслов прозора…"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:411 src/apprt/gtk/ui/1.5/window.blp:220
+#: src/input/command.zig:421
+msgid "New Window"
+msgstr "Нови прозор"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:416 src/apprt/gtk/ui/1.5/window.blp:225
+#: src/input/command.zig:630
+msgid "Close Window"
+msgstr "Затвори прозор"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:424 src/apprt/gtk/ui/1.5/window.blp:303
+msgid "Config"
+msgstr "Подешавања"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:427 src/apprt/gtk/ui/1.5/window.blp:306
+msgid "Open Configuration in OS Editor"
+msgstr "Отвори поставке у уређивачу ОС-а"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:433 src/apprt/gtk/ui/1.5/window.blp:312
+msgid "Open Configuration in New Window"
+msgstr "Отвори поставке у новом прозору"
+
+#: src/apprt/gtk/ui/1.5/title-dialog.blp:5
+msgid "Leave blank to restore the default title."
+msgstr "Оставите празно да бисте вратили подразумевани наслов."
+
+#: src/apprt/gtk/ui/1.5/title-dialog.blp:9
+msgid "OK"
+msgstr "У реду"
+
+#: src/apprt/gtk/ui/1.5/window.blp:61 src/apprt/gtk/ui/1.5/window.blp:111
+msgid "New Split"
+msgstr "Нова раздела"
+
+#: src/apprt/gtk/ui/1.5/window.blp:71 src/apprt/gtk/ui/1.5/window.blp:129
+msgid "View Open Tabs"
+msgstr "Прикажи отворене језичке"
+
+#: src/apprt/gtk/ui/1.5/window.blp:81 src/apprt/gtk/ui/1.5/window.blp:143
+msgid "Main Menu"
+msgstr "Главни мени"
+
+#: src/apprt/gtk/ui/1.5/window.blp:293
+msgid "Command Palette"
+msgstr "Палета наредби"
+
+#: src/apprt/gtk/ui/1.5/window.blp:298
+msgid "Terminal Inspector"
+msgstr "Инспектор терминала"
+
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1991
+msgid "About Ghostty"
+msgstr "О програму Ghostty"
+
+#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:702
+msgid "Quit"
+msgstr "Изађи"
+
+#: src/apprt/gtk/ui/1.5/command-palette.blp:17
+msgid "Execute a command…"
+msgstr "Изврши наредбу…"
+
+#: src/apprt/gtk/class/application.zig:1767
+msgid "The keybind was revoked by the system."
+msgstr "Систем је опозвао пречицу."
+
+#: src/apprt/gtk/class/application.zig:1769
+msgid "The keybind was denied by the system."
+msgstr "Систем је одбио пречицу."
+
+#: src/apprt/gtk/class/application.zig:1780
+msgid "Global keybind unavailable"
+msgstr "Глобална пречица није доступна"
+
+#: src/apprt/gtk/class/application.zig:2259
+msgid "Export Terminal IO Events"
+msgstr "Извези догађаје улаза/излаза терминала"
+
+#: src/apprt/gtk/class/application.zig:2262
+msgid "Export"
+msgstr "Извези"
+
+#: src/apprt/gtk/class/application.zig:2783
+msgid "Editing configuration file"
+msgstr "Уређивање датотеке са поставкама"
+
+#: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
+msgid ""
+"An application is attempting to write to the clipboard. The current "
+"clipboard contents are shown below."
+msgstr ""
+"Програм покушава да пише у оставу. Тренутни садржај оставе је приказан испод."
+
+#: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:202
+msgid ""
+"An application is attempting to read from the clipboard. The current "
+"clipboard contents are shown below."
+msgstr ""
+"Програм покушава да чита из оставе. Тренутни садржај оставе је приказан "
+"испод."
+
+#: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:205
+msgid "Warning: Potentially Unsafe Paste"
+msgstr "Упозорење: потенцијално небезбедно убацивање"
+
+#: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:206
+msgid ""
+"Pasting this text into the terminal may be dangerous as it looks like some "
+"commands may be executed."
+msgstr ""
+"Убацивање овог текста у терминал може бити опасно јер изгледа као да се неке "
+"наредбе могу извршити."
+
+#: src/apprt/gtk/class/close_confirmation_dialog.zig:184
+msgid "Quit Ghostty?"
+msgstr "Изаћи из Ghostty-ја?"
+
+#: src/apprt/gtk/class/close_confirmation_dialog.zig:185
+msgid "Close Tab?"
+msgstr "Да затворим језичак?"
+
+#: src/apprt/gtk/class/close_confirmation_dialog.zig:186
+msgid "Close Window?"
+msgstr "Да затворим прозор?"
+
+#: src/apprt/gtk/class/close_confirmation_dialog.zig:187
+msgid "Close Split?"
+msgstr "Затворити разделу?"
+
+#: src/apprt/gtk/class/close_confirmation_dialog.zig:193
+msgid "All terminal sessions will be terminated."
+msgstr "Све сесије терминала биће прекинуте."
+
+#: src/apprt/gtk/class/close_confirmation_dialog.zig:194
+msgid "All terminal sessions in this tab will be terminated."
+msgstr "Све сесије терминала у овом језичку биће прекинуте."
+
+#: src/apprt/gtk/class/close_confirmation_dialog.zig:195
+msgid "All terminal sessions in this window will be terminated."
+msgstr "Све сесије терминала у овом прозору биће прекинуте."
+
+#: src/apprt/gtk/class/close_confirmation_dialog.zig:196
+msgid "The currently running process in this split will be terminated."
+msgstr "Тренутно покренут процес у овој раздели биће прекинут."
+
+#: src/apprt/gtk/class/surface.zig:1181
+msgid "Command Finished"
+msgstr "Наредба је завршена"
+
+#: src/apprt/gtk/class/surface.zig:1182
+#: src/apprt/gtk/class/surface_child_exited.zig:109
+msgid "Command Succeeded"
+msgstr "Наредба је успешно извршена"
+
+#: src/apprt/gtk/class/surface.zig:1183
+#: src/apprt/gtk/class/surface_child_exited.zig:113
+msgid "Command Failed"
+msgstr "Наредба није успела"
+
+#: src/apprt/gtk/class/title_dialog.zig:227
+msgid "Change Terminal Title"
+msgstr "Промени наслов терминала"
+
+#: src/apprt/gtk/class/title_dialog.zig:228
+msgid "Change Tab Title"
+msgstr "Промени наслов језичка"
+
+#: src/apprt/gtk/class/title_dialog.zig:229
+msgid "Change Window Title"
+msgstr "Промени наслов прозора"
+
+#: src/apprt/gtk/class/window.zig:1153
+msgid "Reloaded the configuration"
+msgstr "Поново учитане поставке"
+
+#: src/apprt/gtk/class/window.zig:1830
+msgid "Copied to clipboard"
+msgstr "Копирано у оставу"
+
+#: src/apprt/gtk/class/window.zig:1832
+msgid "Cleared clipboard"
+msgstr "Остава очишћена"
+
+#: src/apprt/gtk/class/window.zig:1972
+msgid "Ghostty Developers"
+msgstr "Програмери Ghostty-ја"
+
+#: src/input/command.zig:149
+msgid "Reset Terminal"
+msgstr "Поврати терминал"
+
+#: src/input/command.zig:150
+msgid "Reset the terminal to a clean state."
+msgstr "Врати терминал у чисто стање."
+
+#: src/input/command.zig:155
+msgid "Copy to Clipboard"
+msgstr "Копирај у оставу"
+
+#: src/input/command.zig:156
+msgid ""
+"Copy the selected text to the clipboard in both plain and styled formats."
+msgstr "Копирај изабрани текст у оставу у обичном и обликованом формату."
+
+#: src/input/command.zig:159
+msgid "Copy Selection as Plain Text to Clipboard"
+msgstr "Копирај изабрано као обичан текст у оставу"
+
+#: src/input/command.zig:160
+msgid "Copy the selected text as plain text to the clipboard."
+msgstr "Копирај изабрани текст као обичан текст у оставу."
+
+#: src/input/command.zig:163
+msgid "Copy Selection as ANSI Sequences to Clipboard"
+msgstr "Копирај изабрано као ANSI низове у оставу"
+
+#: src/input/command.zig:164
+msgid "Copy the selected text as ANSI escape sequences to the clipboard."
+msgstr "Копирај изабрани текст као ANSI излазне низове у оставу."
+
+#: src/input/command.zig:167
+msgid "Copy Selection as HTML to Clipboard"
+msgstr "Копирај изабрано као хтмл у оставу"
+
+#: src/input/command.zig:168
+msgid "Copy the selected text as HTML to the clipboard."
+msgstr "Копирајте изабрани текст као хтмл у оставу."
+
+#: src/input/command.zig:173
+msgid "Copy URL to Clipboard"
+msgstr "Копирај УРЛ у оставу"
+
+#: src/input/command.zig:174
+msgid "Copy the URL under the cursor to the clipboard."
+msgstr "Копирајте УРЛ испод показивача у оставу."
+
+#: src/input/command.zig:179
+msgid "Copy Terminal Title to Clipboard"
+msgstr "Копирај наслов терминала у оставу"
+
+#: src/input/command.zig:180
+msgid ""
+"Copy the terminal title to the clipboard. If the terminal title is not set "
+"this has no effect."
+msgstr "Копирајте наслов терминала у оставу. Ако наслов терминала није постављен, ово неће имати дејства."
+
+#: src/input/command.zig:185
+msgid "Paste from Clipboard"
+msgstr "Убаци из оставе"
+
+#: src/input/command.zig:186
+msgid "Paste the contents of the main clipboard."
+msgstr "Убаците садржај главне оставе."
+
+#: src/input/command.zig:191
+msgid "Paste from Selection"
+msgstr "Убаци из избора"
+
+#: src/input/command.zig:192
+msgid "Paste the contents of the selection clipboard."
+msgstr "Убаците садржај оставе избора."
+
+#: src/input/command.zig:197
+msgid "Start Search"
+msgstr "Покрени претрагу"
+
+#: src/input/command.zig:198
+msgid "Start a search if one isn't already active."
+msgstr "Покрени претрагу ако већ ниједна није активна."
+
+#: src/input/command.zig:203
+msgid "Search Selection"
+msgstr "Претражи избор"
+
+#: src/input/command.zig:204
+msgid "Start a search for the current text selection."
+msgstr "Покрени претрагу за тренутни текстуални избор."
+
+#: src/input/command.zig:209
+msgid "End Search"
+msgstr "Заврши претрагу"
+
+#: src/input/command.zig:210
+msgid "End the current search if any and hide any GUI elements."
+msgstr "Заврши тренутну претрагу, ако постоји, и сакриј све графичке елементе."
+
+#: src/input/command.zig:215
+msgid "Next Search Result"
+msgstr "Следећи резултат претраге"
+
+#: src/input/command.zig:216
+msgid "Navigate to the next search result, if any."
+msgstr "Иди до следећег резултата претраге, ако постоји."
+
+#: src/input/command.zig:219
+msgid "Previous Search Result"
+msgstr "Претходни резултат претраге"
+
+#: src/input/command.zig:220
+msgid "Navigate to the previous search result, if any."
+msgstr "Иди до претходног резултата претраге, ако постоји."
+
+#: src/input/command.zig:225
+msgid "Increase Font Size"
+msgstr "Повећај величину фонта"
+
+#: src/input/command.zig:226
+msgid "Increase the font size by 1 point."
+msgstr "Увећај величину фонта за 1 тачку."
+
+#: src/input/command.zig:231
+msgid "Decrease Font Size"
+msgstr "Смањи величину фонта"
+
+#: src/input/command.zig:232
+msgid "Decrease the font size by 1 point."
+msgstr "Умањи величину фонта за 1 тачку."
+
+#: src/input/command.zig:237
+msgid "Reset Font Size"
+msgstr "Врати величину фонта"
+
+#: src/input/command.zig:238
+msgid "Reset the font size to the default."
+msgstr "Врати величину фонта на подразумевану."
+
+#: src/input/command.zig:243
+msgid "Clear Screen"
+msgstr "Очисти екран"
+
+#: src/input/command.zig:244
+msgid "Clear the screen and scrollback."
+msgstr "Очисти екран и историју помицања."
+
+#: src/input/command.zig:249
+msgid "Select All"
+msgstr "Изабери све"
+
+#: src/input/command.zig:250
+msgid "Select all text on the screen."
+msgstr "Изабери сав текст на екрану."
+
+#: src/input/command.zig:255
+msgid "Scroll to Top"
+msgstr "Помакни на врх"
+
+#: src/input/command.zig:256
+msgid "Scroll to the top of the screen."
+msgstr "Помакните на врх екрана."
+
+#: src/input/command.zig:261
+msgid "Scroll to Bottom"
+msgstr "Помакни на дно"
+
+#: src/input/command.zig:262
+msgid "Scroll to the bottom of the screen."
+msgstr "Помакните на дно екрана."
+
+#: src/input/command.zig:267
+msgid "Scroll to Selection"
+msgstr "Помакни до избора"
+
+#: src/input/command.zig:268
+msgid "Scroll to the selected text."
+msgstr "Помакните до изабраног текста."
+
+#: src/input/command.zig:273
+msgid "Scroll Page Up"
+msgstr "Помакни страницу нагоре"
+
+#: src/input/command.zig:274
+msgid "Scroll the screen up by a page."
+msgstr "Помакните екран нагоре за једну страницу."
+
+#: src/input/command.zig:279
+msgid "Scroll Page Down"
+msgstr "Помакни страницу надоле"
+
+#: src/input/command.zig:280
+msgid "Scroll the screen down by a page."
+msgstr "Помакните екран надоле за једну страницу."
+
+#: src/input/command.zig:286
+msgid "Copy Screen to Temporary File and Copy Path"
+msgstr "Копирај екран у привремену датотеку и копирај путању"
+
+#: src/input/command.zig:287
+msgid ""
+"Copy the screen contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr "Копирајте садржај екрана у привремену датотеку и копирајте путању у оставу."
+
+#: src/input/command.zig:291
+msgid "Copy Screen to Temporary File and Paste Path"
+msgstr "Копирај екран у привремену датотеку и убаци путању"
+
+#: src/input/command.zig:292
+msgid ""
+"Copy the screen contents to a temporary file and paste the path to the file."
+msgstr "Копирајте садржај екрана у привремену датотеку и убаците путању до те датотеке."
+
+#: src/input/command.zig:296
+msgid "Copy Screen to Temporary File and Open"
+msgstr "Копирај екран у привремену датотеку и отвори"
+
+#: src/input/command.zig:297
+msgid "Copy the screen contents to a temporary file and open it."
+msgstr "Копирајте садржај екрана у привремену датотеку и отворите је."
+
+#: src/input/command.zig:305
+msgid "Copy Screen as HTML to Temporary File and Copy Path"
+msgstr "Копирај екран као ХТМЛ у привремену датотеку и копирај путању"
+
+#: src/input/command.zig:306
+msgid ""
+"Copy the screen contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr "Копирајте садржај екрана као ХТМЛ у привремену датотеку и копирајте путању у оставу."
+
+#: src/input/command.zig:313
+msgid "Copy Screen as HTML to Temporary File and Paste Path"
+msgstr "Копирај екран као ХТМЛ у привремену датотеку и убаци путању"
+
+#: src/input/command.zig:314
+msgid ""
+"Copy the screen contents as HTML to a temporary file and paste the path to "
+"the file."
+msgstr "Копирајте садржај екрана као ХТМЛ у привремену датотеку и убаците путању до те датотеке."
+
+#: src/input/command.zig:321
+msgid "Copy Screen as HTML to Temporary File and Open"
+msgstr "Копирај екран као ХТМЛ у привремену датотеку и отвори"
+
+#: src/input/command.zig:322
+msgid "Copy the screen contents as HTML to a temporary file and open it."
+msgstr "Копирај садржај екрана као ХТМЛ у привремену датотеку и отвори је."
+
+#: src/input/command.zig:330
+msgid "Copy Screen as ANSI Sequences to Temporary File and Copy Path"
+msgstr "Копирај екран као ANSI низове у привремену датотеку и копирај путању"
+
+#: src/input/command.zig:331
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr "Копирај садржај екрана као излазне ANSI низове у привремену датотеку и копирај путању у оставу."
+
+#: src/input/command.zig:338
+msgid "Copy Screen as ANSI Sequences to Temporary File and Paste Path"
+msgstr "Копирај екран као ANSI низове у привремену датотеку и убаци путању"
+
+#: src/input/command.zig:339
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr "Копирај садржај екрана као излазне ANSI низове у привремену датотеку и убаци путању до датотеке."
+
+#: src/input/command.zig:346
+msgid "Copy Screen as ANSI Sequences to Temporary File and Open"
+msgstr "Копирај екран као ANSI низове у привремену датотеку и отвори"
+
+#: src/input/command.zig:347
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr "Копирај садржај екрана као излазне ANSI низове у привремену датотеку и отвори је."
+
+#: src/input/command.zig:354
+msgid "Copy Selection to Temporary File and Copy Path"
+msgstr "Копирај изабрано у привремену датотеку и копирај путању"
+
+#: src/input/command.zig:355
+msgid ""
+"Copy the selection contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr "Копирај садржај изабраног у привремену датотеку и копирај путању у оставу."
+
+#: src/input/command.zig:359
+msgid "Copy Selection to Temporary File and Paste Path"
+msgstr "Копирај изабрано у привремену датотеку и убаци путању"
+
+#: src/input/command.zig:360
+msgid ""
+"Copy the selection contents to a temporary file and paste the path to the "
+"file."
+msgstr "Копирај садржај изабраног у привремену датотеку и убаци путању до датотеке."
+
+#: src/input/command.zig:364
+msgid "Copy Selection to Temporary File and Open"
+msgstr "Копирај изабрано у привремену датотеку и отвори"
+
+#: src/input/command.zig:365
+msgid "Copy the selection contents to a temporary file and open it."
+msgstr "Копирај садржај изабраног у привремену датотеку и отвори је."
+
+#: src/input/command.zig:373
+msgid "Copy Selection as HTML to Temporary File and Copy Path"
+msgstr "Копирај изабрано као ХТМЛ у привремену датотеку и копирај путању"
+
+#: src/input/command.zig:374
+msgid ""
+"Copy the selection contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr "Копирај садржај изабраног као ХТМЛ у привремену датотеку и копирај путању у оставу."
+
+#: src/input/command.zig:381
+msgid "Copy Selection as HTML to Temporary File and Paste Path"
+msgstr "Копирај изабрано као ХТМЛ у привремену датотеку и убаци путању"
+
+#: src/input/command.zig:382
+msgid ""
+"Copy the selection contents as HTML to a temporary file and paste the path "
+"to the file."
+msgstr "Копирај садржај изабраног као ХТМЛ у привремену датотеку и убаци путању до датотеке."
+
+#: src/input/command.zig:389
+msgid "Copy Selection as HTML to Temporary File and Open"
+msgstr "Копирај изабрано као ХТМЛ у привремену датотеку и отвори"
+
+#: src/input/command.zig:390
+msgid "Copy the selection contents as HTML to a temporary file and open it."
+msgstr "Копирај садржај изабраног као ХТМЛ у привремену датотеку и отвори је."
+
+#: src/input/command.zig:398
+msgid "Copy Selection as ANSI Sequences to Temporary File and Copy Path"
+msgstr "Копирај изабрано као ANSI низове у привремену датотеку и копирај путању"
+
+#: src/input/command.zig:399
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr "Копирај садржај избора као излазне ANSI низове у привремену датотеку и копирај путању у оставу."
+
+#: src/input/command.zig:406
+msgid "Copy Selection as ANSI Sequences to Temporary File and Paste Path"
+msgstr "Копирај изабрано као ANSI низове у привремену датотеку и убаци путању"
+
+#: src/input/command.zig:407
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr "Копирај садржај избора као излазне ANSI низове у привремену датотеку и убаци путању до те датотеке."
+
+#: src/input/command.zig:414
+msgid "Copy Selection as ANSI Sequences to Temporary File and Open"
+msgstr "Копирај изабрано као ANSI низове у привремену датотеку и отвори"
+
+#: src/input/command.zig:415
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr "Копирај садржај избора као излазне ANSI низове у привремену датотеку и отвори је."
+
+#: src/input/command.zig:422
+msgid "Open a new window."
+msgstr "Отвори нови прозор."
+
+#: src/input/command.zig:428
+msgid "Open a new tab."
+msgstr "Отвори нови језичак."
+
+#: src/input/command.zig:434
+msgid "Move Tab Left"
+msgstr "Помери језичак улево"
+
+#: src/input/command.zig:435
+msgid "Move the current tab to the left."
+msgstr "Премести текући језичак лево."
+
+#: src/input/command.zig:439
+msgid "Move Tab Right"
+msgstr "Помери језичак удесно"
+
+#: src/input/command.zig:440
+msgid "Move the current tab to the right."
+msgstr "Преместите текући језичак десно."
+
+#: src/input/command.zig:446
+msgid "Move Tab to New Window"
+msgstr "Помери језичак у нови прозор"
+
+#: src/input/command.zig:447
+msgid "Move the current tab to a new window."
+msgstr "Преместите текући језичак у нови прозор."
+
+#: src/input/command.zig:452
+msgid "Toggle Tab Overview"
+msgstr "Окини преглед језичака"
+
+#: src/input/command.zig:453
+msgid "Toggle the tab overview."
+msgstr "Окините преглед језичака."
+
+#: src/input/command.zig:458
+msgid "Change Terminal Title…"
+msgstr "Промени наслов терминала…"
+
+#: src/input/command.zig:459
+msgid "Prompt for a new title for the current terminal."
+msgstr "Затражите нови наслов за текући терминал."
+
+#: src/input/command.zig:465
+msgid "Prompt for a new title for the current tab."
+msgstr "Затражите нови наслов за текући језичак."
+
+#: src/input/command.zig:478
+msgid "Split the terminal to the left."
+msgstr "Раздели терминал лево."
+
+#: src/input/command.zig:483
+msgid "Split the terminal to the right."
+msgstr "Раздели терминал десно."
+
+#: src/input/command.zig:488
+msgid "Split the terminal up."
+msgstr "Раздели терминал горе."
+
+#: src/input/command.zig:493
+msgid "Split the terminal down."
+msgstr "Раздели терминал доле."
+
+#: src/input/command.zig:500
+msgid "Focus Split: Previous"
+msgstr "Фокус разделе: претходна"
+
+#: src/input/command.zig:501
+msgid "Focus the previous split, if any."
+msgstr "Фокусирај претходну разделу, ако постоји."
+
+#: src/input/command.zig:505
+msgid "Focus Split: Next"
+msgstr "Фокус разделе: следећа"
+
+#: src/input/command.zig:506
+msgid "Focus the next split, if any."
+msgstr "Фокусирај следећу разделу, ако постоји."
+
+#: src/input/command.zig:510
+msgid "Focus Split: Left"
+msgstr "Фокус разделе: лево"
+
+#: src/input/command.zig:511
+msgid "Focus the split to the left, if it exists."
+msgstr "Фокусирај разделу лево, ако постоји."
+
+#: src/input/command.zig:515
+msgid "Focus Split: Right"
+msgstr "Фокус разделе: десно"
+
+#: src/input/command.zig:516
+msgid "Focus the split to the right, if it exists."
+msgstr "Усредсреди десну разделу, ако постоји."
+
+#: src/input/command.zig:520
+msgid "Focus Split: Up"
+msgstr "Усредсреди разделу: горе"
+
+#: src/input/command.zig:521
+msgid "Focus the split above, if it exists."
+msgstr "Усредсреди горњу разделу, ако постоји."
+
+#: src/input/command.zig:525
+msgid "Focus Split: Down"
+msgstr "Усредсреди разделу: доле"
+
+#: src/input/command.zig:526
+msgid "Focus the split below, if it exists."
+msgstr "Усредсреди доњу разделу, ако постоји."
+
+#: src/input/command.zig:533
+msgid "Focus Window: Previous"
+msgstr "Усредсреди прозор: претходни"
+
+#: src/input/command.zig:534
+msgid "Focus the previous window, if any."
+msgstr "Усредсреди претходни прозор, ако постоји."
+
+#: src/input/command.zig:538
+msgid "Focus Window: Next"
+msgstr "Усредсреди прозор: следећи"
+
+#: src/input/command.zig:539
+msgid "Focus the next window, if any."
+msgstr "Усредсреди следећи прозор, ако постоји."
+
+#: src/input/command.zig:545
+msgid "Toggle Split Zoom"
+msgstr "Окини увећање разделе"
+
+#: src/input/command.zig:546
+msgid "Toggle the zoom state of the current split."
+msgstr "Промени стање увећања тренутне разделе."
+
+#: src/input/command.zig:551
+msgid "Toggle Read-Only Mode"
+msgstr "Окини режим само за читање"
+
+#: src/input/command.zig:552
+msgid "Toggle read-only mode for the current surface."
+msgstr "Окини режим само за читање за тренутну површину."
+
+#: src/input/command.zig:557
+msgid "Equalize Splits"
+msgstr "Изједначи разделе"
+
+#: src/input/command.zig:558
+msgid "Equalize the size of all splits."
+msgstr "Изједначи величину свих раздела."
+
+#: src/input/command.zig:563
+msgid "Reset Window Size"
+msgstr "Врати величину прозора"
+
+#: src/input/command.zig:564
+msgid "Reset the window size to the default."
+msgstr "Врати величину прозора на подразумевану."
+
+#: src/input/command.zig:569
+msgid "Toggle Inspector"
+msgstr "Окини инспектора"
+
+#: src/input/command.zig:570
+msgid "Toggle the inspector."
+msgstr "Окини инспектора."
+
+#: src/input/command.zig:575
+msgid "Show the GTK Inspector"
+msgstr "Прикажи ГТК инспектора"
+
+#: src/input/command.zig:576
+msgid "Show the GTK inspector."
+msgstr "Прикажи ГТК Inspector."
+
+#: src/input/command.zig:581
+msgid "Show On-Screen Keyboard"
+msgstr "Прикажи тастатуру на екрану"
+
+#: src/input/command.zig:582
+msgid "Show the on-screen keyboard if present."
+msgstr "Прикажи тастатуру на екрану ако постоји."
+
+#: src/input/command.zig:588
+msgid "Open Config Using OS editor"
+msgstr "Отвори подешавања помоћу уређивача ОС-а"
+
+#: src/input/command.zig:589
+msgid "Open the config file with the OS's default editor."
+msgstr "Отвори датотеку подешавања помоћу подразумеваног уређивача ОС-а."
+
+#: src/input/command.zig:593
+msgid "Open Config in New Terminal Window"
+msgstr "Отвори подешавања у новом прозору терминала"
+
+#: src/input/command.zig:594
+msgid "Open the config file in a new window using $EDITOR or $VISUAL."
+msgstr "Отвори датотеку подешавања у новом прозору помоћу $EDITOR или $VISUAL."
+
+#: src/input/command.zig:600
+msgid "Reload Config"
+msgstr "Поново учитај подешавања"
+
+#: src/input/command.zig:601
+msgid "Reload the config file."
+msgstr "Поново учитај датотеку подешавања."
+
+#: src/input/command.zig:606
+msgid "Close Terminal"
+msgstr "Затвори терминал"
+
+#: src/input/command.zig:607
+msgid "Close the current terminal."
+msgstr "Затвори тренутни терминал."
+
+#: src/input/command.zig:614
+msgid "Close the current tab."
+msgstr "Затвори тренутни језичак."
+
+#: src/input/command.zig:618
+msgid "Close Other Tabs"
+msgstr "Затвори друге језичке"
+
+#: src/input/command.zig:619
+msgid "Close all tabs in this window except the current one."
+msgstr "Затвори све језичке у овом прозору изузев тренутног."
+
+#: src/input/command.zig:623
+msgid "Close Tabs to the Right"
+msgstr "Затвори језичке удесно"
+
+#: src/input/command.zig:624
+msgid "Close all tabs to the right of the current one."
+msgstr "Затвори све језичке десно од тренутног."
+
+#: src/input/command.zig:631
+msgid "Close the current window."
+msgstr "Затвори тренутни прозор."
+
+#: src/input/command.zig:636
+msgid "Close All Windows"
+msgstr "Затвори све прозоре"
+
+#: src/input/command.zig:637
+msgid "Close all windows."
+msgstr "Затвори све прозоре."
+
+#: src/input/command.zig:642
+msgid "Toggle Maximize"
+msgstr "Окини увећање"
+
+#: src/input/command.zig:643
+msgid "Toggle the maximized state of the current window."
+msgstr "Промени стање увећања тренутног прозора."
+
+#: src/input/command.zig:648
+msgid "Toggle Fullscreen"
+msgstr "Пребаци преко целог екрана"
+
+#: src/input/command.zig:649
+msgid "Toggle the fullscreen state of the current window."
+msgstr "Промени стање приказивања тренутног прозора преко целог екрана."
+
+#: src/input/command.zig:654
+msgid "Toggle Window Decorations"
+msgstr "Окини декорације прозора"
+
+#: src/input/command.zig:655
+msgid "Toggle the window decorations."
+msgstr "Промени стање декорације прозора."
+
+#: src/input/command.zig:660
+msgid "Toggle Float on Top"
+msgstr "Окини плутајуће на врху"
+
+#: src/input/command.zig:661
+msgid "Toggle the float on top state of the current window."
+msgstr "Промени стање плутања на врху тренутног прозора."
+
+#: src/input/command.zig:666
+msgid "Toggle Secure Input"
+msgstr "Окини безбедан унос"
+
+#: src/input/command.zig:667
+msgid "Toggle secure input mode."
+msgstr "Промени режим безбедног уноса."
+
+#: src/input/command.zig:672
+msgid "Toggle Mouse Reporting"
+msgstr "Окини пријављивање миша"
+
+#: src/input/command.zig:673
+msgid "Toggle whether mouse events are reported to terminal applications."
+msgstr "Пребаци да ли се догађаји миша пријављују терминалним програмима."
+
+#: src/input/command.zig:678
+msgid "Toggle Background Opacity"
+msgstr "Окини непровидност позадине"
+
+#: src/input/command.zig:679
+msgid "Toggle the background opacity of a window that started transparent."
+msgstr "Пребаци непровидност позадине прозора који је првобитно био провидан."
+
+#: src/input/command.zig:684
+msgid "Check for Updates"
+msgstr "Провери ажурирања"
+
+#: src/input/command.zig:685
+msgid "Check for updates to the application."
+msgstr "Провери ажурирања за програм."
+
+#: src/input/command.zig:690
+msgid "Undo"
+msgstr "Опозови"
+
+#: src/input/command.zig:691
+msgid "Undo the last action."
+msgstr "Опозовите последњу радњу."
+
+#: src/input/command.zig:696
+msgid "Redo"
+msgstr "Понови"
+
+#: src/input/command.zig:697
+msgid "Redo the last undone action."
+msgstr "Поновите последњу опозвану радњу."
+
+#: src/input/command.zig:703
+msgid "Quit the application."
+msgstr "Изађи из програма."
+
+#: src/input/command.zig:708
+msgid "Ghostty"
+msgstr "Ghostty"
+
+#: src/input/command.zig:709
+msgid "Put a little Ghostty in your terminal."
+msgstr "Убаците мало Ghostty-ја у ваш терминал."

--- a/po/sr.po
+++ b/po/sr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
 "POT-Creation-Date: 2026-08-10 10:06-0500\n"
-"PO-Revision-Date: 2026-08-15 10:28+0200\n"
+"PO-Revision-Date: 2026-08-29 12:49+0200\n"
 "Last-Translator: Марко Костић <marko.m.kostic@gmail.com>\n"
 "Language-Team: Language SR\n"
 "Language: sr\n"
@@ -44,45 +44,41 @@ msgstr "Запамти избор за ову разделу"
 
 #: src/apprt/gtk/ui/1.4/clipboard-confirmation-dialog.blp:93
 msgid "Reload configuration to show this prompt again"
-msgstr "Поново учитај поставке да би се овај упит поново приказао"
+msgstr "Поново учитај подешавања да би се овај упит поново приказао"
 
-#: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
-#: src/apprt/gtk/ui/1.5/title-dialog.blp:8
+#: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7 src/apprt/gtk/ui/1.5/title-dialog.blp:8
 #: src/apprt/gtk/class/application.zig:2263
 msgid "Cancel"
 msgstr "Откажи"
 
-#: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:8
-#: src/apprt/gtk/ui/1.2/search-overlay.blp:90
+#: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:8 src/apprt/gtk/ui/1.2/search-overlay.blp:90
 #: src/apprt/gtk/ui/1.3/surface-child-exited.blp:17
 msgid "Close"
 msgstr "Затвори"
 
 #: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:6
 msgid "Configuration Errors"
-msgstr "Грешке у поставкама"
+msgstr "Грешке у подешавањима"
 
 #: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:8
 msgid ""
-"One or more configuration errors were found. Please review the errors below, "
-"and either reload your configuration or ignore these errors."
+"One or more configuration errors were found. Please review the errors below, and either reload your "
+"configuration or ignore these errors."
 msgstr ""
-"Пронађена је једна или више грешака у поставкама. Прегледајте грешке испод, "
-"и поново учитајте своје поставке или занемарите ове грешке."
+"Пронађена је једна или више грешака у подешавањима. Прегледајте грешке испод, и поново учитајте своја "
+"подешавања или занемарите ове грешке."
 
 #: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:12
 msgid "Ignore"
 msgstr "Занемари"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:13
-#: src/apprt/gtk/ui/1.2/surface.blp:439 src/apprt/gtk/ui/1.5/window.blp:318
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:13 src/apprt/gtk/ui/1.2/surface.blp:439
+#: src/apprt/gtk/ui/1.5/window.blp:318
 msgid "Reload Configuration"
-msgstr "Поново учитај поставке"
+msgstr "Поново учитај подешавања"
 
-#: src/apprt/gtk/ui/1.2/debug-warning.blp:7
-#: src/apprt/gtk/ui/1.3/debug-warning.blp:6
-msgid ""
-"⚠️ You're running a debug build of Ghostty! Performance will be degraded."
+#: src/apprt/gtk/ui/1.2/debug-warning.blp:7 src/apprt/gtk/ui/1.3/debug-warning.blp:6
+msgid "⚠️ You're running a debug build of Ghostty! Performance will be degraded."
 msgstr "⚠️ Покрећете издање Ghostty-ја за отклањање грешака! Перформансе биће смањене."
 
 #: src/apprt/gtk/ui/1.5/inspector-window.blp:5
@@ -111,12 +107,11 @@ msgstr "Није било могуће обезбедити OpenGL контек�
 
 #: src/apprt/gtk/ui/1.2/surface.blp:101
 msgid ""
-"This terminal is in read-only mode. You can still view, select, and scroll "
-"through the content, but no input events will be sent to the running "
-"application."
+"This terminal is in read-only mode. You can still view, select, and scroll through the content, but no "
+"input events will be sent to the running application."
 msgstr ""
-"Овај терминал је у режиму само за читање. И даље можете прегледати, бирати и "
-"помицати садржај, али догађаји уноса неће бити послати покренутом програму."
+"Овај терминал је у режиму само за читање. И даље можете прегледати, бирати и помицати садржај, али "
+"догађаји уноса неће бити послати покренутом програму."
 
 #: src/apprt/gtk/ui/1.2/surface.blp:112
 msgid "Read-only"
@@ -184,13 +179,11 @@ msgid "Change Tab Title…"
 msgstr "Промени наслов језичка…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:391 src/apprt/gtk/ui/1.5/window.blp:60
-#: src/apprt/gtk/ui/1.5/window.blp:110 src/apprt/gtk/ui/1.5/window.blp:237
-#: src/input/command.zig:427
+#: src/apprt/gtk/ui/1.5/window.blp:110 src/apprt/gtk/ui/1.5/window.blp:237 src/input/command.zig:427
 msgid "New Tab"
 msgstr "Нови језичак"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:242
-#: src/input/command.zig:613
+#: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:242 src/input/command.zig:613
 msgid "Close Tab"
 msgstr "Затвори језичак"
 
@@ -202,13 +195,11 @@ msgstr "Прозор"
 msgid "Change Window Title…"
 msgstr "Промени наслов прозора…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:411 src/apprt/gtk/ui/1.5/window.blp:220
-#: src/input/command.zig:421
+#: src/apprt/gtk/ui/1.2/surface.blp:411 src/apprt/gtk/ui/1.5/window.blp:220 src/input/command.zig:421
 msgid "New Window"
 msgstr "Нови прозор"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:416 src/apprt/gtk/ui/1.5/window.blp:225
-#: src/input/command.zig:630
+#: src/apprt/gtk/ui/1.2/surface.blp:416 src/apprt/gtk/ui/1.5/window.blp:225 src/input/command.zig:630
 msgid "Close Window"
 msgstr "Затвори прозор"
 
@@ -218,11 +209,11 @@ msgstr "Подешавања"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:427 src/apprt/gtk/ui/1.5/window.blp:306
 msgid "Open Configuration in OS Editor"
-msgstr "Отвори поставке у уређивачу ОС-а"
+msgstr "Отвори подешавања у уређивачу ОС-а"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:433 src/apprt/gtk/ui/1.5/window.blp:312
 msgid "Open Configuration in New Window"
-msgstr "Отвори поставке у новом прозору"
+msgstr "Отвори подешавања у новом прозору"
 
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:5
 msgid "Leave blank to restore the default title."
@@ -286,34 +277,25 @@ msgstr "Извези"
 
 #: src/apprt/gtk/class/application.zig:2783
 msgid "Editing configuration file"
-msgstr "Уређивање датотеке са поставкама"
+msgstr "Уређивање датотеке са подешавањима"
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
 msgid ""
-"An application is attempting to write to the clipboard. The current "
-"clipboard contents are shown below."
-msgstr ""
-"Програм покушава да пише у оставу. Тренутни садржај оставе је приказан испод."
+"An application is attempting to write to the clipboard. The current clipboard contents are shown below."
+msgstr "Програм покушава да пише у оставу. Тренутни садржај оставе је приказан испод."
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:202
 msgid ""
-"An application is attempting to read from the clipboard. The current "
-"clipboard contents are shown below."
-msgstr ""
-"Програм покушава да чита из оставе. Тренутни садржај оставе је приказан "
-"испод."
+"An application is attempting to read from the clipboard. The current clipboard contents are shown below."
+msgstr "Програм покушава да чита из оставе. Тренутни садржај оставе је приказан испод."
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:205
 msgid "Warning: Potentially Unsafe Paste"
 msgstr "Упозорење: потенцијално небезбедно убацивање"
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:206
-msgid ""
-"Pasting this text into the terminal may be dangerous as it looks like some "
-"commands may be executed."
-msgstr ""
-"Убацивање овог текста у терминал може бити опасно јер изгледа као да се неке "
-"наредбе могу извршити."
+msgid "Pasting this text into the terminal may be dangerous as it looks like some commands may be executed."
+msgstr "Убацивање овог текста у терминал може бити опасно јер изгледа као да се неке наредбе могу извршити."
 
 #: src/apprt/gtk/class/close_confirmation_dialog.zig:184
 msgid "Quit Ghostty?"
@@ -351,13 +333,11 @@ msgstr "Тренутно покренут процес у овој раздел�
 msgid "Command Finished"
 msgstr "Наредба је завршена"
 
-#: src/apprt/gtk/class/surface.zig:1182
-#: src/apprt/gtk/class/surface_child_exited.zig:109
+#: src/apprt/gtk/class/surface.zig:1182 src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Наредба је успешно извршена"
 
-#: src/apprt/gtk/class/surface.zig:1183
-#: src/apprt/gtk/class/surface_child_exited.zig:113
+#: src/apprt/gtk/class/surface.zig:1183 src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Наредба није успела"
 
@@ -375,7 +355,7 @@ msgstr "Промени наслов прозора"
 
 #: src/apprt/gtk/class/window.zig:1153
 msgid "Reloaded the configuration"
-msgstr "Поново учитане поставке"
+msgstr "Поново учитана подешавања"
 
 #: src/apprt/gtk/class/window.zig:1830
 msgid "Copied to clipboard"
@@ -402,8 +382,7 @@ msgid "Copy to Clipboard"
 msgstr "Копирај у оставу"
 
 #: src/input/command.zig:156
-msgid ""
-"Copy the selected text to the clipboard in both plain and styled formats."
+msgid "Copy the selected text to the clipboard in both plain and styled formats."
 msgstr "Копирај изабрани текст у оставу у обичном и обликованом формату."
 
 #: src/input/command.zig:159
@@ -443,9 +422,7 @@ msgid "Copy Terminal Title to Clipboard"
 msgstr "Копирај наслов терминала у оставу"
 
 #: src/input/command.zig:180
-msgid ""
-"Copy the terminal title to the clipboard. If the terminal title is not set "
-"this has no effect."
+msgid "Copy the terminal title to the clipboard. If the terminal title is not set this has no effect."
 msgstr "Копирајте наслов терминала у оставу. Ако наслов терминала није постављен, ово неће имати дејства."
 
 #: src/input/command.zig:185
@@ -589,9 +566,7 @@ msgid "Copy Screen to Temporary File and Copy Path"
 msgstr "Копирај екран у привремену датотеку и копирај путању"
 
 #: src/input/command.zig:287
-msgid ""
-"Copy the screen contents to a temporary file and copy the path to the "
-"clipboard."
+msgid "Copy the screen contents to a temporary file and copy the path to the clipboard."
 msgstr "Копирајте садржај екрана у привремену датотеку и копирајте путању у оставу."
 
 #: src/input/command.zig:291
@@ -599,8 +574,7 @@ msgid "Copy Screen to Temporary File and Paste Path"
 msgstr "Копирај екран у привремену датотеку и убаци путању"
 
 #: src/input/command.zig:292
-msgid ""
-"Copy the screen contents to a temporary file and paste the path to the file."
+msgid "Copy the screen contents to a temporary file and paste the path to the file."
 msgstr "Копирајте садржај екрана у привремену датотеку и убаците путању до те датотеке."
 
 #: src/input/command.zig:296
@@ -616,9 +590,7 @@ msgid "Copy Screen as HTML to Temporary File and Copy Path"
 msgstr "Копирај екран као ХТМЛ у привремену датотеку и копирај путању"
 
 #: src/input/command.zig:306
-msgid ""
-"Copy the screen contents as HTML to a temporary file and copy the path to "
-"the clipboard."
+msgid "Copy the screen contents as HTML to a temporary file and copy the path to the clipboard."
 msgstr "Копирајте садржај екрана као ХТМЛ у привремену датотеку и копирајте путању у оставу."
 
 #: src/input/command.zig:313
@@ -626,9 +598,7 @@ msgid "Copy Screen as HTML to Temporary File and Paste Path"
 msgstr "Копирај екран као ХТМЛ у привремену датотеку и убаци путању"
 
 #: src/input/command.zig:314
-msgid ""
-"Copy the screen contents as HTML to a temporary file and paste the path to "
-"the file."
+msgid "Copy the screen contents as HTML to a temporary file and paste the path to the file."
 msgstr "Копирајте садржај екрана као ХТМЛ у привремену датотеку и убаците путању до те датотеке."
 
 #: src/input/command.zig:321
@@ -645,8 +615,7 @@ msgstr "Копирај екран као ANSI низове у привремен
 
 #: src/input/command.zig:331
 msgid ""
-"Copy the screen contents as ANSI escape sequences to a temporary file and "
-"copy the path to the clipboard."
+"Copy the screen contents as ANSI escape sequences to a temporary file and copy the path to the clipboard."
 msgstr "Копирај садржај екрана као излазне ANSI низове у привремену датотеку и копирај путању у оставу."
 
 #: src/input/command.zig:338
@@ -655,8 +624,7 @@ msgstr "Копирај екран као ANSI низове у привремен
 
 #: src/input/command.zig:339
 msgid ""
-"Copy the screen contents as ANSI escape sequences to a temporary file and "
-"paste the path to the file."
+"Copy the screen contents as ANSI escape sequences to a temporary file and paste the path to the file."
 msgstr "Копирај садржај екрана као излазне ANSI низове у привремену датотеку и убаци путању до датотеке."
 
 #: src/input/command.zig:346
@@ -664,9 +632,7 @@ msgid "Copy Screen as ANSI Sequences to Temporary File and Open"
 msgstr "Копирај екран као ANSI низове у привремену датотеку и отвори"
 
 #: src/input/command.zig:347
-msgid ""
-"Copy the screen contents as ANSI escape sequences to a temporary file and "
-"open it."
+msgid "Copy the screen contents as ANSI escape sequences to a temporary file and open it."
 msgstr "Копирај садржај екрана као излазне ANSI низове у привремену датотеку и отвори је."
 
 #: src/input/command.zig:354
@@ -674,9 +640,7 @@ msgid "Copy Selection to Temporary File and Copy Path"
 msgstr "Копирај изабрано у привремену датотеку и копирај путању"
 
 #: src/input/command.zig:355
-msgid ""
-"Copy the selection contents to a temporary file and copy the path to the "
-"clipboard."
+msgid "Copy the selection contents to a temporary file and copy the path to the clipboard."
 msgstr "Копирај садржај изабраног у привремену датотеку и копирај путању у оставу."
 
 #: src/input/command.zig:359
@@ -684,9 +648,7 @@ msgid "Copy Selection to Temporary File and Paste Path"
 msgstr "Копирај изабрано у привремену датотеку и убаци путању"
 
 #: src/input/command.zig:360
-msgid ""
-"Copy the selection contents to a temporary file and paste the path to the "
-"file."
+msgid "Copy the selection contents to a temporary file and paste the path to the file."
 msgstr "Копирај садржај изабраног у привремену датотеку и убаци путању до датотеке."
 
 #: src/input/command.zig:364
@@ -702,9 +664,7 @@ msgid "Copy Selection as HTML to Temporary File and Copy Path"
 msgstr "Копирај изабрано као ХТМЛ у привремену датотеку и копирај путању"
 
 #: src/input/command.zig:374
-msgid ""
-"Copy the selection contents as HTML to a temporary file and copy the path to "
-"the clipboard."
+msgid "Copy the selection contents as HTML to a temporary file and copy the path to the clipboard."
 msgstr "Копирај садржај изабраног као ХТМЛ у привремену датотеку и копирај путању у оставу."
 
 #: src/input/command.zig:381
@@ -712,9 +672,7 @@ msgid "Copy Selection as HTML to Temporary File and Paste Path"
 msgstr "Копирај изабрано као ХТМЛ у привремену датотеку и убаци путању"
 
 #: src/input/command.zig:382
-msgid ""
-"Copy the selection contents as HTML to a temporary file and paste the path "
-"to the file."
+msgid "Copy the selection contents as HTML to a temporary file and paste the path to the file."
 msgstr "Копирај садржај изабраног као ХТМЛ у привремену датотеку и убаци путању до датотеке."
 
 #: src/input/command.zig:389
@@ -731,8 +689,8 @@ msgstr "Копирај изабрано као ANSI низове у привре
 
 #: src/input/command.zig:399
 msgid ""
-"Copy the selection contents as ANSI escape sequences to a temporary file and "
-"copy the path to the clipboard."
+"Copy the selection contents as ANSI escape sequences to a temporary file and copy the path to the "
+"clipboard."
 msgstr "Копирај садржај избора као излазне ANSI низове у привремену датотеку и копирај путању у оставу."
 
 #: src/input/command.zig:406
@@ -741,8 +699,7 @@ msgstr "Копирај изабрано као ANSI низове у привре
 
 #: src/input/command.zig:407
 msgid ""
-"Copy the selection contents as ANSI escape sequences to a temporary file and "
-"paste the path to the file."
+"Copy the selection contents as ANSI escape sequences to a temporary file and paste the path to the file."
 msgstr "Копирај садржај избора као излазне ANSI низове у привремену датотеку и убаци путању до те датотеке."
 
 #: src/input/command.zig:414
@@ -750,9 +707,7 @@ msgid "Copy Selection as ANSI Sequences to Temporary File and Open"
 msgstr "Копирај изабрано као ANSI низове у привремену датотеку и отвори"
 
 #: src/input/command.zig:415
-msgid ""
-"Copy the selection contents as ANSI escape sequences to a temporary file and "
-"open it."
+msgid "Copy the selection contents as ANSI escape sequences to a temporary file and open it."
 msgstr "Копирај садржај избора као излазне ANSI низове у привремену датотеку и отвори је."
 
 #: src/input/command.zig:422

--- a/po/sr.po
+++ b/po/sr.po
@@ -158,12 +158,12 @@ msgstr "Раздели доле"
 #: src/apprt/gtk/ui/1.2/surface.blp:365 src/apprt/gtk/ui/1.5/window.blp:190
 #: src/apprt/gtk/ui/1.5/window.blp:268 src/input/command.zig:477
 msgid "Split Left"
-msgstr "Раздели лево"
+msgstr "Раздели улево"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:195
 #: src/apprt/gtk/ui/1.5/window.blp:273 src/input/command.zig:482
 msgid "Split Right"
-msgstr "Раздели десно"
+msgstr "Раздели удесно"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:377
 msgid "Close Split"
@@ -724,7 +724,7 @@ msgstr "Помери језичак улево"
 
 #: src/input/command.zig:435
 msgid "Move the current tab to the left."
-msgstr "Премести текући језичак лево."
+msgstr "Премести тренутни језичак улево."
 
 #: src/input/command.zig:439
 msgid "Move Tab Right"
@@ -732,7 +732,7 @@ msgstr "Помери језичак удесно"
 
 #: src/input/command.zig:440
 msgid "Move the current tab to the right."
-msgstr "Преместите текући језичак десно."
+msgstr "Премести тренутни језичак удесно."
 
 #: src/input/command.zig:446
 msgid "Move Tab to New Window"
@@ -740,7 +740,7 @@ msgstr "Помери језичак у нови прозор"
 
 #: src/input/command.zig:447
 msgid "Move the current tab to a new window."
-msgstr "Преместите текући језичак у нови прозор."
+msgstr "Премести тренутни језичак у нови прозор."
 
 #: src/input/command.zig:452
 msgid "Toggle Tab Overview"
@@ -764,11 +764,11 @@ msgstr "Затражи унос новог наслова за тренутни 
 
 #: src/input/command.zig:478
 msgid "Split the terminal to the left."
-msgstr "Раздели терминал лево."
+msgstr "Раздели терминал улево."
 
 #: src/input/command.zig:483
 msgid "Split the terminal to the right."
-msgstr "Раздели терминал десно."
+msgstr "Раздели терминал удесно."
 
 #: src/input/command.zig:488
 msgid "Split the terminal up."
@@ -796,19 +796,19 @@ msgstr "Фокусирај следећу разделу, ако постоји.
 
 #: src/input/command.zig:510
 msgid "Focus Split: Left"
-msgstr "Фокус разделе: лево"
+msgstr "Фокус разделе: улево"
 
 #: src/input/command.zig:511
 msgid "Focus the split to the left, if it exists."
-msgstr "Фокусирај разделу лево, ако постоји."
+msgstr "Фокусирај разделу улево, ако постоји."
 
 #: src/input/command.zig:515
 msgid "Focus Split: Right"
-msgstr "Фокус разделе: десно"
+msgstr "Фокус разделе: удесно"
 
 #: src/input/command.zig:516
 msgid "Focus the split to the right, if it exists."
-msgstr "Усредсреди десну разделу, ако постоји."
+msgstr "Фокусирај разделу удесно, ако постоји."
 
 #: src/input/command.zig:520
 msgid "Focus Split: Up"

--- a/po/sr.po
+++ b/po/sr.po
@@ -812,35 +812,35 @@ msgstr "Фокусирај разделу удесно, ако постоји."
 
 #: src/input/command.zig:520
 msgid "Focus Split: Up"
-msgstr "Усредсреди разделу: горе"
+msgstr "Фокусирај разделу: горе"
 
 #: src/input/command.zig:521
 msgid "Focus the split above, if it exists."
-msgstr "Усредсреди горњу разделу, ако постоји."
+msgstr "Фокусирај горњу разделу, ако постоји."
 
 #: src/input/command.zig:525
 msgid "Focus Split: Down"
-msgstr "Усредсреди разделу: доле"
+msgstr "Фокусирај разделу: доле"
 
 #: src/input/command.zig:526
 msgid "Focus the split below, if it exists."
-msgstr "Усредсреди доњу разделу, ако постоји."
+msgstr "Фокусирај доњу разделу, ако постоји."
 
 #: src/input/command.zig:533
 msgid "Focus Window: Previous"
-msgstr "Усредсреди прозор: претходни"
+msgstr "Фокусирај прозор: претходни"
 
 #: src/input/command.zig:534
 msgid "Focus the previous window, if any."
-msgstr "Усредсреди претходни прозор, ако постоји."
+msgstr "Фокусирај претходни прозор, ако постоји."
 
 #: src/input/command.zig:538
 msgid "Focus Window: Next"
-msgstr "Усредсреди прозор: следећи"
+msgstr "Фокусирај прозор: следећи"
 
 #: src/input/command.zig:539
 msgid "Focus the next window, if any."
-msgstr "Усредсреди следећи прозор, ако постоји."
+msgstr "Фокусирај следећи прозор, ако постоји."
 
 #: src/input/command.zig:545
 msgid "Toggle Split Zoom"

--- a/po/sr.po
+++ b/po/sr.po
@@ -403,15 +403,15 @@ msgstr "Копирај изабрани текст као ANSI излазне с
 
 #: src/input/command.zig:167
 msgid "Copy Selection as HTML to Clipboard"
-msgstr "Копирај изабрано као хтмл у оставу"
+msgstr "Копирај изабрано као HTML у оставу"
 
 #: src/input/command.zig:168
 msgid "Copy the selected text as HTML to the clipboard."
-msgstr "Копирајте изабрани текст као хтмл у оставу."
+msgstr "Копирај изабрани текст као HTML у оставу."
 
 #: src/input/command.zig:173
 msgid "Copy URL to Clipboard"
-msgstr "Копирај УРЛ у оставу"
+msgstr "Копирај URL у оставу"
 
 #: src/input/command.zig:174
 msgid "Copy the URL under the cursor to the clipboard."
@@ -423,7 +423,7 @@ msgstr "Копирај наслов терминала у оставу"
 
 #: src/input/command.zig:180
 msgid "Copy the terminal title to the clipboard. If the terminal title is not set this has no effect."
-msgstr "Копирајте наслов терминала у оставу. Ако наслов терминала није постављен, ово неће имати дејства."
+msgstr "Копирај наслов терминала у оставу. Ако наслов терминала није постављен, ово неће имати дејства."
 
 #: src/input/command.zig:185
 msgid "Paste from Clipboard"
@@ -431,7 +431,7 @@ msgstr "Убаци из оставе"
 
 #: src/input/command.zig:186
 msgid "Paste the contents of the main clipboard."
-msgstr "Убаците садржај главне оставе."
+msgstr "Убаци садржај главне оставе."
 
 #: src/input/command.zig:191
 msgid "Paste from Selection"
@@ -455,7 +455,7 @@ msgstr "Претражи избор"
 
 #: src/input/command.zig:204
 msgid "Start a search for the current text selection."
-msgstr "Покрени претрагу за тренутни текстуални избор."
+msgstr "Покрени претрагу за тренутно изабрани текст."
 
 #: src/input/command.zig:209
 msgid "End Search"
@@ -567,7 +567,7 @@ msgstr "Копирај екран у привремену датотеку и к
 
 #: src/input/command.zig:287
 msgid "Copy the screen contents to a temporary file and copy the path to the clipboard."
-msgstr "Копирајте садржај екрана у привремену датотеку и копирајте путању у оставу."
+msgstr "Копирај садржај екрана у привремену датотеку и копирајте путању у оставу."
 
 #: src/input/command.zig:291
 msgid "Copy Screen to Temporary File and Paste Path"
@@ -587,11 +587,11 @@ msgstr "Копирајте садржај екрана у привремену �
 
 #: src/input/command.zig:305
 msgid "Copy Screen as HTML to Temporary File and Copy Path"
-msgstr "Копирај екран као ХТМЛ у привремену датотеку и копирај путању"
+msgstr "Копирај екран као HTML у привремену датотеку и копирај путању"
 
 #: src/input/command.zig:306
 msgid "Copy the screen contents as HTML to a temporary file and copy the path to the clipboard."
-msgstr "Копирајте садржај екрана као ХТМЛ у привремену датотеку и копирајте путању у оставу."
+msgstr "Копирајте садржај екрана као HTML у привремену датотеку и копирајте путању у оставу."
 
 #: src/input/command.zig:313
 msgid "Copy Screen as HTML to Temporary File and Paste Path"
@@ -756,11 +756,11 @@ msgstr "Промени наслов терминала…"
 
 #: src/input/command.zig:459
 msgid "Prompt for a new title for the current terminal."
-msgstr "Затражите нови наслов за текући терминал."
+msgstr "Затражи унос новог наслова за тренутни терминал."
 
 #: src/input/command.zig:465
 msgid "Prompt for a new title for the current tab."
-msgstr "Затражите нови наслов за текући језичак."
+msgstr "Затражи унос новог наслова за тренутни језичак."
 
 #: src/input/command.zig:478
 msgid "Split the terminal to the left."
@@ -888,7 +888,7 @@ msgstr "Прикажи ГТК инспектора"
 
 #: src/input/command.zig:576
 msgid "Show the GTK inspector."
-msgstr "Прикажи ГТК Inspector."
+msgstr "Прикажи ГТК инспектор."
 
 #: src/input/command.zig:581
 msgid "Show On-Screen Keyboard"
@@ -1004,7 +1004,7 @@ msgstr "Промени режим безбедног уноса."
 
 #: src/input/command.zig:672
 msgid "Toggle Mouse Reporting"
-msgstr "Окини пријављивање миша"
+msgstr "Окини прослеђивање догађаја миша"
 
 #: src/input/command.zig:673
 msgid "Toggle whether mouse events are reported to terminal applications."
@@ -1032,7 +1032,7 @@ msgstr "Опозови"
 
 #: src/input/command.zig:691
 msgid "Undo the last action."
-msgstr "Опозовите последњу радњу."
+msgstr "Опозови последњу радњу."
 
 #: src/input/command.zig:696
 msgid "Redo"
@@ -1040,7 +1040,7 @@ msgstr "Понови"
 
 #: src/input/command.zig:697
 msgid "Redo the last undone action."
-msgstr "Поновите последњу опозвану радњу."
+msgstr "Понови последњу опозвану радњу."
 
 #: src/input/command.zig:703
 msgid "Quit the application."

--- a/po/sr.po
+++ b/po/sr.po
@@ -876,15 +876,15 @@ msgstr "Врати величину прозора на подразумеван
 
 #: src/input/command.zig:569
 msgid "Toggle Inspector"
-msgstr "Окини инспектора"
+msgstr "Окини инспектор"
 
 #: src/input/command.zig:570
 msgid "Toggle the inspector."
-msgstr "Окини инспектора."
+msgstr "Окини инспектор."
 
 #: src/input/command.zig:575
 msgid "Show the GTK Inspector"
-msgstr "Прикажи ГТК инспектора"
+msgstr "Прикажи ГТК инспектор"
 
 #: src/input/command.zig:576
 msgid "Show the GTK inspector."

--- a/po/sr.po
+++ b/po/sr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
 "POT-Creation-Date: 2026-08-10 10:06-0500\n"
-"PO-Revision-Date: 2026-08-29 12:49+0200\n"
+"PO-Revision-Date: 2026-08-31 21:45+0200\n"
 "Last-Translator: Марко Костић <marko.m.kostic@gmail.com>\n"
 "Language-Team: Language SR\n"
 "Language: sr\n"
@@ -65,8 +65,8 @@ msgid ""
 "One or more configuration errors were found. Please review the errors below, and either reload your "
 "configuration or ignore these errors."
 msgstr ""
-"Пронађена је једна или више грешака у подешавањима. Прегледајте грешке испод, и поново учитајте своја "
-"подешавања или занемарите ове грешке."
+"Пронађена је једна или више грешака у подешавањима. Прегледај грешке испод, и поново учитај своја "
+"подешавања или занемари ове грешке."
 
 #: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:12
 msgid "Ignore"
@@ -79,7 +79,7 @@ msgstr "Поново учитај подешавања"
 
 #: src/apprt/gtk/ui/1.2/debug-warning.blp:7 src/apprt/gtk/ui/1.3/debug-warning.blp:6
 msgid "⚠️ You're running a debug build of Ghostty! Performance will be degraded."
-msgstr "⚠️ Покрећете издање Ghostty-ја за отклањање грешака! Перформансе биће смањене."
+msgstr "⚠️ Покрећеш издање Ghostty-ја за отклањање грешака! Перформансе биће смањене."
 
 #: src/apprt/gtk/ui/1.5/inspector-window.blp:5
 msgid "Ghostty: Terminal Inspector"
@@ -110,7 +110,7 @@ msgid ""
 "This terminal is in read-only mode. You can still view, select, and scroll through the content, but no "
 "input events will be sent to the running application."
 msgstr ""
-"Овај терминал је у режиму само за читање. И даље можете прегледати, бирати и помицати садржај, али "
+"Овај терминал је у режиму само за читање. И даље можеш прегледати, бирати и помицати садржај, али "
 "догађаји уноса неће бити послати покренутом програму."
 
 #: src/apprt/gtk/ui/1.2/surface.blp:112
@@ -217,7 +217,7 @@ msgstr "Отвори подешавања у новом прозору"
 
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:5
 msgid "Leave blank to restore the default title."
-msgstr "Оставите празно да бисте вратили подразумевани наслов."
+msgstr "Остави празно да вратиш подразумевани наслов."
 
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:9
 msgid "OK"
@@ -415,7 +415,7 @@ msgstr "Копирај URL у оставу"
 
 #: src/input/command.zig:174
 msgid "Copy the URL under the cursor to the clipboard."
-msgstr "Копирајте URL испод показивача у оставу."
+msgstr "Копирај URL испод показивача у оставу."
 
 #: src/input/command.zig:179
 msgid "Copy Terminal Title to Clipboard"
@@ -439,7 +439,7 @@ msgstr "Убаци из избора"
 
 #: src/input/command.zig:192
 msgid "Paste the contents of the selection clipboard."
-msgstr "Убаците садржај оставе избора."
+msgstr "Убаци садржај оставе избора."
 
 #: src/input/command.zig:197
 msgid "Start Search"
@@ -527,7 +527,7 @@ msgstr "Помакни на врх"
 
 #: src/input/command.zig:256
 msgid "Scroll to the top of the screen."
-msgstr "Помакните на врх екрана."
+msgstr "Помакни на врх екрана."
 
 #: src/input/command.zig:261
 msgid "Scroll to Bottom"
@@ -535,7 +535,7 @@ msgstr "Помакни на дно"
 
 #: src/input/command.zig:262
 msgid "Scroll to the bottom of the screen."
-msgstr "Помакните на дно екрана."
+msgstr "Помакни на дно екрана."
 
 #: src/input/command.zig:267
 msgid "Scroll to Selection"
@@ -543,7 +543,7 @@ msgstr "Помакни до избора"
 
 #: src/input/command.zig:268
 msgid "Scroll to the selected text."
-msgstr "Помакните до изабраног текста."
+msgstr "Помакни до изабраног текста."
 
 #: src/input/command.zig:273
 msgid "Scroll Page Up"
@@ -551,7 +551,7 @@ msgstr "Помакни страницу нагоре"
 
 #: src/input/command.zig:274
 msgid "Scroll the screen up by a page."
-msgstr "Помакните екран нагоре за једну страницу."
+msgstr "Помакни екран нагоре за једну страницу."
 
 #: src/input/command.zig:279
 msgid "Scroll Page Down"
@@ -559,7 +559,7 @@ msgstr "Помакни страницу надоле"
 
 #: src/input/command.zig:280
 msgid "Scroll the screen down by a page."
-msgstr "Помакните екран надоле за једну страницу."
+msgstr "Помакни екран надоле за једну страницу."
 
 #: src/input/command.zig:286
 msgid "Copy Screen to Temporary File and Copy Path"
@@ -567,7 +567,7 @@ msgstr "Копирај екран у привремену датотеку и к
 
 #: src/input/command.zig:287
 msgid "Copy the screen contents to a temporary file and copy the path to the clipboard."
-msgstr "Копирај садржај екрана у привремену датотеку и копирајте путању у оставу."
+msgstr "Копирај садржај екрана у привремену датотеку и копирај путању у оставу."
 
 #: src/input/command.zig:291
 msgid "Copy Screen to Temporary File and Paste Path"
@@ -575,7 +575,7 @@ msgstr "Копирај екран у привремену датотеку и у
 
 #: src/input/command.zig:292
 msgid "Copy the screen contents to a temporary file and paste the path to the file."
-msgstr "Копирајте садржај екрана у привремену датотеку и убаците путању до те датотеке."
+msgstr "Копирај садржај екрана у привремену датотеку и убаци путању до те датотеке."
 
 #: src/input/command.zig:296
 msgid "Copy Screen to Temporary File and Open"
@@ -583,7 +583,7 @@ msgstr "Копирај екран у привремену датотеку и о
 
 #: src/input/command.zig:297
 msgid "Copy the screen contents to a temporary file and open it."
-msgstr "Копирајте садржај екрана у привремену датотеку и отворите је."
+msgstr "Копирај садржај екрана у привремену датотеку и отвори је."
 
 #: src/input/command.zig:305
 msgid "Copy Screen as HTML to Temporary File and Copy Path"
@@ -591,7 +591,7 @@ msgstr "Копирај екран као HTML у привремену датот
 
 #: src/input/command.zig:306
 msgid "Copy the screen contents as HTML to a temporary file and copy the path to the clipboard."
-msgstr "Копирајте садржај екрана као HTML у привремену датотеку и копирајте путању у оставу."
+msgstr "Копирај садржај екрана као HTML у привремену датотеку и копирај путању у оставу."
 
 #: src/input/command.zig:313
 msgid "Copy Screen as HTML to Temporary File and Paste Path"
@@ -599,7 +599,7 @@ msgstr "Копирај екран као HTML у привремену датот
 
 #: src/input/command.zig:314
 msgid "Copy the screen contents as HTML to a temporary file and paste the path to the file."
-msgstr "Копирајте садржај екрана као HTML у привремену датотеку и убаците путању до те датотеке."
+msgstr "Копирај садржај екрана као HTML у привремену датотеку и убаци путању до те датотеке."
 
 #: src/input/command.zig:321
 msgid "Copy Screen as HTML to Temporary File and Open"
@@ -748,7 +748,7 @@ msgstr "Окини преглед језичака"
 
 #: src/input/command.zig:453
 msgid "Toggle the tab overview."
-msgstr "Окините преглед језичака."
+msgstr "Окини преглед језичака."
 
 #: src/input/command.zig:458
 msgid "Change Terminal Title…"
@@ -1052,4 +1052,4 @@ msgstr "Ghostty"
 
 #: src/input/command.zig:709
 msgid "Put a little Ghostty in your terminal."
-msgstr "Убаците мало Ghostty-ја у ваш терминал."
+msgstr "Убаци мало Ghostty-ја у свој терминал."

--- a/po/sr.po
+++ b/po/sr.po
@@ -395,11 +395,11 @@ msgstr "Копирај изабрани текст као обичан текс�
 
 #: src/input/command.zig:163
 msgid "Copy Selection as ANSI Sequences to Clipboard"
-msgstr "Копирај изабрано као ANSI низове у оставу"
+msgstr "Копирај изабрано као ANSI секвенце у оставу"
 
 #: src/input/command.zig:164
 msgid "Copy the selected text as ANSI escape sequences to the clipboard."
-msgstr "Копирај изабрани текст као ANSI излазне низове у оставу."
+msgstr "Копирај изабрани текст као ANSI излазне секвенце у оставу."
 
 #: src/input/command.zig:167
 msgid "Copy Selection as HTML to Clipboard"
@@ -611,29 +611,29 @@ msgstr "Копирај садржај екрана као ХТМЛ у привр
 
 #: src/input/command.zig:330
 msgid "Copy Screen as ANSI Sequences to Temporary File and Copy Path"
-msgstr "Копирај екран као ANSI низове у привремену датотеку и копирај путању"
+msgstr "Копирај екран као ANSI секвенце у привремену датотеку и копирај путању"
 
 #: src/input/command.zig:331
 msgid ""
 "Copy the screen contents as ANSI escape sequences to a temporary file and copy the path to the clipboard."
-msgstr "Копирај садржај екрана као излазне ANSI низове у привремену датотеку и копирај путању у оставу."
+msgstr "Копирај садржај екрана као излазне ANSI секвенце у привремену датотеку и копирај путању у оставу."
 
 #: src/input/command.zig:338
 msgid "Copy Screen as ANSI Sequences to Temporary File and Paste Path"
-msgstr "Копирај екран као ANSI низове у привремену датотеку и убаци путању"
+msgstr "Копирај екран као ANSI секвенце у привремену датотеку и убаци путању"
 
 #: src/input/command.zig:339
 msgid ""
 "Copy the screen contents as ANSI escape sequences to a temporary file and paste the path to the file."
-msgstr "Копирај садржај екрана као излазне ANSI низове у привремену датотеку и убаци путању до датотеке."
+msgstr "Копирај садржај екрана као излазне ANSI секвенце у привремену датотеку и убаци путању до датотеке."
 
 #: src/input/command.zig:346
 msgid "Copy Screen as ANSI Sequences to Temporary File and Open"
-msgstr "Копирај екран као ANSI низове у привремену датотеку и отвори"
+msgstr "Копирај екран као ANSI секвенце у привремену датотеку и отвори"
 
 #: src/input/command.zig:347
 msgid "Copy the screen contents as ANSI escape sequences to a temporary file and open it."
-msgstr "Копирај садржај екрана као излазне ANSI низове у привремену датотеку и отвори је."
+msgstr "Копирај садржај екрана као излазне ANSI секвенце у привремену датотеку и отвори је."
 
 #: src/input/command.zig:354
 msgid "Copy Selection to Temporary File and Copy Path"
@@ -685,30 +685,30 @@ msgstr "Копирај садржај изабраног као ХТМЛ у пр
 
 #: src/input/command.zig:398
 msgid "Copy Selection as ANSI Sequences to Temporary File and Copy Path"
-msgstr "Копирај изабрано као ANSI низове у привремену датотеку и копирај путању"
+msgstr "Копирај изабрано као ANSI секвенце у привремену датотеку и копирај путању"
 
 #: src/input/command.zig:399
 msgid ""
 "Copy the selection contents as ANSI escape sequences to a temporary file and copy the path to the "
 "clipboard."
-msgstr "Копирај садржај избора као излазне ANSI низове у привремену датотеку и копирај путању у оставу."
+msgstr "Копирај садржај избора као излазне ANSI секвенце у привремену датотеку и копирај путању у оставу."
 
 #: src/input/command.zig:406
 msgid "Copy Selection as ANSI Sequences to Temporary File and Paste Path"
-msgstr "Копирај изабрано као ANSI низове у привремену датотеку и убаци путању"
+msgstr "Копирај изабрано као ANSI секвенце у привремену датотеку и убаци путању"
 
 #: src/input/command.zig:407
 msgid ""
 "Copy the selection contents as ANSI escape sequences to a temporary file and paste the path to the file."
-msgstr "Копирај садржај избора као излазне ANSI низове у привремену датотеку и убаци путању до те датотеке."
+msgstr "Копирај садржај избора као излазне ANSI секвенце у привремену датотеку и убаци путању до те датотеке."
 
 #: src/input/command.zig:414
 msgid "Copy Selection as ANSI Sequences to Temporary File and Open"
-msgstr "Копирај изабрано као ANSI низове у привремену датотеку и отвори"
+msgstr "Копирај изабрано као ANSI секвенце у привремену датотеку и отвори"
 
 #: src/input/command.zig:415
 msgid "Copy the selection contents as ANSI escape sequences to a temporary file and open it."
-msgstr "Копирај садржај избора као излазне ANSI низове у привремену датотеку и отвори је."
+msgstr "Копирај садржај избора као излазне ANSI секвенце у привремену датотеку и отвори је."
 
 #: src/input/command.zig:422
 msgid "Open a new window."

--- a/po/sr.po
+++ b/po/sr.po
@@ -415,7 +415,7 @@ msgstr "Копирај URL у оставу"
 
 #: src/input/command.zig:174
 msgid "Copy the URL under the cursor to the clipboard."
-msgstr "Копирајте УРЛ испод показивача у оставу."
+msgstr "Копирајте URL испод показивача у оставу."
 
 #: src/input/command.zig:179
 msgid "Copy Terminal Title to Clipboard"
@@ -595,19 +595,19 @@ msgstr "Копирајте садржај екрана као HTML у привр
 
 #: src/input/command.zig:313
 msgid "Copy Screen as HTML to Temporary File and Paste Path"
-msgstr "Копирај екран као ХТМЛ у привремену датотеку и убаци путању"
+msgstr "Копирај екран као HTML у привремену датотеку и убаци путању"
 
 #: src/input/command.zig:314
 msgid "Copy the screen contents as HTML to a temporary file and paste the path to the file."
-msgstr "Копирајте садржај екрана као ХТМЛ у привремену датотеку и убаците путању до те датотеке."
+msgstr "Копирајте садржај екрана као HTML у привремену датотеку и убаците путању до те датотеке."
 
 #: src/input/command.zig:321
 msgid "Copy Screen as HTML to Temporary File and Open"
-msgstr "Копирај екран као ХТМЛ у привремену датотеку и отвори"
+msgstr "Копирај екран као HTML у привремену датотеку и отвори"
 
 #: src/input/command.zig:322
 msgid "Copy the screen contents as HTML to a temporary file and open it."
-msgstr "Копирај садржај екрана као ХТМЛ у привремену датотеку и отвори је."
+msgstr "Копирај садржај екрана као HTML у привремену датотеку и отвори је."
 
 #: src/input/command.zig:330
 msgid "Copy Screen as ANSI Sequences to Temporary File and Copy Path"
@@ -661,27 +661,27 @@ msgstr "Копирај садржај изабраног у привремену
 
 #: src/input/command.zig:373
 msgid "Copy Selection as HTML to Temporary File and Copy Path"
-msgstr "Копирај изабрано као ХТМЛ у привремену датотеку и копирај путању"
+msgstr "Копирај изабрано као HTML у привремену датотеку и копирај путању"
 
 #: src/input/command.zig:374
 msgid "Copy the selection contents as HTML to a temporary file and copy the path to the clipboard."
-msgstr "Копирај садржај изабраног као ХТМЛ у привремену датотеку и копирај путању у оставу."
+msgstr "Копирај садржај изабраног као HTML у привремену датотеку и копирај путању у оставу."
 
 #: src/input/command.zig:381
 msgid "Copy Selection as HTML to Temporary File and Paste Path"
-msgstr "Копирај изабрано као ХТМЛ у привремену датотеку и убаци путању"
+msgstr "Копирај изабрано као HTML у привремену датотеку и убаци путању"
 
 #: src/input/command.zig:382
 msgid "Copy the selection contents as HTML to a temporary file and paste the path to the file."
-msgstr "Копирај садржај изабраног као ХТМЛ у привремену датотеку и убаци путању до датотеке."
+msgstr "Копирај садржај изабраног као HTML у привремену датотеку и убаци путању до датотеке."
 
 #: src/input/command.zig:389
 msgid "Copy Selection as HTML to Temporary File and Open"
-msgstr "Копирај изабрано као ХТМЛ у привремену датотеку и отвори"
+msgstr "Копирај изабрано као HTML у привремену датотеку и отвори"
 
 #: src/input/command.zig:390
 msgid "Copy the selection contents as HTML to a temporary file and open it."
-msgstr "Копирај садржај изабраног као ХТМЛ у привремену датотеку и отвори је."
+msgstr "Копирај садржај изабраног као HTML у привремену датотеку и отвори је."
 
 #: src/input/command.zig:398
 msgid "Copy Selection as ANSI Sequences to Temporary File and Copy Path"

--- a/po/sr@latin.po
+++ b/po/sr@latin.po
@@ -1,0 +1,1134 @@
+# Language SR@latin translations for com.mitchellh.ghostty package.
+# Copyright (C) 2026 "Mitchell Hashimoto, Ghostty contributors"
+# This file is distributed under the same license as the com.mitchellh.ghostty package.
+# Марко Костић <marko.m.kostic@gmail.com>, 2026.
+#
+# Do not translate or edit this file directly. It is generated from po/sr.po with:
+# msgfilter -i po/sr.po -o po/sr@latin.po recode-sr-latin
+# After updating po/sr.po, regenerate this file and set `Language: sr@latin`.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: com.mitchellh.ghostty\n"
+"Report-Msgid-Bugs-To: m@mitchellh.com\n"
+"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"PO-Revision-Date: 2026-08-15 10:28+0200\n"
+"Last-Translator: Marko Kostić <marko.m.kostic@gmail.com>\n"
+"Language-Team: Language SR\n"
+"Language: sr@latin\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: dist/linux/ghostty_nautilus.py:53
+msgid "Open in Ghostty"
+msgstr "Otvori u Ghostty-ju"
+
+#: src/apprt/gtk/ui/1.0/clipboard-confirmation-dialog.blp:12
+#: src/apprt/gtk/ui/1.4/clipboard-confirmation-dialog.blp:12
+#: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:197
+#: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:201
+msgid "Authorize Clipboard Access"
+msgstr "Ovlasti pristup ostavi"
+
+#: src/apprt/gtk/ui/1.0/clipboard-confirmation-dialog.blp:17
+#: src/apprt/gtk/ui/1.4/clipboard-confirmation-dialog.blp:17
+msgid "Deny"
+msgstr "Odbij"
+
+#: src/apprt/gtk/ui/1.0/clipboard-confirmation-dialog.blp:18
+#: src/apprt/gtk/ui/1.4/clipboard-confirmation-dialog.blp:18
+msgid "Allow"
+msgstr "Dozvoli"
+
+#: src/apprt/gtk/ui/1.4/clipboard-confirmation-dialog.blp:92
+msgid "Remember choice for this split"
+msgstr "Zapamti izbor za ovu razdelu"
+
+#: src/apprt/gtk/ui/1.4/clipboard-confirmation-dialog.blp:93
+msgid "Reload configuration to show this prompt again"
+msgstr "Ponovo učitaj postavke da bi se ovaj upit ponovo prikazao"
+
+#: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
+#: src/apprt/gtk/ui/1.5/title-dialog.blp:8
+#: src/apprt/gtk/class/application.zig:2263
+msgid "Cancel"
+msgstr "Otkaži"
+
+#: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:8
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:90
+#: src/apprt/gtk/ui/1.3/surface-child-exited.blp:17
+msgid "Close"
+msgstr "Zatvori"
+
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:6
+msgid "Configuration Errors"
+msgstr "Greške u postavkama"
+
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:8
+msgid ""
+"One or more configuration errors were found. Please review the errors below, "
+"and either reload your configuration or ignore these errors."
+msgstr ""
+"Pronađena je jedna ili više grešaka u postavkama. Pregledajte greške ispod, "
+"i ponovo učitajte svoje postavke ili zanemarite ove greške."
+
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:12
+msgid "Ignore"
+msgstr "Zanemari"
+
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:13
+#: src/apprt/gtk/ui/1.2/surface.blp:439 src/apprt/gtk/ui/1.5/window.blp:318
+msgid "Reload Configuration"
+msgstr "Ponovo učitaj postavke"
+
+#: src/apprt/gtk/ui/1.2/debug-warning.blp:7
+#: src/apprt/gtk/ui/1.3/debug-warning.blp:6
+msgid ""
+"⚠️ You're running a debug build of Ghostty! Performance will be degraded."
+msgstr ""
+"⚠️ Pokrećete izdanje Ghostty-ja za otklanjanje grešaka! Performanse biće "
+"smanjene."
+
+#: src/apprt/gtk/ui/1.5/inspector-window.blp:5
+msgid "Ghostty: Terminal Inspector"
+msgstr "Ghostty: inspektor terminala"
+
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:29
+msgid "Find…"
+msgstr "Nađi…"
+
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:69
+msgid "Previous Match"
+msgstr "Prethodno poklapanje"
+
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:79
+msgid "Next Match"
+msgstr "Sledeće poklapanje"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:7
+msgid "Oh, no."
+msgstr "O, ne."
+
+#: src/apprt/gtk/ui/1.2/surface.blp:8
+msgid "Unable to acquire an OpenGL context for rendering."
+msgstr "Nije bilo moguće obezbediti OpenGL kontekst za iscrtavanje."
+
+#: src/apprt/gtk/ui/1.2/surface.blp:101
+msgid ""
+"This terminal is in read-only mode. You can still view, select, and scroll "
+"through the content, but no input events will be sent to the running "
+"application."
+msgstr ""
+"Ovaj terminal je u režimu samo za čitanje. I dalje možete pregledati, birati "
+"i pomicati sadržaj, ali događaji unosa neće biti poslati pokrenutom programu."
+
+#: src/apprt/gtk/ui/1.2/surface.blp:112
+msgid "Read-only"
+msgstr "Samo za čitanje"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:316 src/apprt/gtk/ui/1.5/window.blp:203
+msgid "Copy"
+msgstr "Kopiraj"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:321 src/apprt/gtk/ui/1.5/window.blp:208
+msgid "Paste"
+msgstr "Ubaci"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:326
+msgid "Notify on Next Command Finish"
+msgstr "Obavesti kada se sledeća naredba završi"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:333 src/apprt/gtk/ui/1.5/window.blp:281
+msgid "Clear"
+msgstr "Očisti"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:338 src/apprt/gtk/ui/1.5/window.blp:286
+msgid "Reset"
+msgstr "Vrati"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:345 src/apprt/gtk/ui/1.5/window.blp:250
+msgid "Split"
+msgstr "Razdeli"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:348 src/apprt/gtk/ui/1.5/window.blp:253
+msgid "Change Title…"
+msgstr "Promeni naslov…"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:353 src/apprt/gtk/ui/1.5/window.blp:180
+#: src/apprt/gtk/ui/1.5/window.blp:258 src/input/command.zig:487
+msgid "Split Up"
+msgstr "Razdeli nagore"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:359 src/apprt/gtk/ui/1.5/window.blp:185
+#: src/apprt/gtk/ui/1.5/window.blp:263 src/input/command.zig:492
+msgid "Split Down"
+msgstr "Razdeli dole"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:365 src/apprt/gtk/ui/1.5/window.blp:190
+#: src/apprt/gtk/ui/1.5/window.blp:268 src/input/command.zig:477
+msgid "Split Left"
+msgstr "Razdeli levo"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:195
+#: src/apprt/gtk/ui/1.5/window.blp:273 src/input/command.zig:482
+msgid "Split Right"
+msgstr "Razdeli desno"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:377
+msgid "Close Split"
+msgstr "Zatvori razdelu"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:383
+msgid "Tab"
+msgstr "Jezičak"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:386 src/apprt/gtk/ui/1.5/window.blp:232
+#: src/apprt/gtk/ui/1.5/window.blp:339 src/input/command.zig:464
+msgid "Change Tab Title…"
+msgstr "Promeni naslov jezička…"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:391 src/apprt/gtk/ui/1.5/window.blp:60
+#: src/apprt/gtk/ui/1.5/window.blp:110 src/apprt/gtk/ui/1.5/window.blp:237
+#: src/input/command.zig:427
+msgid "New Tab"
+msgstr "Novi jezičak"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/input/command.zig:613
+msgid "Close Tab"
+msgstr "Zatvori jezičak"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:403
+msgid "Window"
+msgstr "Prozor"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:406 src/apprt/gtk/ui/1.5/window.blp:215
+msgid "Change Window Title…"
+msgstr "Promeni naslov prozora…"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:411 src/apprt/gtk/ui/1.5/window.blp:220
+#: src/input/command.zig:421
+msgid "New Window"
+msgstr "Novi prozor"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:416 src/apprt/gtk/ui/1.5/window.blp:225
+#: src/input/command.zig:630
+msgid "Close Window"
+msgstr "Zatvori prozor"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:424 src/apprt/gtk/ui/1.5/window.blp:303
+msgid "Config"
+msgstr "Podešavanja"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:427 src/apprt/gtk/ui/1.5/window.blp:306
+msgid "Open Configuration in OS Editor"
+msgstr "Otvori postavke u uređivaču OS-a"
+
+#: src/apprt/gtk/ui/1.2/surface.blp:433 src/apprt/gtk/ui/1.5/window.blp:312
+msgid "Open Configuration in New Window"
+msgstr "Otvori postavke u novom prozoru"
+
+#: src/apprt/gtk/ui/1.5/title-dialog.blp:5
+msgid "Leave blank to restore the default title."
+msgstr "Ostavite prazno da biste vratili podrazumevani naslov."
+
+#: src/apprt/gtk/ui/1.5/title-dialog.blp:9
+msgid "OK"
+msgstr "U redu"
+
+#: src/apprt/gtk/ui/1.5/window.blp:61 src/apprt/gtk/ui/1.5/window.blp:111
+msgid "New Split"
+msgstr "Nova razdela"
+
+#: src/apprt/gtk/ui/1.5/window.blp:71 src/apprt/gtk/ui/1.5/window.blp:129
+msgid "View Open Tabs"
+msgstr "Prikaži otvorene jezičke"
+
+#: src/apprt/gtk/ui/1.5/window.blp:81 src/apprt/gtk/ui/1.5/window.blp:143
+msgid "Main Menu"
+msgstr "Glavni meni"
+
+#: src/apprt/gtk/ui/1.5/window.blp:293
+msgid "Command Palette"
+msgstr "Paleta naredbi"
+
+#: src/apprt/gtk/ui/1.5/window.blp:298
+msgid "Terminal Inspector"
+msgstr "Inspektor terminala"
+
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1991
+msgid "About Ghostty"
+msgstr "O programu Ghostty"
+
+#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:702
+msgid "Quit"
+msgstr "Izađi"
+
+#: src/apprt/gtk/ui/1.5/command-palette.blp:17
+msgid "Execute a command…"
+msgstr "Izvrši naredbu…"
+
+#: src/apprt/gtk/class/application.zig:1767
+msgid "The keybind was revoked by the system."
+msgstr "Sistem je opozvao prečicu."
+
+#: src/apprt/gtk/class/application.zig:1769
+msgid "The keybind was denied by the system."
+msgstr "Sistem je odbio prečicu."
+
+#: src/apprt/gtk/class/application.zig:1780
+msgid "Global keybind unavailable"
+msgstr "Globalna prečica nije dostupna"
+
+#: src/apprt/gtk/class/application.zig:2259
+msgid "Export Terminal IO Events"
+msgstr "Izvezi događaje ulaza/izlaza terminala"
+
+#: src/apprt/gtk/class/application.zig:2262
+msgid "Export"
+msgstr "Izvezi"
+
+#: src/apprt/gtk/class/application.zig:2783
+msgid "Editing configuration file"
+msgstr "Uređivanje datoteke sa postavkama"
+
+#: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
+msgid ""
+"An application is attempting to write to the clipboard. The current "
+"clipboard contents are shown below."
+msgstr ""
+"Program pokušava da piše u ostavu. Trenutni sadržaj ostave je prikazan ispod."
+
+#: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:202
+msgid ""
+"An application is attempting to read from the clipboard. The current "
+"clipboard contents are shown below."
+msgstr ""
+"Program pokušava da čita iz ostave. Trenutni sadržaj ostave je prikazan "
+"ispod."
+
+#: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:205
+msgid "Warning: Potentially Unsafe Paste"
+msgstr "Upozorenje: potencijalno nebezbedno ubacivanje"
+
+#: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:206
+msgid ""
+"Pasting this text into the terminal may be dangerous as it looks like some "
+"commands may be executed."
+msgstr ""
+"Ubacivanje ovog teksta u terminal može biti opasno jer izgleda kao da se "
+"neke naredbe mogu izvršiti."
+
+#: src/apprt/gtk/class/close_confirmation_dialog.zig:184
+msgid "Quit Ghostty?"
+msgstr "Izaći iz Ghostty-ja?"
+
+#: src/apprt/gtk/class/close_confirmation_dialog.zig:185
+msgid "Close Tab?"
+msgstr "Da zatvorim jezičak?"
+
+#: src/apprt/gtk/class/close_confirmation_dialog.zig:186
+msgid "Close Window?"
+msgstr "Da zatvorim prozor?"
+
+#: src/apprt/gtk/class/close_confirmation_dialog.zig:187
+msgid "Close Split?"
+msgstr "Zatvoriti razdelu?"
+
+#: src/apprt/gtk/class/close_confirmation_dialog.zig:193
+msgid "All terminal sessions will be terminated."
+msgstr "Sve sesije terminala biće prekinute."
+
+#: src/apprt/gtk/class/close_confirmation_dialog.zig:194
+msgid "All terminal sessions in this tab will be terminated."
+msgstr "Sve sesije terminala u ovom jezičku biće prekinute."
+
+#: src/apprt/gtk/class/close_confirmation_dialog.zig:195
+msgid "All terminal sessions in this window will be terminated."
+msgstr "Sve sesije terminala u ovom prozoru biće prekinute."
+
+#: src/apprt/gtk/class/close_confirmation_dialog.zig:196
+msgid "The currently running process in this split will be terminated."
+msgstr "Trenutno pokrenut proces u ovoj razdeli biće prekinut."
+
+#: src/apprt/gtk/class/surface.zig:1181
+msgid "Command Finished"
+msgstr "Naredba je završena"
+
+#: src/apprt/gtk/class/surface.zig:1182
+#: src/apprt/gtk/class/surface_child_exited.zig:109
+msgid "Command Succeeded"
+msgstr "Naredba je uspešno izvršena"
+
+#: src/apprt/gtk/class/surface.zig:1183
+#: src/apprt/gtk/class/surface_child_exited.zig:113
+msgid "Command Failed"
+msgstr "Naredba nije uspela"
+
+#: src/apprt/gtk/class/title_dialog.zig:227
+msgid "Change Terminal Title"
+msgstr "Promeni naslov terminala"
+
+#: src/apprt/gtk/class/title_dialog.zig:228
+msgid "Change Tab Title"
+msgstr "Promeni naslov jezička"
+
+#: src/apprt/gtk/class/title_dialog.zig:229
+msgid "Change Window Title"
+msgstr "Promeni naslov prozora"
+
+#: src/apprt/gtk/class/window.zig:1153
+msgid "Reloaded the configuration"
+msgstr "Ponovo učitane postavke"
+
+#: src/apprt/gtk/class/window.zig:1830
+msgid "Copied to clipboard"
+msgstr "Kopirano u ostavu"
+
+#: src/apprt/gtk/class/window.zig:1832
+msgid "Cleared clipboard"
+msgstr "Ostava očišćena"
+
+#: src/apprt/gtk/class/window.zig:1972
+msgid "Ghostty Developers"
+msgstr "Programeri Ghostty-ja"
+
+#: src/input/command.zig:149
+msgid "Reset Terminal"
+msgstr "Povrati terminal"
+
+#: src/input/command.zig:150
+msgid "Reset the terminal to a clean state."
+msgstr "Vrati terminal u čisto stanje."
+
+#: src/input/command.zig:155
+msgid "Copy to Clipboard"
+msgstr "Kopiraj u ostavu"
+
+#: src/input/command.zig:156
+msgid ""
+"Copy the selected text to the clipboard in both plain and styled formats."
+msgstr "Kopiraj izabrani tekst u ostavu u običnom i oblikovanom formatu."
+
+#: src/input/command.zig:159
+msgid "Copy Selection as Plain Text to Clipboard"
+msgstr "Kopiraj izabrano kao običan tekst u ostavu"
+
+#: src/input/command.zig:160
+msgid "Copy the selected text as plain text to the clipboard."
+msgstr "Kopiraj izabrani tekst kao običan tekst u ostavu."
+
+#: src/input/command.zig:163
+msgid "Copy Selection as ANSI Sequences to Clipboard"
+msgstr "Kopiraj izabrano kao ANSI nizove u ostavu"
+
+#: src/input/command.zig:164
+msgid "Copy the selected text as ANSI escape sequences to the clipboard."
+msgstr "Kopiraj izabrani tekst kao ANSI izlazne nizove u ostavu."
+
+#: src/input/command.zig:167
+msgid "Copy Selection as HTML to Clipboard"
+msgstr "Kopiraj izabrano kao html u ostavu"
+
+#: src/input/command.zig:168
+msgid "Copy the selected text as HTML to the clipboard."
+msgstr "Kopirajte izabrani tekst kao html u ostavu."
+
+#: src/input/command.zig:173
+msgid "Copy URL to Clipboard"
+msgstr "Kopiraj URL u ostavu"
+
+#: src/input/command.zig:174
+msgid "Copy the URL under the cursor to the clipboard."
+msgstr "Kopirajte URL ispod pokazivača u ostavu."
+
+#: src/input/command.zig:179
+msgid "Copy Terminal Title to Clipboard"
+msgstr "Kopiraj naslov terminala u ostavu"
+
+#: src/input/command.zig:180
+msgid ""
+"Copy the terminal title to the clipboard. If the terminal title is not set "
+"this has no effect."
+msgstr ""
+"Kopirajte naslov terminala u ostavu. Ako naslov terminala nije postavljen, "
+"ovo neće imati dejstva."
+
+#: src/input/command.zig:185
+msgid "Paste from Clipboard"
+msgstr "Ubaci iz ostave"
+
+#: src/input/command.zig:186
+msgid "Paste the contents of the main clipboard."
+msgstr "Ubacite sadržaj glavne ostave."
+
+#: src/input/command.zig:191
+msgid "Paste from Selection"
+msgstr "Ubaci iz izbora"
+
+#: src/input/command.zig:192
+msgid "Paste the contents of the selection clipboard."
+msgstr "Ubacite sadržaj ostave izbora."
+
+#: src/input/command.zig:197
+msgid "Start Search"
+msgstr "Pokreni pretragu"
+
+#: src/input/command.zig:198
+msgid "Start a search if one isn't already active."
+msgstr "Pokreni pretragu ako već nijedna nije aktivna."
+
+#: src/input/command.zig:203
+msgid "Search Selection"
+msgstr "Pretraži izbor"
+
+#: src/input/command.zig:204
+msgid "Start a search for the current text selection."
+msgstr "Pokreni pretragu za trenutni tekstualni izbor."
+
+#: src/input/command.zig:209
+msgid "End Search"
+msgstr "Završi pretragu"
+
+#: src/input/command.zig:210
+msgid "End the current search if any and hide any GUI elements."
+msgstr "Završi trenutnu pretragu, ako postoji, i sakrij sve grafičke elemente."
+
+#: src/input/command.zig:215
+msgid "Next Search Result"
+msgstr "Sledeći rezultat pretrage"
+
+#: src/input/command.zig:216
+msgid "Navigate to the next search result, if any."
+msgstr "Idi do sledećeg rezultata pretrage, ako postoji."
+
+#: src/input/command.zig:219
+msgid "Previous Search Result"
+msgstr "Prethodni rezultat pretrage"
+
+#: src/input/command.zig:220
+msgid "Navigate to the previous search result, if any."
+msgstr "Idi do prethodnog rezultata pretrage, ako postoji."
+
+#: src/input/command.zig:225
+msgid "Increase Font Size"
+msgstr "Povećaj veličinu fonta"
+
+#: src/input/command.zig:226
+msgid "Increase the font size by 1 point."
+msgstr "Uvećaj veličinu fonta za 1 tačku."
+
+#: src/input/command.zig:231
+msgid "Decrease Font Size"
+msgstr "Smanji veličinu fonta"
+
+#: src/input/command.zig:232
+msgid "Decrease the font size by 1 point."
+msgstr "Umanji veličinu fonta za 1 tačku."
+
+#: src/input/command.zig:237
+msgid "Reset Font Size"
+msgstr "Vrati veličinu fonta"
+
+#: src/input/command.zig:238
+msgid "Reset the font size to the default."
+msgstr "Vrati veličinu fonta na podrazumevanu."
+
+#: src/input/command.zig:243
+msgid "Clear Screen"
+msgstr "Očisti ekran"
+
+#: src/input/command.zig:244
+msgid "Clear the screen and scrollback."
+msgstr "Očisti ekran i istoriju pomicanja."
+
+#: src/input/command.zig:249
+msgid "Select All"
+msgstr "Izaberi sve"
+
+#: src/input/command.zig:250
+msgid "Select all text on the screen."
+msgstr "Izaberi sav tekst na ekranu."
+
+#: src/input/command.zig:255
+msgid "Scroll to Top"
+msgstr "Pomakni na vrh"
+
+#: src/input/command.zig:256
+msgid "Scroll to the top of the screen."
+msgstr "Pomaknite na vrh ekrana."
+
+#: src/input/command.zig:261
+msgid "Scroll to Bottom"
+msgstr "Pomakni na dno"
+
+#: src/input/command.zig:262
+msgid "Scroll to the bottom of the screen."
+msgstr "Pomaknite na dno ekrana."
+
+#: src/input/command.zig:267
+msgid "Scroll to Selection"
+msgstr "Pomakni do izbora"
+
+#: src/input/command.zig:268
+msgid "Scroll to the selected text."
+msgstr "Pomaknite do izabranog teksta."
+
+#: src/input/command.zig:273
+msgid "Scroll Page Up"
+msgstr "Pomakni stranicu nagore"
+
+#: src/input/command.zig:274
+msgid "Scroll the screen up by a page."
+msgstr "Pomaknite ekran nagore za jednu stranicu."
+
+#: src/input/command.zig:279
+msgid "Scroll Page Down"
+msgstr "Pomakni stranicu nadole"
+
+#: src/input/command.zig:280
+msgid "Scroll the screen down by a page."
+msgstr "Pomaknite ekran nadole za jednu stranicu."
+
+#: src/input/command.zig:286
+msgid "Copy Screen to Temporary File and Copy Path"
+msgstr "Kopiraj ekran u privremenu datoteku i kopiraj putanju"
+
+#: src/input/command.zig:287
+msgid ""
+"Copy the screen contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+"Kopirajte sadržaj ekrana u privremenu datoteku i kopirajte putanju u ostavu."
+
+#: src/input/command.zig:291
+msgid "Copy Screen to Temporary File and Paste Path"
+msgstr "Kopiraj ekran u privremenu datoteku i ubaci putanju"
+
+#: src/input/command.zig:292
+msgid ""
+"Copy the screen contents to a temporary file and paste the path to the file."
+msgstr ""
+"Kopirajte sadržaj ekrana u privremenu datoteku i ubacite putanju do te "
+"datoteke."
+
+#: src/input/command.zig:296
+msgid "Copy Screen to Temporary File and Open"
+msgstr "Kopiraj ekran u privremenu datoteku i otvori"
+
+#: src/input/command.zig:297
+msgid "Copy the screen contents to a temporary file and open it."
+msgstr "Kopirajte sadržaj ekrana u privremenu datoteku i otvorite je."
+
+#: src/input/command.zig:305
+msgid "Copy Screen as HTML to Temporary File and Copy Path"
+msgstr "Kopiraj ekran kao HTML u privremenu datoteku i kopiraj putanju"
+
+#: src/input/command.zig:306
+msgid ""
+"Copy the screen contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+"Kopirajte sadržaj ekrana kao HTML u privremenu datoteku i kopirajte putanju "
+"u ostavu."
+
+#: src/input/command.zig:313
+msgid "Copy Screen as HTML to Temporary File and Paste Path"
+msgstr "Kopiraj ekran kao HTML u privremenu datoteku i ubaci putanju"
+
+#: src/input/command.zig:314
+msgid ""
+"Copy the screen contents as HTML to a temporary file and paste the path to "
+"the file."
+msgstr ""
+"Kopirajte sadržaj ekrana kao HTML u privremenu datoteku i ubacite putanju do "
+"te datoteke."
+
+#: src/input/command.zig:321
+msgid "Copy Screen as HTML to Temporary File and Open"
+msgstr "Kopiraj ekran kao HTML u privremenu datoteku i otvori"
+
+#: src/input/command.zig:322
+msgid "Copy the screen contents as HTML to a temporary file and open it."
+msgstr "Kopiraj sadržaj ekrana kao HTML u privremenu datoteku i otvori je."
+
+#: src/input/command.zig:330
+msgid "Copy Screen as ANSI Sequences to Temporary File and Copy Path"
+msgstr "Kopiraj ekran kao ANSI nizove u privremenu datoteku i kopiraj putanju"
+
+#: src/input/command.zig:331
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+"Kopiraj sadržaj ekrana kao izlazne ANSI nizove u privremenu datoteku i "
+"kopiraj putanju u ostavu."
+
+#: src/input/command.zig:338
+msgid "Copy Screen as ANSI Sequences to Temporary File and Paste Path"
+msgstr "Kopiraj ekran kao ANSI nizove u privremenu datoteku i ubaci putanju"
+
+#: src/input/command.zig:339
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+"Kopiraj sadržaj ekrana kao izlazne ANSI nizove u privremenu datoteku i ubaci "
+"putanju do datoteke."
+
+#: src/input/command.zig:346
+msgid "Copy Screen as ANSI Sequences to Temporary File and Open"
+msgstr "Kopiraj ekran kao ANSI nizove u privremenu datoteku i otvori"
+
+#: src/input/command.zig:347
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+"Kopiraj sadržaj ekrana kao izlazne ANSI nizove u privremenu datoteku i "
+"otvori je."
+
+#: src/input/command.zig:354
+msgid "Copy Selection to Temporary File and Copy Path"
+msgstr "Kopiraj izabrano u privremenu datoteku i kopiraj putanju"
+
+#: src/input/command.zig:355
+msgid ""
+"Copy the selection contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+"Kopiraj sadržaj izabranog u privremenu datoteku i kopiraj putanju u ostavu."
+
+#: src/input/command.zig:359
+msgid "Copy Selection to Temporary File and Paste Path"
+msgstr "Kopiraj izabrano u privremenu datoteku i ubaci putanju"
+
+#: src/input/command.zig:360
+msgid ""
+"Copy the selection contents to a temporary file and paste the path to the "
+"file."
+msgstr ""
+"Kopiraj sadržaj izabranog u privremenu datoteku i ubaci putanju do datoteke."
+
+#: src/input/command.zig:364
+msgid "Copy Selection to Temporary File and Open"
+msgstr "Kopiraj izabrano u privremenu datoteku i otvori"
+
+#: src/input/command.zig:365
+msgid "Copy the selection contents to a temporary file and open it."
+msgstr "Kopiraj sadržaj izabranog u privremenu datoteku i otvori je."
+
+#: src/input/command.zig:373
+msgid "Copy Selection as HTML to Temporary File and Copy Path"
+msgstr "Kopiraj izabrano kao HTML u privremenu datoteku i kopiraj putanju"
+
+#: src/input/command.zig:374
+msgid ""
+"Copy the selection contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+"Kopiraj sadržaj izabranog kao HTML u privremenu datoteku i kopiraj putanju u "
+"ostavu."
+
+#: src/input/command.zig:381
+msgid "Copy Selection as HTML to Temporary File and Paste Path"
+msgstr "Kopiraj izabrano kao HTML u privremenu datoteku i ubaci putanju"
+
+#: src/input/command.zig:382
+msgid ""
+"Copy the selection contents as HTML to a temporary file and paste the path "
+"to the file."
+msgstr ""
+"Kopiraj sadržaj izabranog kao HTML u privremenu datoteku i ubaci putanju do "
+"datoteke."
+
+#: src/input/command.zig:389
+msgid "Copy Selection as HTML to Temporary File and Open"
+msgstr "Kopiraj izabrano kao HTML u privremenu datoteku i otvori"
+
+#: src/input/command.zig:390
+msgid "Copy the selection contents as HTML to a temporary file and open it."
+msgstr "Kopiraj sadržaj izabranog kao HTML u privremenu datoteku i otvori je."
+
+#: src/input/command.zig:398
+msgid "Copy Selection as ANSI Sequences to Temporary File and Copy Path"
+msgstr ""
+"Kopiraj izabrano kao ANSI nizove u privremenu datoteku i kopiraj putanju"
+
+#: src/input/command.zig:399
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+"Kopiraj sadržaj izbora kao izlazne ANSI nizove u privremenu datoteku i "
+"kopiraj putanju u ostavu."
+
+#: src/input/command.zig:406
+msgid "Copy Selection as ANSI Sequences to Temporary File and Paste Path"
+msgstr "Kopiraj izabrano kao ANSI nizove u privremenu datoteku i ubaci putanju"
+
+#: src/input/command.zig:407
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+"Kopiraj sadržaj izbora kao izlazne ANSI nizove u privremenu datoteku i ubaci "
+"putanju do te datoteke."
+
+#: src/input/command.zig:414
+msgid "Copy Selection as ANSI Sequences to Temporary File and Open"
+msgstr "Kopiraj izabrano kao ANSI nizove u privremenu datoteku i otvori"
+
+#: src/input/command.zig:415
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+"Kopiraj sadržaj izbora kao izlazne ANSI nizove u privremenu datoteku i "
+"otvori je."
+
+#: src/input/command.zig:422
+msgid "Open a new window."
+msgstr "Otvori novi prozor."
+
+#: src/input/command.zig:428
+msgid "Open a new tab."
+msgstr "Otvori novi jezičak."
+
+#: src/input/command.zig:434
+msgid "Move Tab Left"
+msgstr "Pomeri jezičak ulevo"
+
+#: src/input/command.zig:435
+msgid "Move the current tab to the left."
+msgstr "Premesti tekući jezičak levo."
+
+#: src/input/command.zig:439
+msgid "Move Tab Right"
+msgstr "Pomeri jezičak udesno"
+
+#: src/input/command.zig:440
+msgid "Move the current tab to the right."
+msgstr "Premestite tekući jezičak desno."
+
+#: src/input/command.zig:446
+msgid "Move Tab to New Window"
+msgstr "Pomeri jezičak u novi prozor"
+
+#: src/input/command.zig:447
+msgid "Move the current tab to a new window."
+msgstr "Premestite tekući jezičak u novi prozor."
+
+#: src/input/command.zig:452
+msgid "Toggle Tab Overview"
+msgstr "Okini pregled jezičaka"
+
+#: src/input/command.zig:453
+msgid "Toggle the tab overview."
+msgstr "Okinite pregled jezičaka."
+
+#: src/input/command.zig:458
+msgid "Change Terminal Title…"
+msgstr "Promeni naslov terminala…"
+
+#: src/input/command.zig:459
+msgid "Prompt for a new title for the current terminal."
+msgstr "Zatražite novi naslov za tekući terminal."
+
+#: src/input/command.zig:465
+msgid "Prompt for a new title for the current tab."
+msgstr "Zatražite novi naslov za tekući jezičak."
+
+#: src/input/command.zig:478
+msgid "Split the terminal to the left."
+msgstr "Razdeli terminal levo."
+
+#: src/input/command.zig:483
+msgid "Split the terminal to the right."
+msgstr "Razdeli terminal desno."
+
+#: src/input/command.zig:488
+msgid "Split the terminal up."
+msgstr "Razdeli terminal gore."
+
+#: src/input/command.zig:493
+msgid "Split the terminal down."
+msgstr "Razdeli terminal dole."
+
+#: src/input/command.zig:500
+msgid "Focus Split: Previous"
+msgstr "Fokus razdele: prethodna"
+
+#: src/input/command.zig:501
+msgid "Focus the previous split, if any."
+msgstr "Fokusiraj prethodnu razdelu, ako postoji."
+
+#: src/input/command.zig:505
+msgid "Focus Split: Next"
+msgstr "Fokus razdele: sledeća"
+
+#: src/input/command.zig:506
+msgid "Focus the next split, if any."
+msgstr "Fokusiraj sledeću razdelu, ako postoji."
+
+#: src/input/command.zig:510
+msgid "Focus Split: Left"
+msgstr "Fokus razdele: levo"
+
+#: src/input/command.zig:511
+msgid "Focus the split to the left, if it exists."
+msgstr "Fokusiraj razdelu levo, ako postoji."
+
+#: src/input/command.zig:515
+msgid "Focus Split: Right"
+msgstr "Fokus razdele: desno"
+
+#: src/input/command.zig:516
+msgid "Focus the split to the right, if it exists."
+msgstr "Usredsredi desnu razdelu, ako postoji."
+
+#: src/input/command.zig:520
+msgid "Focus Split: Up"
+msgstr "Usredsredi razdelu: gore"
+
+#: src/input/command.zig:521
+msgid "Focus the split above, if it exists."
+msgstr "Usredsredi gornju razdelu, ako postoji."
+
+#: src/input/command.zig:525
+msgid "Focus Split: Down"
+msgstr "Usredsredi razdelu: dole"
+
+#: src/input/command.zig:526
+msgid "Focus the split below, if it exists."
+msgstr "Usredsredi donju razdelu, ako postoji."
+
+#: src/input/command.zig:533
+msgid "Focus Window: Previous"
+msgstr "Usredsredi prozor: prethodni"
+
+#: src/input/command.zig:534
+msgid "Focus the previous window, if any."
+msgstr "Usredsredi prethodni prozor, ako postoji."
+
+#: src/input/command.zig:538
+msgid "Focus Window: Next"
+msgstr "Usredsredi prozor: sledeći"
+
+#: src/input/command.zig:539
+msgid "Focus the next window, if any."
+msgstr "Usredsredi sledeći prozor, ako postoji."
+
+#: src/input/command.zig:545
+msgid "Toggle Split Zoom"
+msgstr "Okini uvećanje razdele"
+
+#: src/input/command.zig:546
+msgid "Toggle the zoom state of the current split."
+msgstr "Promeni stanje uvećanja trenutne razdele."
+
+#: src/input/command.zig:551
+msgid "Toggle Read-Only Mode"
+msgstr "Okini režim samo za čitanje"
+
+#: src/input/command.zig:552
+msgid "Toggle read-only mode for the current surface."
+msgstr "Okini režim samo za čitanje za trenutnu površinu."
+
+#: src/input/command.zig:557
+msgid "Equalize Splits"
+msgstr "Izjednači razdele"
+
+#: src/input/command.zig:558
+msgid "Equalize the size of all splits."
+msgstr "Izjednači veličinu svih razdela."
+
+#: src/input/command.zig:563
+msgid "Reset Window Size"
+msgstr "Vrati veličinu prozora"
+
+#: src/input/command.zig:564
+msgid "Reset the window size to the default."
+msgstr "Vrati veličinu prozora na podrazumevanu."
+
+#: src/input/command.zig:569
+msgid "Toggle Inspector"
+msgstr "Okini inspektora"
+
+#: src/input/command.zig:570
+msgid "Toggle the inspector."
+msgstr "Okini inspektora."
+
+#: src/input/command.zig:575
+msgid "Show the GTK Inspector"
+msgstr "Prikaži GTK inspektora"
+
+#: src/input/command.zig:576
+msgid "Show the GTK inspector."
+msgstr "Prikaži GTK Inspector."
+
+#: src/input/command.zig:581
+msgid "Show On-Screen Keyboard"
+msgstr "Prikaži tastaturu na ekranu"
+
+#: src/input/command.zig:582
+msgid "Show the on-screen keyboard if present."
+msgstr "Prikaži tastaturu na ekranu ako postoji."
+
+#: src/input/command.zig:588
+msgid "Open Config Using OS editor"
+msgstr "Otvori podešavanja pomoću uređivača OS-a"
+
+#: src/input/command.zig:589
+msgid "Open the config file with the OS's default editor."
+msgstr "Otvori datoteku podešavanja pomoću podrazumevanog uređivača OS-a."
+
+#: src/input/command.zig:593
+msgid "Open Config in New Terminal Window"
+msgstr "Otvori podešavanja u novom prozoru terminala"
+
+#: src/input/command.zig:594
+msgid "Open the config file in a new window using $EDITOR or $VISUAL."
+msgstr ""
+"Otvori datoteku podešavanja u novom prozoru pomoću $EDITOR ili $VISUAL."
+
+#: src/input/command.zig:600
+msgid "Reload Config"
+msgstr "Ponovo učitaj podešavanja"
+
+#: src/input/command.zig:601
+msgid "Reload the config file."
+msgstr "Ponovo učitaj datoteku podešavanja."
+
+#: src/input/command.zig:606
+msgid "Close Terminal"
+msgstr "Zatvori terminal"
+
+#: src/input/command.zig:607
+msgid "Close the current terminal."
+msgstr "Zatvori trenutni terminal."
+
+#: src/input/command.zig:614
+msgid "Close the current tab."
+msgstr "Zatvori trenutni jezičak."
+
+#: src/input/command.zig:618
+msgid "Close Other Tabs"
+msgstr "Zatvori druge jezičke"
+
+#: src/input/command.zig:619
+msgid "Close all tabs in this window except the current one."
+msgstr "Zatvori sve jezičke u ovom prozoru izuzev trenutnog."
+
+#: src/input/command.zig:623
+msgid "Close Tabs to the Right"
+msgstr "Zatvori jezičke udesno"
+
+#: src/input/command.zig:624
+msgid "Close all tabs to the right of the current one."
+msgstr "Zatvori sve jezičke desno od trenutnog."
+
+#: src/input/command.zig:631
+msgid "Close the current window."
+msgstr "Zatvori trenutni prozor."
+
+#: src/input/command.zig:636
+msgid "Close All Windows"
+msgstr "Zatvori sve prozore"
+
+#: src/input/command.zig:637
+msgid "Close all windows."
+msgstr "Zatvori sve prozore."
+
+#: src/input/command.zig:642
+msgid "Toggle Maximize"
+msgstr "Okini uvećanje"
+
+#: src/input/command.zig:643
+msgid "Toggle the maximized state of the current window."
+msgstr "Promeni stanje uvećanja trenutnog prozora."
+
+#: src/input/command.zig:648
+msgid "Toggle Fullscreen"
+msgstr "Prebaci preko celog ekrana"
+
+#: src/input/command.zig:649
+msgid "Toggle the fullscreen state of the current window."
+msgstr "Promeni stanje prikazivanja trenutnog prozora preko celog ekrana."
+
+#: src/input/command.zig:654
+msgid "Toggle Window Decorations"
+msgstr "Okini dekoracije prozora"
+
+#: src/input/command.zig:655
+msgid "Toggle the window decorations."
+msgstr "Promeni stanje dekoracije prozora."
+
+#: src/input/command.zig:660
+msgid "Toggle Float on Top"
+msgstr "Okini plutajuće na vrhu"
+
+#: src/input/command.zig:661
+msgid "Toggle the float on top state of the current window."
+msgstr "Promeni stanje plutanja na vrhu trenutnog prozora."
+
+#: src/input/command.zig:666
+msgid "Toggle Secure Input"
+msgstr "Okini bezbedan unos"
+
+#: src/input/command.zig:667
+msgid "Toggle secure input mode."
+msgstr "Promeni režim bezbednog unosa."
+
+#: src/input/command.zig:672
+msgid "Toggle Mouse Reporting"
+msgstr "Okini prijavljivanje miša"
+
+#: src/input/command.zig:673
+msgid "Toggle whether mouse events are reported to terminal applications."
+msgstr "Prebaci da li se događaji miša prijavljuju terminalnim programima."
+
+#: src/input/command.zig:678
+msgid "Toggle Background Opacity"
+msgstr "Okini neprovidnost pozadine"
+
+#: src/input/command.zig:679
+msgid "Toggle the background opacity of a window that started transparent."
+msgstr "Prebaci neprovidnost pozadine prozora koji je prvobitno bio providan."
+
+#: src/input/command.zig:684
+msgid "Check for Updates"
+msgstr "Proveri ažuriranja"
+
+#: src/input/command.zig:685
+msgid "Check for updates to the application."
+msgstr "Proveri ažuriranja za program."
+
+#: src/input/command.zig:690
+msgid "Undo"
+msgstr "Opozovi"
+
+#: src/input/command.zig:691
+msgid "Undo the last action."
+msgstr "Opozovite poslednju radnju."
+
+#: src/input/command.zig:696
+msgid "Redo"
+msgstr "Ponovi"
+
+#: src/input/command.zig:697
+msgid "Redo the last undone action."
+msgstr "Ponovite poslednju opozvanu radnju."
+
+#: src/input/command.zig:703
+msgid "Quit the application."
+msgstr "Izađi iz programa."
+
+#: src/input/command.zig:708
+msgid "Ghostty"
+msgstr "Ghostty"
+
+#: src/input/command.zig:709
+msgid "Put a little Ghostty in your terminal."
+msgstr "Ubacite malo Ghostty-ja u vaš terminal."

--- a/po/sr@latin.po
+++ b/po/sr@latin.po
@@ -1,24 +1,21 @@
-# Language SR@latin translations for com.mitchellh.ghostty package.
+# Language SR translations for com.mitchellh.ghostty package.
 # Copyright (C) 2026 "Mitchell Hashimoto, Ghostty contributors"
 # This file is distributed under the same license as the com.mitchellh.ghostty package.
 # Марко Костић <marko.m.kostic@gmail.com>, 2026.
-#
-# Do not translate or edit this file directly. It is generated from po/sr.po with:
-# msgfilter -i po/sr.po -o po/sr@latin.po recode-sr-latin
-# After updating po/sr.po, regenerate this file and set `Language: sr@latin`.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
 "POT-Creation-Date: 2026-08-10 10:06-0500\n"
-"PO-Revision-Date: 2026-08-15 10:28+0200\n"
+"PO-Revision-Date: 2026-08-29 12:49+0200\n"
 "Last-Translator: Marko Kostić <marko.m.kostic@gmail.com>\n"
 "Language-Team: Language SR\n"
-"Language: sr@latin\n"
+"Language: sr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.9\n"
 
 #: dist/linux/ghostty_nautilus.py:53
 msgid "Open in Ghostty"
@@ -29,7 +26,7 @@ msgstr "Otvori u Ghostty-ju"
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:197
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:201
 msgid "Authorize Clipboard Access"
-msgstr "Ovlasti pristup ostavi"
+msgstr "Odobri pristup ostavi"
 
 #: src/apprt/gtk/ui/1.0/clipboard-confirmation-dialog.blp:17
 #: src/apprt/gtk/ui/1.4/clipboard-confirmation-dialog.blp:17
@@ -47,7 +44,7 @@ msgstr "Zapamti izbor za ovu razdelu"
 
 #: src/apprt/gtk/ui/1.4/clipboard-confirmation-dialog.blp:93
 msgid "Reload configuration to show this prompt again"
-msgstr "Ponovo učitaj postavke da bi se ovaj upit ponovo prikazao"
+msgstr "Ponovo učitaj podešavanja da bi se ovaj upit ponovo prikazao"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
@@ -63,15 +60,15 @@ msgstr "Zatvori"
 
 #: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:6
 msgid "Configuration Errors"
-msgstr "Greške u postavkama"
+msgstr "Greške u podešavanjima"
 
 #: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:8
 msgid ""
 "One or more configuration errors were found. Please review the errors below, "
 "and either reload your configuration or ignore these errors."
 msgstr ""
-"Pronađena je jedna ili više grešaka u postavkama. Pregledajte greške ispod, "
-"i ponovo učitajte svoje postavke ili zanemarite ove greške."
+"Pronađena je jedna ili više grešaka u podešavanjima. Pregledajte greške "
+"ispod, i ponovo učitajte svoja podešavanja ili zanemarite ove greške."
 
 #: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:12
 msgid "Ignore"
@@ -80,7 +77,7 @@ msgstr "Zanemari"
 #: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:13
 #: src/apprt/gtk/ui/1.2/surface.blp:439 src/apprt/gtk/ui/1.5/window.blp:318
 msgid "Reload Configuration"
-msgstr "Ponovo učitaj postavke"
+msgstr "Ponovo učitaj podešavanja"
 
 #: src/apprt/gtk/ui/1.2/debug-warning.blp:7
 #: src/apprt/gtk/ui/1.3/debug-warning.blp:6
@@ -168,12 +165,12 @@ msgstr "Razdeli dole"
 #: src/apprt/gtk/ui/1.2/surface.blp:365 src/apprt/gtk/ui/1.5/window.blp:190
 #: src/apprt/gtk/ui/1.5/window.blp:268 src/input/command.zig:477
 msgid "Split Left"
-msgstr "Razdeli levo"
+msgstr "Razdeli ulevo"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:371 src/apprt/gtk/ui/1.5/window.blp:195
 #: src/apprt/gtk/ui/1.5/window.blp:273 src/input/command.zig:482
 msgid "Split Right"
-msgstr "Razdeli desno"
+msgstr "Razdeli udesno"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:377
 msgid "Close Split"
@@ -223,11 +220,11 @@ msgstr "Podešavanja"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:427 src/apprt/gtk/ui/1.5/window.blp:306
 msgid "Open Configuration in OS Editor"
-msgstr "Otvori postavke u uređivaču OS-a"
+msgstr "Otvori podešavanja u uređivaču OS-a"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:433 src/apprt/gtk/ui/1.5/window.blp:312
 msgid "Open Configuration in New Window"
-msgstr "Otvori postavke u novom prozoru"
+msgstr "Otvori podešavanja u novom prozoru"
 
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:5
 msgid "Leave blank to restore the default title."
@@ -291,7 +288,7 @@ msgstr "Izvezi"
 
 #: src/apprt/gtk/class/application.zig:2783
 msgid "Editing configuration file"
-msgstr "Uređivanje datoteke sa postavkama"
+msgstr "Uređivanje datoteke sa podešavanjima"
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
 msgid ""
@@ -380,7 +377,7 @@ msgstr "Promeni naslov prozora"
 
 #: src/apprt/gtk/class/window.zig:1153
 msgid "Reloaded the configuration"
-msgstr "Ponovo učitane postavke"
+msgstr "Ponovo učitana podešavanja"
 
 #: src/apprt/gtk/class/window.zig:1830
 msgid "Copied to clipboard"
@@ -421,19 +418,19 @@ msgstr "Kopiraj izabrani tekst kao običan tekst u ostavu."
 
 #: src/input/command.zig:163
 msgid "Copy Selection as ANSI Sequences to Clipboard"
-msgstr "Kopiraj izabrano kao ANSI nizove u ostavu"
+msgstr "Kopiraj izabrano kao ANSI sekvence u ostavu"
 
 #: src/input/command.zig:164
 msgid "Copy the selected text as ANSI escape sequences to the clipboard."
-msgstr "Kopiraj izabrani tekst kao ANSI izlazne nizove u ostavu."
+msgstr "Kopiraj izabrani tekst kao ANSI izlazne sekvence u ostavu."
 
 #: src/input/command.zig:167
 msgid "Copy Selection as HTML to Clipboard"
-msgstr "Kopiraj izabrano kao html u ostavu"
+msgstr "Kopiraj izabrano kao HTML u ostavu"
 
 #: src/input/command.zig:168
 msgid "Copy the selected text as HTML to the clipboard."
-msgstr "Kopirajte izabrani tekst kao html u ostavu."
+msgstr "Kopiraj izabrani tekst kao HTML u ostavu."
 
 #: src/input/command.zig:173
 msgid "Copy URL to Clipboard"
@@ -452,8 +449,8 @@ msgid ""
 "Copy the terminal title to the clipboard. If the terminal title is not set "
 "this has no effect."
 msgstr ""
-"Kopirajte naslov terminala u ostavu. Ako naslov terminala nije postavljen, "
-"ovo neće imati dejstva."
+"Kopiraj naslov terminala u ostavu. Ako naslov terminala nije postavljen, ovo "
+"neće imati dejstva."
 
 #: src/input/command.zig:185
 msgid "Paste from Clipboard"
@@ -461,7 +458,7 @@ msgstr "Ubaci iz ostave"
 
 #: src/input/command.zig:186
 msgid "Paste the contents of the main clipboard."
-msgstr "Ubacite sadržaj glavne ostave."
+msgstr "Ubaci sadržaj glavne ostave."
 
 #: src/input/command.zig:191
 msgid "Paste from Selection"
@@ -485,7 +482,7 @@ msgstr "Pretraži izbor"
 
 #: src/input/command.zig:204
 msgid "Start a search for the current text selection."
-msgstr "Pokreni pretragu za trenutni tekstualni izbor."
+msgstr "Pokreni pretragu za trenutno izabrani tekst."
 
 #: src/input/command.zig:209
 msgid "End Search"
@@ -600,7 +597,7 @@ msgid ""
 "Copy the screen contents to a temporary file and copy the path to the "
 "clipboard."
 msgstr ""
-"Kopirajte sadržaj ekrana u privremenu datoteku i kopirajte putanju u ostavu."
+"Kopiraj sadržaj ekrana u privremenu datoteku i kopirajte putanju u ostavu."
 
 #: src/input/command.zig:291
 msgid "Copy Screen to Temporary File and Paste Path"
@@ -655,38 +652,39 @@ msgstr "Kopiraj sadržaj ekrana kao HTML u privremenu datoteku i otvori je."
 
 #: src/input/command.zig:330
 msgid "Copy Screen as ANSI Sequences to Temporary File and Copy Path"
-msgstr "Kopiraj ekran kao ANSI nizove u privremenu datoteku i kopiraj putanju"
+msgstr ""
+"Kopiraj ekran kao ANSI sekvence u privremenu datoteku i kopiraj putanju"
 
 #: src/input/command.zig:331
 msgid ""
 "Copy the screen contents as ANSI escape sequences to a temporary file and "
 "copy the path to the clipboard."
 msgstr ""
-"Kopiraj sadržaj ekrana kao izlazne ANSI nizove u privremenu datoteku i "
+"Kopiraj sadržaj ekrana kao izlazne ANSI sekvence u privremenu datoteku i "
 "kopiraj putanju u ostavu."
 
 #: src/input/command.zig:338
 msgid "Copy Screen as ANSI Sequences to Temporary File and Paste Path"
-msgstr "Kopiraj ekran kao ANSI nizove u privremenu datoteku i ubaci putanju"
+msgstr "Kopiraj ekran kao ANSI sekvence u privremenu datoteku i ubaci putanju"
 
 #: src/input/command.zig:339
 msgid ""
 "Copy the screen contents as ANSI escape sequences to a temporary file and "
 "paste the path to the file."
 msgstr ""
-"Kopiraj sadržaj ekrana kao izlazne ANSI nizove u privremenu datoteku i ubaci "
-"putanju do datoteke."
+"Kopiraj sadržaj ekrana kao izlazne ANSI sekvence u privremenu datoteku i "
+"ubaci putanju do datoteke."
 
 #: src/input/command.zig:346
 msgid "Copy Screen as ANSI Sequences to Temporary File and Open"
-msgstr "Kopiraj ekran kao ANSI nizove u privremenu datoteku i otvori"
+msgstr "Kopiraj ekran kao ANSI sekvence u privremenu datoteku i otvori"
 
 #: src/input/command.zig:347
 msgid ""
 "Copy the screen contents as ANSI escape sequences to a temporary file and "
 "open it."
 msgstr ""
-"Kopiraj sadržaj ekrana kao izlazne ANSI nizove u privremenu datoteku i "
+"Kopiraj sadržaj ekrana kao izlazne ANSI sekvence u privremenu datoteku i "
 "otvori je."
 
 #: src/input/command.zig:354
@@ -754,38 +752,39 @@ msgstr "Kopiraj sadržaj izabranog kao HTML u privremenu datoteku i otvori je."
 #: src/input/command.zig:398
 msgid "Copy Selection as ANSI Sequences to Temporary File and Copy Path"
 msgstr ""
-"Kopiraj izabrano kao ANSI nizove u privremenu datoteku i kopiraj putanju"
+"Kopiraj izabrano kao ANSI sekvence u privremenu datoteku i kopiraj putanju"
 
 #: src/input/command.zig:399
 msgid ""
 "Copy the selection contents as ANSI escape sequences to a temporary file and "
 "copy the path to the clipboard."
 msgstr ""
-"Kopiraj sadržaj izbora kao izlazne ANSI nizove u privremenu datoteku i "
+"Kopiraj sadržaj izbora kao izlazne ANSI sekvence u privremenu datoteku i "
 "kopiraj putanju u ostavu."
 
 #: src/input/command.zig:406
 msgid "Copy Selection as ANSI Sequences to Temporary File and Paste Path"
-msgstr "Kopiraj izabrano kao ANSI nizove u privremenu datoteku i ubaci putanju"
+msgstr ""
+"Kopiraj izabrano kao ANSI sekvence u privremenu datoteku i ubaci putanju"
 
 #: src/input/command.zig:407
 msgid ""
 "Copy the selection contents as ANSI escape sequences to a temporary file and "
 "paste the path to the file."
 msgstr ""
-"Kopiraj sadržaj izbora kao izlazne ANSI nizove u privremenu datoteku i ubaci "
-"putanju do te datoteke."
+"Kopiraj sadržaj izbora kao izlazne ANSI sekvence u privremenu datoteku i "
+"ubaci putanju do te datoteke."
 
 #: src/input/command.zig:414
 msgid "Copy Selection as ANSI Sequences to Temporary File and Open"
-msgstr "Kopiraj izabrano kao ANSI nizove u privremenu datoteku i otvori"
+msgstr "Kopiraj izabrano kao ANSI sekvence u privremenu datoteku i otvori"
 
 #: src/input/command.zig:415
 msgid ""
 "Copy the selection contents as ANSI escape sequences to a temporary file and "
 "open it."
 msgstr ""
-"Kopiraj sadržaj izbora kao izlazne ANSI nizove u privremenu datoteku i "
+"Kopiraj sadržaj izbora kao izlazne ANSI sekvence u privremenu datoteku i "
 "otvori je."
 
 #: src/input/command.zig:422
@@ -802,7 +801,7 @@ msgstr "Pomeri jezičak ulevo"
 
 #: src/input/command.zig:435
 msgid "Move the current tab to the left."
-msgstr "Premesti tekući jezičak levo."
+msgstr "Premesti trenutni jezičak ulevo."
 
 #: src/input/command.zig:439
 msgid "Move Tab Right"
@@ -810,7 +809,7 @@ msgstr "Pomeri jezičak udesno"
 
 #: src/input/command.zig:440
 msgid "Move the current tab to the right."
-msgstr "Premestite tekući jezičak desno."
+msgstr "Premesti trenutni jezičak udesno."
 
 #: src/input/command.zig:446
 msgid "Move Tab to New Window"
@@ -818,7 +817,7 @@ msgstr "Pomeri jezičak u novi prozor"
 
 #: src/input/command.zig:447
 msgid "Move the current tab to a new window."
-msgstr "Premestite tekući jezičak u novi prozor."
+msgstr "Premesti trenutni jezičak u novi prozor."
 
 #: src/input/command.zig:452
 msgid "Toggle Tab Overview"
@@ -834,19 +833,19 @@ msgstr "Promeni naslov terminala…"
 
 #: src/input/command.zig:459
 msgid "Prompt for a new title for the current terminal."
-msgstr "Zatražite novi naslov za tekući terminal."
+msgstr "Zatraži unos novog naslova za trenutni terminal."
 
 #: src/input/command.zig:465
 msgid "Prompt for a new title for the current tab."
-msgstr "Zatražite novi naslov za tekući jezičak."
+msgstr "Zatraži unos novog naslova za trenutni jezičak."
 
 #: src/input/command.zig:478
 msgid "Split the terminal to the left."
-msgstr "Razdeli terminal levo."
+msgstr "Razdeli terminal ulevo."
 
 #: src/input/command.zig:483
 msgid "Split the terminal to the right."
-msgstr "Razdeli terminal desno."
+msgstr "Razdeli terminal udesno."
 
 #: src/input/command.zig:488
 msgid "Split the terminal up."
@@ -874,51 +873,51 @@ msgstr "Fokusiraj sledeću razdelu, ako postoji."
 
 #: src/input/command.zig:510
 msgid "Focus Split: Left"
-msgstr "Fokus razdele: levo"
+msgstr "Fokus razdele: ulevo"
 
 #: src/input/command.zig:511
 msgid "Focus the split to the left, if it exists."
-msgstr "Fokusiraj razdelu levo, ako postoji."
+msgstr "Fokusiraj razdelu ulevo, ako postoji."
 
 #: src/input/command.zig:515
 msgid "Focus Split: Right"
-msgstr "Fokus razdele: desno"
+msgstr "Fokus razdele: udesno"
 
 #: src/input/command.zig:516
 msgid "Focus the split to the right, if it exists."
-msgstr "Usredsredi desnu razdelu, ako postoji."
+msgstr "Fokusiraj razdelu udesno, ako postoji."
 
 #: src/input/command.zig:520
 msgid "Focus Split: Up"
-msgstr "Usredsredi razdelu: gore"
+msgstr "Fokusiraj razdelu: gore"
 
 #: src/input/command.zig:521
 msgid "Focus the split above, if it exists."
-msgstr "Usredsredi gornju razdelu, ako postoji."
+msgstr "Fokusiraj gornju razdelu, ako postoji."
 
 #: src/input/command.zig:525
 msgid "Focus Split: Down"
-msgstr "Usredsredi razdelu: dole"
+msgstr "Fokusiraj razdelu: dole"
 
 #: src/input/command.zig:526
 msgid "Focus the split below, if it exists."
-msgstr "Usredsredi donju razdelu, ako postoji."
+msgstr "Fokusiraj donju razdelu, ako postoji."
 
 #: src/input/command.zig:533
 msgid "Focus Window: Previous"
-msgstr "Usredsredi prozor: prethodni"
+msgstr "Fokusiraj prozor: prethodni"
 
 #: src/input/command.zig:534
 msgid "Focus the previous window, if any."
-msgstr "Usredsredi prethodni prozor, ako postoji."
+msgstr "Fokusiraj prethodni prozor, ako postoji."
 
 #: src/input/command.zig:538
 msgid "Focus Window: Next"
-msgstr "Usredsredi prozor: sledeći"
+msgstr "Fokusiraj prozor: sledeći"
 
 #: src/input/command.zig:539
 msgid "Focus the next window, if any."
-msgstr "Usredsredi sledeći prozor, ako postoji."
+msgstr "Fokusiraj sledeći prozor, ako postoji."
 
 #: src/input/command.zig:545
 msgid "Toggle Split Zoom"
@@ -954,19 +953,19 @@ msgstr "Vrati veličinu prozora na podrazumevanu."
 
 #: src/input/command.zig:569
 msgid "Toggle Inspector"
-msgstr "Okini inspektora"
+msgstr "Okini inspektor"
 
 #: src/input/command.zig:570
 msgid "Toggle the inspector."
-msgstr "Okini inspektora."
+msgstr "Okini inspektor."
 
 #: src/input/command.zig:575
 msgid "Show the GTK Inspector"
-msgstr "Prikaži GTK inspektora"
+msgstr "Prikaži GTK inspektor"
 
 #: src/input/command.zig:576
 msgid "Show the GTK inspector."
-msgstr "Prikaži GTK Inspector."
+msgstr "Prikaži GTK inspektor."
 
 #: src/input/command.zig:581
 msgid "Show On-Screen Keyboard"
@@ -1083,7 +1082,7 @@ msgstr "Promeni režim bezbednog unosa."
 
 #: src/input/command.zig:672
 msgid "Toggle Mouse Reporting"
-msgstr "Okini prijavljivanje miša"
+msgstr "Okini prosleđivanje događaja miša"
 
 #: src/input/command.zig:673
 msgid "Toggle whether mouse events are reported to terminal applications."
@@ -1111,7 +1110,7 @@ msgstr "Opozovi"
 
 #: src/input/command.zig:691
 msgid "Undo the last action."
-msgstr "Opozovite poslednju radnju."
+msgstr "Opozovi poslednju radnju."
 
 #: src/input/command.zig:696
 msgid "Redo"
@@ -1119,7 +1118,7 @@ msgstr "Ponovi"
 
 #: src/input/command.zig:697
 msgid "Redo the last undone action."
-msgstr "Ponovite poslednju opozvanu radnju."
+msgstr "Ponovi poslednju opozvanu radnju."
 
 #: src/input/command.zig:703
 msgid "Quit the application."

--- a/po/sr@latin.po
+++ b/po/sr@latin.po
@@ -1,21 +1,24 @@
-# Language SR translations for com.mitchellh.ghostty package.
+# Language SR@latin translations for com.mitchellh.ghostty package.
 # Copyright (C) 2026 "Mitchell Hashimoto, Ghostty contributors"
 # This file is distributed under the same license as the com.mitchellh.ghostty package.
 # Марко Костић <marko.m.kostic@gmail.com>, 2026.
+#
+# Do not translate or edit this file directly. It is generated from po/sr.po with:
+# msgfilter -i po/sr.po -o po/sr@latin.po recode-sr-latin
+# After updating po/sr.po, regenerate this file and set `Language: sr@latin`.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
 "POT-Creation-Date: 2026-08-10 10:06-0500\n"
-"PO-Revision-Date: 2026-08-29 12:49+0200\n"
+"PO-Revision-Date: 2026-08-31 21:45+0200\n"
 "Last-Translator: Marko Kostić <marko.m.kostic@gmail.com>\n"
 "Language-Team: Language SR\n"
-"Language: sr\n"
+"Language: sr@latin\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 3.9\n"
 
 #: dist/linux/ghostty_nautilus.py:53
 msgid "Open in Ghostty"
@@ -67,8 +70,8 @@ msgid ""
 "One or more configuration errors were found. Please review the errors below, "
 "and either reload your configuration or ignore these errors."
 msgstr ""
-"Pronađena je jedna ili više grešaka u podešavanjima. Pregledajte greške "
-"ispod, i ponovo učitajte svoja podešavanja ili zanemarite ove greške."
+"Pronađena je jedna ili više grešaka u podešavanjima. Pregledaj greške ispod, "
+"i ponovo učitaj svoja podešavanja ili zanemari ove greške."
 
 #: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:12
 msgid "Ignore"
@@ -84,7 +87,7 @@ msgstr "Ponovo učitaj podešavanja"
 msgid ""
 "⚠️ You're running a debug build of Ghostty! Performance will be degraded."
 msgstr ""
-"⚠️ Pokrećete izdanje Ghostty-ja za otklanjanje grešaka! Performanse biće "
+"⚠️ Pokrećeš izdanje Ghostty-ja za otklanjanje grešaka! Performanse biće "
 "smanjene."
 
 #: src/apprt/gtk/ui/1.5/inspector-window.blp:5
@@ -117,7 +120,7 @@ msgid ""
 "through the content, but no input events will be sent to the running "
 "application."
 msgstr ""
-"Ovaj terminal je u režimu samo za čitanje. I dalje možete pregledati, birati "
+"Ovaj terminal je u režimu samo za čitanje. I dalje možeš pregledati, birati "
 "i pomicati sadržaj, ali događaji unosa neće biti poslati pokrenutom programu."
 
 #: src/apprt/gtk/ui/1.2/surface.blp:112
@@ -228,7 +231,7 @@ msgstr "Otvori podešavanja u novom prozoru"
 
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:5
 msgid "Leave blank to restore the default title."
-msgstr "Ostavite prazno da biste vratili podrazumevani naslov."
+msgstr "Ostavi prazno da vratiš podrazumevani naslov."
 
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:9
 msgid "OK"
@@ -438,7 +441,7 @@ msgstr "Kopiraj URL u ostavu"
 
 #: src/input/command.zig:174
 msgid "Copy the URL under the cursor to the clipboard."
-msgstr "Kopirajte URL ispod pokazivača u ostavu."
+msgstr "Kopiraj URL ispod pokazivača u ostavu."
 
 #: src/input/command.zig:179
 msgid "Copy Terminal Title to Clipboard"
@@ -466,7 +469,7 @@ msgstr "Ubaci iz izbora"
 
 #: src/input/command.zig:192
 msgid "Paste the contents of the selection clipboard."
-msgstr "Ubacite sadržaj ostave izbora."
+msgstr "Ubaci sadržaj ostave izbora."
 
 #: src/input/command.zig:197
 msgid "Start Search"
@@ -554,7 +557,7 @@ msgstr "Pomakni na vrh"
 
 #: src/input/command.zig:256
 msgid "Scroll to the top of the screen."
-msgstr "Pomaknite na vrh ekrana."
+msgstr "Pomakni na vrh ekrana."
 
 #: src/input/command.zig:261
 msgid "Scroll to Bottom"
@@ -562,7 +565,7 @@ msgstr "Pomakni na dno"
 
 #: src/input/command.zig:262
 msgid "Scroll to the bottom of the screen."
-msgstr "Pomaknite na dno ekrana."
+msgstr "Pomakni na dno ekrana."
 
 #: src/input/command.zig:267
 msgid "Scroll to Selection"
@@ -570,7 +573,7 @@ msgstr "Pomakni do izbora"
 
 #: src/input/command.zig:268
 msgid "Scroll to the selected text."
-msgstr "Pomaknite do izabranog teksta."
+msgstr "Pomakni do izabranog teksta."
 
 #: src/input/command.zig:273
 msgid "Scroll Page Up"
@@ -578,7 +581,7 @@ msgstr "Pomakni stranicu nagore"
 
 #: src/input/command.zig:274
 msgid "Scroll the screen up by a page."
-msgstr "Pomaknite ekran nagore za jednu stranicu."
+msgstr "Pomakni ekran nagore za jednu stranicu."
 
 #: src/input/command.zig:279
 msgid "Scroll Page Down"
@@ -586,7 +589,7 @@ msgstr "Pomakni stranicu nadole"
 
 #: src/input/command.zig:280
 msgid "Scroll the screen down by a page."
-msgstr "Pomaknite ekran nadole za jednu stranicu."
+msgstr "Pomakni ekran nadole za jednu stranicu."
 
 #: src/input/command.zig:286
 msgid "Copy Screen to Temporary File and Copy Path"
@@ -597,7 +600,7 @@ msgid ""
 "Copy the screen contents to a temporary file and copy the path to the "
 "clipboard."
 msgstr ""
-"Kopiraj sadržaj ekrana u privremenu datoteku i kopirajte putanju u ostavu."
+"Kopiraj sadržaj ekrana u privremenu datoteku i kopiraj putanju u ostavu."
 
 #: src/input/command.zig:291
 msgid "Copy Screen to Temporary File and Paste Path"
@@ -607,8 +610,7 @@ msgstr "Kopiraj ekran u privremenu datoteku i ubaci putanju"
 msgid ""
 "Copy the screen contents to a temporary file and paste the path to the file."
 msgstr ""
-"Kopirajte sadržaj ekrana u privremenu datoteku i ubacite putanju do te "
-"datoteke."
+"Kopiraj sadržaj ekrana u privremenu datoteku i ubaci putanju do te datoteke."
 
 #: src/input/command.zig:296
 msgid "Copy Screen to Temporary File and Open"
@@ -616,7 +618,7 @@ msgstr "Kopiraj ekran u privremenu datoteku i otvori"
 
 #: src/input/command.zig:297
 msgid "Copy the screen contents to a temporary file and open it."
-msgstr "Kopirajte sadržaj ekrana u privremenu datoteku i otvorite je."
+msgstr "Kopiraj sadržaj ekrana u privremenu datoteku i otvori je."
 
 #: src/input/command.zig:305
 msgid "Copy Screen as HTML to Temporary File and Copy Path"
@@ -627,8 +629,8 @@ msgid ""
 "Copy the screen contents as HTML to a temporary file and copy the path to "
 "the clipboard."
 msgstr ""
-"Kopirajte sadržaj ekrana kao HTML u privremenu datoteku i kopirajte putanju "
-"u ostavu."
+"Kopiraj sadržaj ekrana kao HTML u privremenu datoteku i kopiraj putanju u "
+"ostavu."
 
 #: src/input/command.zig:313
 msgid "Copy Screen as HTML to Temporary File and Paste Path"
@@ -639,8 +641,8 @@ msgid ""
 "Copy the screen contents as HTML to a temporary file and paste the path to "
 "the file."
 msgstr ""
-"Kopirajte sadržaj ekrana kao HTML u privremenu datoteku i ubacite putanju do "
-"te datoteke."
+"Kopiraj sadržaj ekrana kao HTML u privremenu datoteku i ubaci putanju do te "
+"datoteke."
 
 #: src/input/command.zig:321
 msgid "Copy Screen as HTML to Temporary File and Open"
@@ -825,7 +827,7 @@ msgstr "Okini pregled jezičaka"
 
 #: src/input/command.zig:453
 msgid "Toggle the tab overview."
-msgstr "Okinite pregled jezičaka."
+msgstr "Okini pregled jezičaka."
 
 #: src/input/command.zig:458
 msgid "Change Terminal Title…"
@@ -1130,4 +1132,4 @@ msgstr "Ghostty"
 
 #: src/input/command.zig:709
 msgid "Put a little Ghostty in your terminal."
-msgstr "Ubacite malo Ghostty-ja u vaš terminal."
+msgstr "Ubaci malo Ghostty-ja u svoj terminal."

--- a/src/os/i18n_locales.zig
+++ b/src/os/i18n_locales.zig
@@ -60,4 +60,6 @@ pub const locales = [_][:0]const u8{
     "be",
     "eu",
     "da",
+    "sr",
+    "sr@latin",
 };


### PR DESCRIPTION
## Summary
- Adds Serbian translations for both Cyrillic (`sr`) and Latin (`sr@latin`) scripts, registered in `src/os/i18n_locales.zig` and `CODEOWNERS`.
- `po/sr@latin.po` is generated from `po/sr.po` with `msgfilter recode-sr-latin` and should not be translated by hand.
- Replaces the closed #13030; strings are rebased onto current `main`.

Cc @slowdub for a review.

EDIT: AI disclosure: I used Cursor (Grok 4.6) for mechanical repo work only, not for writing the Serbian translations. The agent fetched ghostty-org/ghostty, branched from current main, ran msgmerge on po/sr.po against the template, generated po/sr@latin.po with msgfilter recode-sr-latin, registered sr / sr@latin in src/os/i18n_locales.zig and CODEOWNERS, rebased my three commits onto later main, pushed the branch, and opened this PR (I had intended to open the PR myself, s***** thing ignored my instructions). I translated and reviewed sr.po and the Latin file is a recode of that catalog, not a separate translation since Serbian Cyrillic can be perfectly transcoded to the Latin script via [recode-sr-latin](https://linux.die.net/man/1/recode-sr-latin).