### PR TITLE
libghostty: reduce Wasm stack reservation

### DIFF
--- a/src/build/GhosttyLibVt.zig
+++ b/src/build/GhosttyLibVt.zig
@@ -58,6 +58,12 @@ pub fn initWasm(
     // There is no entrypoint for this wasm module.
     exe.entry = .disabled;
 
+    // Default Zig stack size in Zig 0.16 is 1MB. Lower to 128 KB since
+    // this has to be preallocated up front in Wasm linear memory. Peak
+    // stack under various artificial loads is 17 KB at the time of this
+    // comment but lets do 128KB to be safe. We can lower later.
+    exe.stack_size = 128 * 1024;
+
     // Zig's WASM linker doesn't support --growable-table, so the table
     // is emitted with max == min and can't be grown from JS. Run a
     // small Zig build tool that patches the binary's table section to


### PR DESCRIPTION
Zig default's Wasm stacks to 1MB. Change it to 128 KB instead.

This removes 896 KiB from every Wasm instance's initial linear memory reservation. That means that simply _loading_ `ghostty-vt.wasm` is down this much.

Through various workload benchmarks of real terminal snapshots, artificial worst case full ascii, full styled, full emoji, full mixed, etc. workloads, I wasn't able to get a stack to go above 17 KB, so 128 KB is VERY generous. Lets start here.