### PR TITLE
fix(macos): Quick Terminal leaves menu bar gap when summoned over fullscreen app

### DIFF
--- a/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalController.swift
@@ -124,7 +124,9 @@ class QuickTerminalController: BaseTerminalController {
         syncAppearance()
 
         // Setup our initial size based on our configured position
-        position.setLoaded(window, size: derivedConfig.quickTerminalSize)
+        if let screen = window.screen ?? NSScreen.main {
+            position.setLoaded(window, size: derivedConfig.quickTerminalSize, availableFrame: availableFrame(for: screen))
+        }
 
         // Upon first adding this Window to its host view, older SwiftUI
         // seems to have a "hiccup" and corrupts the frameRect,
@@ -241,11 +243,11 @@ class QuickTerminalController: BaseTerminalController {
         case .top, .bottom, .center:
             // For centered positions (top, bottom, center), we need to recenter the window
             // when it's manually resized to maintain proper positioning
-            let newOrigin = position.centeredOrigin(for: window, on: screen)
+            let newOrigin = position.centeredOrigin(for: window, availableFrame: availableFrame(for: screen))
             window.setFrameOrigin(newOrigin)
         case .left, .right:
             // For side positions, we may need to adjust vertical centering
-            let newOrigin = position.verticallyCenteredOrigin(for: window, on: screen)
+            let newOrigin = position.verticallyCenteredOrigin(for: window, availableFrame: availableFrame(for: screen))
             window.setFrameOrigin(newOrigin)
         }
     }
@@ -426,8 +428,23 @@ class QuickTerminalController: BaseTerminalController {
         }
     }
 
+    /// Returns the frame available for quick terminal positioning on the given screen.
+    ///
+    /// When the active space is a fullscreen space, the menu bar and Dock are hidden,
+    /// so the full screen frame is available. Otherwise, the visible frame (excluding
+    /// menu bar and Dock) is used. This prevents the Quick Terminal from leaving an
+    /// empty gap at the top when summoned over a fullscreen app.
+    /// See: https://github.com/ghostty-org/ghostty/discussions/6950
+    private func availableFrame(for screen: NSScreen) -> NSRect {
+        if CGSSpace.active().type == .fullscreen {
+            return screen.frame
+        }
+        return screen.visibleFrame
+    }
+
     private func animateWindowIn(window: NSWindow, from position: QuickTerminalPosition) {
         guard let screen = derivedConfig.quickTerminalScreen.screen else { return }
+        let frame = availableFrame(for: screen)
 
         // Grab our last closed frame to use from the cache.
         let closedFrame = screenStateCache.frame(for: screen)
@@ -435,7 +452,7 @@ class QuickTerminalController: BaseTerminalController {
         // Move our window off screen to the initial animation position.
         position.setInitial(
             in: window,
-            on: screen,
+            availableFrame: frame,
             terminalSize: derivedConfig.quickTerminalSize,
             closedFrame: closedFrame)
 
@@ -470,7 +487,7 @@ class QuickTerminalController: BaseTerminalController {
             context.timingFunction = .init(name: .easeIn)
             position.setFinal(
                 in: window.animator(),
-                on: screen,
+                availableFrame: frame,
                 terminalSize: derivedConfig.quickTerminalSize,
                 closedFrame: closedFrame)
         }, completionHandler: {
@@ -569,6 +586,7 @@ class QuickTerminalController: BaseTerminalController {
 
         // We always animate out to whatever screen the window is actually on.
         guard let screen = window.screen ?? NSScreen.main else { return }
+        let frame = availableFrame(for: screen)
 
         // If we have a previously active application, restore focus to it. We
         // do this BEFORE the animation below because when the animation completes
@@ -593,7 +611,7 @@ class QuickTerminalController: BaseTerminalController {
             context.timingFunction = .init(name: .easeIn)
             position.setInitial(
                 in: window.animator(),
-                on: screen,
+                availableFrame: frame,
                 terminalSize: derivedConfig.quickTerminalSize,
                 closedFrame: window.frame)
         }, completionHandler: {

--- a/macos/Sources/Features/QuickTerminal/QuickTerminalPosition.swift
+++ b/macos/Sources/Features/QuickTerminal/QuickTerminalPosition.swift
@@ -9,11 +9,10 @@ enum QuickTerminalPosition: String {
 
     /// Set the loaded state for a window. This should only be called when the window is first loaded,
     /// usually in `windowDidLoad` or in a similar callback. This is the initial state.
-    func setLoaded(_ window: NSWindow, size: QuickTerminalSize) {
-        guard let screen = window.screen ?? NSScreen.main else { return }
+    func setLoaded(_ window: NSWindow, size: QuickTerminalSize, availableFrame: NSRect) {
         window.setFrame(.init(
             origin: window.frame.origin,
-            size: size.calculate(position: self, screenDimensions: screen.visibleFrame.size)
+            size: size.calculate(position: self, screenDimensions: availableFrame.size)
         ), display: false)
     }
 
@@ -21,7 +20,7 @@ enum QuickTerminalPosition: String {
     /// after animating out).
     func setInitial(
         in window: NSWindow,
-        on screen: NSScreen,
+        availableFrame: NSRect,
         terminalSize: QuickTerminalSize,
         closedFrame: NSRect? = nil
     ) {
@@ -30,9 +29,9 @@ enum QuickTerminalPosition: String {
 
         // Position depends
         window.setFrame(.init(
-            origin: initialOrigin(for: window, on: screen),
+            origin: initialOrigin(for: window, availableFrame: availableFrame),
             size: closedFrame?.size ?? configuredFrameSize(
-                on: screen,
+                for: availableFrame,
                 terminalSize: terminalSize)
         ), display: false)
     }
@@ -40,7 +39,7 @@ enum QuickTerminalPosition: String {
     /// Set the final state for a window in this position.
     func setFinal(
         in window: NSWindow,
-        on screen: NSScreen,
+        availableFrame: NSRect,
         terminalSize: QuickTerminalSize,
         closedFrame: NSRect? = nil
     ) {
@@ -49,72 +48,72 @@ enum QuickTerminalPosition: String {
 
         // Position depends
         window.setFrame(.init(
-            origin: finalOrigin(for: window, on: screen),
+            origin: finalOrigin(for: window, availableFrame: availableFrame),
             size: closedFrame?.size ?? configuredFrameSize(
-                on: screen,
+                for: availableFrame,
                 terminalSize: terminalSize)
         ), display: true)
     }
 
     /// Get the configured frame size for initial positioning and animations.
-    func configuredFrameSize(on screen: NSScreen, terminalSize: QuickTerminalSize) -> NSSize {
-        let dimensions = terminalSize.calculate(position: self, screenDimensions: screen.visibleFrame.size)
+    func configuredFrameSize(for availableFrame: NSRect, terminalSize: QuickTerminalSize) -> NSSize {
+        let dimensions = terminalSize.calculate(position: self, screenDimensions: availableFrame.size)
         return NSSize(width: dimensions.width, height: dimensions.height)
     }
 
     /// The initial point origin for this position.
-    func initialOrigin(for window: NSWindow, on screen: NSScreen) -> CGPoint {
+    func initialOrigin(for window: NSWindow, availableFrame: NSRect) -> CGPoint {
         switch self {
         case .top:
             return .init(
-                x: round(screen.visibleFrame.origin.x + (screen.visibleFrame.width - window.frame.width) / 2),
-                y: screen.visibleFrame.maxY)
+                x: round(availableFrame.origin.x + (availableFrame.width - window.frame.width) / 2),
+                y: availableFrame.maxY)
 
         case .bottom:
             return .init(
-                x: round(screen.visibleFrame.origin.x + (screen.visibleFrame.width - window.frame.width) / 2),
+                x: round(availableFrame.origin.x + (availableFrame.width - window.frame.width) / 2),
                 y: -window.frame.height)
 
         case .left:
             return .init(
-                x: screen.visibleFrame.minX-window.frame.width,
-                y: round(screen.visibleFrame.origin.y + (screen.visibleFrame.height - window.frame.height) / 2))
+                x: availableFrame.minX - window.frame.width,
+                y: round(availableFrame.origin.y + (availableFrame.height - window.frame.height) / 2))
 
         case .right:
             return .init(
-                x: screen.visibleFrame.maxX,
-                y: round(screen.visibleFrame.origin.y + (screen.visibleFrame.height - window.frame.height) / 2))
+                x: availableFrame.maxX,
+                y: round(availableFrame.origin.y + (availableFrame.height - window.frame.height) / 2))
 
         case .center:
-            return .init(x: round(screen.visibleFrame.origin.x + (screen.visibleFrame.width - window.frame.width) / 2), y: screen.visibleFrame.height - window.frame.width)
+            return .init(x: round(availableFrame.origin.x + (availableFrame.width - window.frame.width) / 2), y: availableFrame.height - window.frame.width)
         }
     }
 
     /// The final point origin for this position.
-    func finalOrigin(for window: NSWindow, on screen: NSScreen) -> CGPoint {
+    func finalOrigin(for window: NSWindow, availableFrame: NSRect) -> CGPoint {
         switch self {
         case .top:
             return .init(
-                x: round(screen.visibleFrame.origin.x + (screen.visibleFrame.width - window.frame.width) / 2),
-                y: screen.visibleFrame.maxY - window.frame.height)
+                x: round(availableFrame.origin.x + (availableFrame.width - window.frame.width) / 2),
+                y: availableFrame.maxY - window.frame.height)
 
         case .bottom:
             return .init(
-                x: round(screen.visibleFrame.origin.x + (screen.visibleFrame.width - window.frame.width) / 2),
-                y: screen.visibleFrame.minY)
+                x: round(availableFrame.origin.x + (availableFrame.width - window.frame.width) / 2),
+                y: availableFrame.minY)
 
         case .left:
             return .init(
-                x: screen.visibleFrame.minX,
-                y: round(screen.visibleFrame.origin.y + (screen.visibleFrame.height - window.frame.height) / 2))
+                x: availableFrame.minX,
+                y: round(availableFrame.origin.y + (availableFrame.height - window.frame.height) / 2))
 
         case .right:
             return .init(
-                x: screen.visibleFrame.maxX - window.frame.width,
-                y: round(screen.visibleFrame.origin.y + (screen.visibleFrame.height - window.frame.height) / 2))
+                x: availableFrame.maxX - window.frame.width,
+                y: round(availableFrame.origin.y + (availableFrame.height - window.frame.height) / 2))
 
         case .center:
-            return .init(x: round(screen.visibleFrame.origin.x + (screen.visibleFrame.width - window.frame.width) / 2), y: round(screen.visibleFrame.origin.y + (screen.visibleFrame.height - window.frame.height) / 2))
+            return .init(x: round(availableFrame.origin.x + (availableFrame.width - window.frame.width) / 2), y: round(availableFrame.origin.y + (availableFrame.height - window.frame.height) / 2))
         }
     }
 
@@ -137,24 +136,24 @@ enum QuickTerminalPosition: String {
     }
 
     /// Calculate the centered origin for a window, keeping it properly positioned after manual resizing
-    func centeredOrigin(for window: NSWindow, on screen: NSScreen) -> CGPoint {
+    func centeredOrigin(for window: NSWindow, availableFrame: NSRect) -> CGPoint {
         switch self {
         case .top:
             return CGPoint(
-                x: round(screen.visibleFrame.origin.x + (screen.visibleFrame.width - window.frame.width) / 2),
+                x: round(availableFrame.origin.x + (availableFrame.width - window.frame.width) / 2),
                 y: window.frame.origin.y // Keep the same Y position
             )
 
         case .bottom:
             return CGPoint(
-                x: round(screen.visibleFrame.origin.x + (screen.visibleFrame.width - window.frame.width) / 2),
+                x: round(availableFrame.origin.x + (availableFrame.width - window.frame.width) / 2),
                 y: window.frame.origin.y // Keep the same Y position
             )
 
         case .center:
             return CGPoint(
-                x: round(screen.visibleFrame.origin.x + (screen.visibleFrame.width - window.frame.width) / 2),
-                y: round(screen.visibleFrame.origin.y + (screen.visibleFrame.height - window.frame.height) / 2)
+                x: round(availableFrame.origin.x + (availableFrame.width - window.frame.width) / 2),
+                y: round(availableFrame.origin.y + (availableFrame.height - window.frame.height) / 2)
             )
 
         case .left, .right:
@@ -164,18 +163,18 @@ enum QuickTerminalPosition: String {
     }
 
     /// Calculate the vertically centered origin for side-positioned windows
-    func verticallyCenteredOrigin(for window: NSWindow, on screen: NSScreen) -> CGPoint {
+    func verticallyCenteredOrigin(for window: NSWindow, availableFrame: NSRect) -> CGPoint {
         switch self {
         case .left:
             return CGPoint(
                 x: window.frame.origin.x, // Keep the same X position
-                y: round(screen.visibleFrame.origin.y + (screen.visibleFrame.height - window.frame.height) / 2)
+                y: round(availableFrame.origin.y + (availableFrame.height - window.frame.height) / 2)
             )
 
         case .right:
             return CGPoint(
                 x: window.frame.origin.x, // Keep the same X position
-                y: round(screen.visibleFrame.origin.y + (screen.visibleFrame.height - window.frame.height) / 2)
+                y: round(availableFrame.origin.y + (availableFrame.height - window.frame.height) / 2)
             )
 
         case .top, .bottom, .center:


### PR DESCRIPTION
## Problem

When the Quick Terminal is summoned while another app is in native fullscreen, the menu bar is hidden, but the Quick Terminal still reserves a gap at the top equal to the menu bar height. This is because all positioning in `QuickTerminalPosition` uses `NSScreen.visibleFrame`, which always excludes the menu bar area regardless of whether it is currently visible.

Closes #6950
Related: #7319

## Root Cause

`QuickTerminalPosition` methods take an `NSScreen` and internally derive `screen.visibleFrame` for all origin and size calculations. `visibleFrame` statically excludes the menu bar and Dock, even in fullscreen spaces where both are hidden.

## Approach

Following the existing pattern in the codebase where context-aware decisions live in the controller (e.g. fullscreen mode selection based on `NSApp.isFrontmost` and `hasNotch`):

1. **`QuickTerminalPosition`** is refactored to accept an explicit `availableFrame: NSRect` parameter instead of deriving `visibleFrame` from `NSScreen` internally. This makes it a pure positioning utility. `conflictsWithDock(on:)` is unchanged since it genuinely needs `NSScreen` (for `hasDock`).

2. **`QuickTerminalController`** gains an `availableFrame(for:)` helper that returns `screen.frame` when the active space is a fullscreen space (`CGSSpace.active().type == .fullscreen`, using the existing `CGSSpace` private API), and `screen.visibleFrame` otherwise. All six call sites pass this frame.

## Files Changed

- `macos/Sources/Features/QuickTerminal/QuickTerminalPosition.swift` — API change: `on screen: NSScreen` → `availableFrame: NSRect` across all positioning methods
- `macos/Sources/Features/QuickTerminal/QuickTerminalController.swift` — add `availableFrame(for:)` helper, update all call sites

## Verification

Builds successfully with `zig build -Demit-xcframework=true` + `xcodebuild` (Debug, macOS arm64). Manual testing on a fullscreen app recommended before merge.