### PR TITLE
fix(kitty): Relax image placement maximum scroll-to-after rows

### DIFF
--- a/src/terminal/kitty/graphics_exec.zig
+++ b/src/terminal/kitty/graphics_exec.zig
@@ -279,7 +279,7 @@ fn display(
                 // the work so an untrusted row count can't make us spin.
                 const rows_to_move: usize = @min(
                     @as(usize, size.rows),
-                    @as(usize, terminal.rows),
+                    @as(usize, 16 *| terminal.rows),
                 );
                 for (0..rows_to_move) |_| terminal.index() catch |err| {
                     log.warn("failed to move cursor: {}", .{err});


### PR DESCRIPTION
While using `icat` consecutively on wallpapers I got overlapping images from `cursor=After`[^1] requests with vertically stacked terminal surfaces.
[^1]: `C=0` for a display command in the protocol

<img width="1914" height="2103" alt="image" src="https://github.com/user-attachments/assets/dc6da3bc-29c4-4ff3-9592-1e0f6f4d3ba9" />

> Top: Ghostty @ tip 12967b68
> Bottom: Kitty 0.47.1
> `kitten icat --transfer-mode=stream -n ~/Pictures/wallpapers/S*`

To relax the terminal-height based limit, cap the scroll bound to be 16x the terminal rows