### PR TITLE
terminal: clear progress bar on full reset

### DIFF
--- a/src/terminal/stream_terminal.zig
+++ b/src/terminal/stream_terminal.zig
@@ -345,7 +345,12 @@ pub const Handler = struct {
             },
             .active_status_display => self.terminal.status_display = value,
             .decaln => try self.terminal.decaln(),
-            .full_reset => self.terminal.fullReset(),
+            .full_reset => {
+                self.terminal.fullReset();
+
+                // Clear the progress bar
+                self.progressReport(.{ .state = .remove });
+            },
             .start_hyperlink => try self.terminal.screens.active.startHyperlink(value.uri, value.id),
             .end_hyperlink => self.terminal.screens.active.endHyperlink(),
             .semantic_prompt => try self.terminal.semanticPrompt(value),
@@ -2504,6 +2509,15 @@ test "progress_report effect callback" {
         try testing.expectEqual(case.state, S.last_state);
         try testing.expectEqual(case.progress, S.last_progress);
     }
+
+    // A full reset (RIS) removes any active progress bar.
+    s.nextSlice("\x1B]9;4;1;50\x1B\\");
+    try testing.expectEqual(@as(usize, cases.len + 1), S.count);
+    try testing.expectEqual(osc.Command.ProgressReport.State.set, S.last_state);
+    s.nextSlice("\x1Bc");
+    try testing.expectEqual(@as(usize, cases.len + 2), S.count);
+    try testing.expectEqual(osc.Command.ProgressReport.State.remove, S.last_state);
+    try testing.expectEqual(@as(?u8, null), S.last_progress);
 }
 
 test "clipboard_write effect callback" {

--- a/src/terminal/stream_terminal.zig
+++ b/src/terminal/stream_terminal.zig
@@ -71,6 +71,9 @@ pub const Handler = struct {
     /// The DCS command handler maintains state for DCS queries.
     dcs_handler: dcs.Handler = .{},
 
+    /// Whether a OSC 9;4 progress bar is active.
+    progress_active: bool = false,
+
     /// Called for sequence identifiers not supported by this library.
     /// Currently, only APC is reported. Content is borrowed and only valid
     /// for the duration of the callback. Set `apc_handler.unknown_max_bytes`
@@ -348,8 +351,8 @@ pub const Handler = struct {
             .full_reset => {
                 self.terminal.fullReset();
 
-                // Clear the progress bar
-                self.progressReport(.{ .state = .remove });
+                // Clear the progress bar if one is active.
+                if (self.progress_active) self.progressReport(.{ .state = .remove });
             },
             .start_hyperlink => try self.terminal.screens.active.startHyperlink(value.uri, value.id),
             .end_hyperlink => self.terminal.screens.active.endHyperlink(),
@@ -501,6 +504,7 @@ pub const Handler = struct {
     }
 
     fn progressReport(self: *Handler, report: osc.Command.ProgressReport) void {
+        self.progress_active = report.state != .remove;
         const func = self.effects.progress_report orelse return;
         func(self, report);
     }
@@ -2518,6 +2522,10 @@ test "progress_report effect callback" {
     try testing.expectEqual(@as(usize, cases.len + 2), S.count);
     try testing.expectEqual(osc.Command.ProgressReport.State.remove, S.last_state);
     try testing.expectEqual(@as(?u8, null), S.last_progress);
+
+    // A full reset with no active progress bar reports nothing.
+    s.nextSlice("\x1Bc");
+    try testing.expectEqual(@as(usize, cases.len + 2), S.count);
 }
 
 test "clipboard_write effect callback" {

--- a/src/terminal/stream_terminal.zig
+++ b/src/terminal/stream_terminal.zig
@@ -71,9 +71,6 @@ pub const Handler = struct {
     /// The DCS command handler maintains state for DCS queries.
     dcs_handler: dcs.Handler = .{},
 
-    /// Whether a OSC 9;4 progress bar is active.
-    progress_active: bool = false,
-
     /// Called for sequence identifiers not supported by this library.
     /// Currently, only APC is reported. Content is borrowed and only valid
     /// for the duration of the callback. Set `apc_handler.unknown_max_bytes`
@@ -351,8 +348,8 @@ pub const Handler = struct {
             .full_reset => {
                 self.terminal.fullReset();
 
-                // Clear the progress bar if one is active.
-                if (self.progress_active) self.progressReport(.{ .state = .remove });
+                // Clear the progress bar
+                self.progressReport(.{ .state = .remove });
             },
             .start_hyperlink => try self.terminal.screens.active.startHyperlink(value.uri, value.id),
             .end_hyperlink => self.terminal.screens.active.endHyperlink(),
@@ -504,7 +501,6 @@ pub const Handler = struct {
     }
 
     fn progressReport(self: *Handler, report: osc.Command.ProgressReport) void {
-        self.progress_active = report.state != .remove;
         const func = self.effects.progress_report orelse return;
         func(self, report);
     }
@@ -2522,10 +2518,6 @@ test "progress_report effect callback" {
     try testing.expectEqual(@as(usize, cases.len + 2), S.count);
     try testing.expectEqual(osc.Command.ProgressReport.State.remove, S.last_state);
     try testing.expectEqual(@as(?u8, null), S.last_progress);
-
-    // A full reset with no active progress bar reports nothing.
-    s.nextSlice("\x1Bc");
-    try testing.expectEqual(@as(usize, cases.len + 2), S.count);
 }
 
 test "clipboard_write effect callback" {


### PR DESCRIPTION
Emit a `progress_report` remove effect from the `full_reset` arm, matching kitty and WezTerm which both clear progress on reset.

Previously, only the termio `StreamHandler` removed the progress bar on RIS (#10178) - but the terminal stream handler used by `libghostty-vt` did not, so an embedder's progress bar would outlive the reset.