### PR TITLE
macOS: group settings menu in a separate group

### DIFF
--- a/macos/Sources/App/MainMenu.xib
+++ b/macos/Sources/App/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="24765" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="25095" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="24765"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="25095"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -99,6 +99,7 @@
                                     <action selector="openConfig:" target="bbz-4X-AYv" id="X65-fg-iWU"/>
                                 </connections>
                             </menuItem>
+                            <menuItem isSeparatorItem="YES" id="GOd-qX-exa"/>
                             <menuItem title="Reload Configuration" id="KKH-XX-5py">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>

--- a/macos/Sources/Helpers/Extensions/NSMenuItem+Extension.swift
+++ b/macos/Sources/Helpers/Extensions/NSMenuItem+Extension.swift
@@ -7,10 +7,5 @@ extension NSMenuItem {
         if #available(macOS 26, *) {
             image = NSImage(systemSymbolName: symbol, accessibilityDescription: title)
         }
-#if compiler(>=6.4)
-        if #available(macOS 27.0, *) {
-            preferredImageVisibility = .automatic
-        }
-#endif
     }
 }


### PR DESCRIPTION
**Reverted https://github.com/ghostty-org/ghostty/pull/13664 with a second thought.** 

This keeps the consistency with other first-party apps like Terminal, Finder, and Music. It seems that most of the first-party apps show the standard icons on macOS 27 for "Settings...", "Find", "AutoFill" and etc., but in a separate group. 

<img width="1060" height="375" alt="image" src="https://github.com/user-attachments/assets/d3017865-a443-4c14-ace9-1c6b5acb3f56" />


I believe this still follows [HIG](https://developer.apple.com/design/human-interface-guidelines/menus#Icons).