### PR TITLE
surface: parse text bindings with stack fallback

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -4871,10 +4871,10 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
         },
 
         .text => |data| {
-            // For text we always allocate just because its easier to
-            // handle all cases that way.
-            const buf = try self.alloc.alloc(u8, data.len);
-            defer self.alloc.free(buf);
+            var stack = std.heap.stackFallback(256, self.alloc);
+            const alloc = stack.get();
+            const buf = try alloc.alloc(u8, data.len);
+            defer alloc.free(buf);
             const text = configpkg.string.parse(buf, data) catch |err| {
                 log.warn(
                     "error parsing text binding text={s} err={}",


### PR DESCRIPTION
Text binding actions previously allocated a temporary buffer for every escaped string. Use a 256-byte stack fallback allocator so typical bindings avoid the transient heap allocation while larger values continue to use the existing heap-backed behavior.