### PR TITLE
shell-integration: avoid owning temporary commands

### DIFF
--- a/src/termio/shell_integration.zig
+++ b/src/termio/shell_integration.zig
@@ -407,7 +407,7 @@ fn setupBash(
     }
 
     // Return a copy of our modified command line to use as the shell command.
-    return .{ .shell = try alloc.dupeZ(u8, try cmd.toOwnedSlice()) };
+    return .{ .shell = try alloc.dupeZ(u8, cmd.buffer.written()) };
 }
 
 test "bash" {
@@ -839,7 +839,7 @@ fn setupNushell(
     }
 
     // Return a copy of our modified command line to use as the shell command.
-    return .{ .shell = try alloc.dupeZ(u8, try cmd.toOwnedSlice()) };
+    return .{ .shell = try alloc.dupeZ(u8, cmd.buffer.written()) };
 }
 
 test "nushell" {


### PR DESCRIPTION
Some shell setup functions previously converted their stack-backed command builders to owned sentinel slices before duplicating them into the result arena. Duplicate the builders' written bytes directly instead, avoiding unnecessary ownership transfer and sentinel handling.