### PR TITLE
pkg/wuffs: fix gray+alpha to RGBA swizzle failing for all inputs

### DIFF
--- a/pkg/wuffs/src/swizzle.zig
+++ b/pkg/wuffs/src/swizzle.zig
@@ -16,11 +16,15 @@ pub fn gToRgba(alloc: Allocator, src: []const u8) Error![]u8 {
 }
 
 pub fn gaToRgba(alloc: Allocator, src: []const u8) Error![]u8 {
+    // Wuffs doesn't support YA_PREMUL as a swizzle source. The nonpremul
+    // pair produces the same bytes (r=g=b=y, a=a, no alpha math), which
+    // is what we want: alpha semantics are preserved as-is, matching the
+    // other conversions here.
     return swizzle(
         alloc,
         src,
-        c.WUFFS_BASE__PIXEL_FORMAT__YA_PREMUL,
-        c.WUFFS_BASE__PIXEL_FORMAT__RGBA_PREMUL,
+        c.WUFFS_BASE__PIXEL_FORMAT__YA_NONPREMUL,
+        c.WUFFS_BASE__PIXEL_FORMAT__RGBA_NONPREMUL,
     );
 }
 
@@ -49,6 +53,16 @@ pub fn bgraToRgba(alloc: Allocator, src: []const u8) Error![]u8 {
         c.WUFFS_BASE__PIXEL_FORMAT__BGRA_PREMUL,
         c.WUFFS_BASE__PIXEL_FORMAT__RGBA_PREMUL,
     );
+}
+
+test "gaToRgba" {
+    const rgba = try gaToRgba(std.testing.allocator, &.{ 7, 100, 8, 200 });
+    defer std.testing.allocator.free(rgba);
+
+    try std.testing.expectEqualSlices(u8, &.{
+        7, 7, 7, 100,
+        8, 8, 8, 200,
+    }, rgba);
 }
 
 fn swizzle(


### PR DESCRIPTION
The gaToRgba swizzle requested a YA_PREMUL source pixel format from the wuffs pixel swizzler, but wuffs does not support YA_PREMUL as a swizzle source. As a result, gaToRgba returned error.WuffsError for every input.

The path can't happen in Ghostty GUI today since our PNG decoding always produces RGBA, but it is possible via libghostty that submit grey+alpha directly.