### PR TITLE
macOS: fix swiftlint warnings

### DIFF
--- a/macos/Sources/Features/About/CyclingIconView.swift
+++ b/macos/Sources/Features/About/CyclingIconView.swift
@@ -39,6 +39,6 @@ struct CyclingIconView: View {
 
         iconImage
             .resizable()
-            .aspectRatio(contentMode: .fit)
+            .scaledToFit()
     }
 }

--- a/macos/Sources/Features/Secure Input/SecureInputOverlay.swift
+++ b/macos/Sources/Features/Secure Input/SecureInputOverlay.swift
@@ -15,7 +15,7 @@ struct SecureInputOverlay: View {
 
                 Image(systemName: "lock.shield.fill")
                     .resizable()
-                    .aspectRatio(contentMode: .fit)
+                    .scaledToFit()
                     .frame(width: 25, height: 25)
                     .foregroundColor(.primary)
                     .padding(5)


### PR DESCRIPTION
swiftlint 0.63.3 introduced a new rule called [`legacy_swiftui_aspect_ratio`](https://github.com/realm/SwiftLint/blob/76363aa4d733934ece226f5bce8e27c43b986a63/CHANGELOG.md?plain=1#L314)

<img width="509" height="451" alt="image" src="https://github.com/user-attachments/assets/1ff6f593-ce8a-493e-a241-e9ae418746ee" />
