### PR TITLE
renderer: Metal and OpenGL sync exact-fit and retain capacity variants

### DIFF
--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -334,6 +334,9 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             cells: CellTextBuffer,
             cells_bg: CellBgBuffer,
 
+            /// Grid size used for the most recent cell buffer upload.
+            cell_grid_size: ?renderer.GridSize = null,
+
             grayscale: Texture,
             grayscale_modified: usize = 0,
             color: Texture,
@@ -1672,6 +1675,13 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 frame.target_config_modified = self.target_config_modified;
             }
 
+            // Check if the cell grid size has changed, which can happen
+            // on rebuildCells.
+            const cell_grid_size_changed = if (frame.cell_grid_size) |size|
+                !std.meta.eql(size, self.cells.size)
+            else
+                true;
+
             // Upload images to the GPU as necessary.
             _ = self.images.upload(self.alloc, &self.api);
 
@@ -1683,8 +1693,20 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
 
             // Setup our frame data
             try frame.uniforms.sync(&.{self.uniforms});
-            try frame.cells_bg.sync(self.cells.bg_cells);
-            const fg_count = try frame.cells.syncFromArrayLists(self.cells.fg_rows);
+
+            const fg_count = if (cell_grid_size_changed) exact: {
+                try frame.cells_bg.sync(self.cells.bg_cells);
+                const count = try frame.cells.syncFromArrayLists(self.cells.fg_rows);
+
+                // Update the frame's cell grid size so we can detect changes next frame.
+                frame.cell_grid_size = self.cells.size;
+                break :exact count;
+            } else retain: {
+                try frame.cells_bg.syncRetainCapacity(self.cells.bg_cells);
+                const count = try frame.cells.syncFromArrayListsRetainCapacity(self.cells.fg_rows);
+
+                break :retain count;
+            };
 
             // If our background image buffer has changed, sync it.
             if (frame.bg_image_buffer_modified != self.bg_image_buffer_modified) {

--- a/src/renderer/metal/buffer.zig
+++ b/src/renderer/metal/buffer.zig
@@ -72,7 +72,7 @@ pub fn Buffer(comptime T: type) type {
         ///
         /// If the amount of data is smaller than the buffer length, the
         /// remaining data in the buffer is left untouched.
-        pub fn sync(self: *Self, data: []const T) !void {
+        pub fn syncRetainCapacity(self: *Self, data: []const T) !void {
             // If we need more bytes than our buffer has, we need to reallocate.
             const req_bytes = data.len * @sizeOf(T);
             const avail_bytes = self.buffer.getProperty(c_ulong, "length");
@@ -92,7 +92,114 @@ pub fn Buffer(comptime T: type) type {
                 );
             }
 
-            // We can fit within the buffer so we can just replace bytes.
+            try self.setBufferData(req_bytes, data);
+        }
+
+        /// Exact-fit sync new contents to the buffer. The data is expected
+        /// to be the complete contents of the buffer. If the amount of data
+        /// is not equal to the buffer length, the buffer will be reallocated.
+        pub fn sync(self: *Self, data: []const T) !void {
+            // Prevent zero-length allocations, necessary
+            // because Metal does not allow zero-length buffers.
+            const alloc_len = @max(data.len, 1);
+
+            // If we need more bytes than our buffer has, we need to reallocate.
+            const req_bytes = alloc_len * @sizeOf(T);
+            const avail_bytes = self.buffer.getProperty(c_ulong, "length");
+
+            if (req_bytes != avail_bytes) {
+                // Deallocate previous buffer
+                self.buffer.msgSend(void, objc.sel("release"), .{});
+
+                // Allocate a new buffer with enough to hold exactly what we require.
+                self.len = alloc_len;
+                self.buffer = self.opts.device.msgSend(
+                    objc.Object,
+                    objc.sel("newBufferWithLength:options:"),
+                    .{
+                        @as(c_ulong, @intCast(self.len * @sizeOf(T))),
+                        self.opts.resource_options,
+                    },
+                );
+            }
+
+            if (data.len > 0) {
+                try self.setBufferData(req_bytes, data);
+            }
+        }
+
+        /// Like Buffer.syncRetainCapacity but takes data from an array of ArrayLists,
+        /// rather than a single array. Returns the number of items synced.
+        pub fn syncFromArrayListsRetainCapacity(self: *Self, lists: []const std.ArrayListUnmanaged(T)) !usize {
+            var total_len: usize = 0;
+            for (lists) |list| {
+                total_len += list.items.len;
+            }
+
+            // If we need more bytes than our buffer has, we need to reallocate.
+            const req_bytes = total_len * @sizeOf(T);
+            const avail_bytes = self.buffer.getProperty(c_ulong, "length");
+            if (req_bytes > avail_bytes) {
+                // Deallocate previous buffer
+                self.buffer.msgSend(void, objc.sel("release"), .{});
+
+                // Allocate a new buffer with enough to hold double what we require.
+                self.len = total_len * 2;
+                self.buffer = self.opts.device.msgSend(
+                    objc.Object,
+                    objc.sel("newBufferWithLength:options:"),
+                    .{
+                        @as(c_ulong, @intCast(self.len * @sizeOf(T))),
+                        self.opts.resource_options,
+                    },
+                );
+            }
+
+            try self.setBufferArrayLists(req_bytes, lists);
+
+            return total_len;
+        }
+
+        /// Like Buffer.sync but takes data from an array of ArrayLists,
+        /// rather than a single array. Returns the number of items synced.
+        pub fn syncFromArrayLists(self: *Self, lists: []const std.ArrayListUnmanaged(T)) !usize {
+            var total_len: usize = 0;
+            for (lists) |list| {
+                total_len += list.items.len;
+            }
+
+            // Prevent zero-length allocations, necessary because Metal
+            // does not allow zero-length buffers.
+            const alloc_len = @max(total_len, 1);
+
+            // If the buffer size does not match our data size, reallocate.
+            const req_bytes = alloc_len * @sizeOf(T);
+            const avail_bytes = self.buffer.getProperty(c_ulong, "length");
+            if (req_bytes != avail_bytes) {
+                // Deallocate previous buffer
+                self.buffer.msgSend(void, objc.sel("release"), .{});
+
+                // Allocate a new buffer with enough to hold exactly what we require.
+                self.len = alloc_len;
+                self.buffer = self.opts.device.msgSend(
+                    objc.Object,
+                    objc.sel("newBufferWithLength:options:"),
+                    .{
+                        @as(c_ulong, @intCast(self.len * @sizeOf(T))),
+                        self.opts.resource_options,
+                    },
+                );
+            }
+
+            if (total_len > 0) {
+                try self.setBufferArrayLists(req_bytes, lists);
+            }
+
+            return total_len;
+        }
+
+        /// Set the buffer data to the given data. This is a helper function that is used by sync and syncRetainCapacity.
+        fn setBufferData(self: *Self, req_bytes: usize, data: []const T) !void {
             const dst = dst: {
                 const ptr = self.buffer.msgSend(?[*]u8, objc.sel("contents"), .{}) orelse {
                     log.warn("buffer contents ptr is null", .{});
@@ -122,33 +229,9 @@ pub fn Buffer(comptime T: type) type {
             }
         }
 
-        /// Like Buffer.sync but takes data from an array of ArrayLists,
-        /// rather than a single array. Returns the number of items synced.
-        pub fn syncFromArrayLists(self: *Self, lists: []const std.ArrayListUnmanaged(T)) !usize {
-            var total_len: usize = 0;
-            for (lists) |list| {
-                total_len += list.items.len;
-            }
-
-            // If we need more bytes than our buffer has, we need to reallocate.
-            const req_bytes = total_len * @sizeOf(T);
-            const avail_bytes = self.buffer.getProperty(c_ulong, "length");
-            if (req_bytes > avail_bytes) {
-                // Deallocate previous buffer
-                self.buffer.msgSend(void, objc.sel("release"), .{});
-
-                // Allocate a new buffer with enough to hold double what we require.
-                self.len = total_len * 2;
-                self.buffer = self.opts.device.msgSend(
-                    objc.Object,
-                    objc.sel("newBufferWithLength:options:"),
-                    .{
-                        @as(c_ulong, @intCast(self.len * @sizeOf(T))),
-                        self.opts.resource_options,
-                    },
-                );
-            }
-
+        /// Set the buffer data to the given data from an array of ArrayLists.
+        /// This is a helper function that is used by syncFromArrayLists and syncFromArrayListsRetainCapacity.
+        fn setBufferArrayLists(self: *Self, req_bytes: usize, lists: []const std.ArrayListUnmanaged(T)) !void {
             // We can fit within the buffer so we can just replace bytes.
             const dst = dst: {
                 const ptr = self.buffer.msgSend(?[*]u8, objc.sel("contents"), .{}) orelse {
@@ -178,8 +261,6 @@ pub fn Buffer(comptime T: type) type {
                     .{macos.foundation.Range.init(0, req_bytes)},
                 );
             }
-
-            return total_len;
         }
     };
 }

--- a/src/renderer/opengl/buffer.zig
+++ b/src/renderer/opengl/buffer.zig
@@ -73,7 +73,7 @@ pub fn Buffer(comptime T: type) type {
         ///
         /// If the amount of data is smaller than the buffer length, the
         /// remaining data in the buffer is left untouched.
-        pub fn sync(self: *Self, data: []const T) !void {
+        pub fn syncRetainCapacity(self: *Self, data: []const T) !void {
             const binding = try self.buffer.bind(self.opts.target);
             defer binding.unbind();
 
@@ -91,9 +91,36 @@ pub fn Buffer(comptime T: type) type {
             try binding.setSubData(0, data);
         }
 
-        /// Like Buffer.sync but takes data from an array of ArrayLists,
+        /// Exact-fit sync new contents to the buffer. The data is expected
+        /// to be the complete contents of the buffer. If the amount of data
+        /// is not equal to the buffer length, the buffer will be reallocated.
+        pub fn sync(self: *Self, data: []const T) !void {
+            const binding = try self.buffer.bind(self.opts.target);
+            defer binding.unbind();
+
+            // Prevent zero-length allocations, not strictly necessary
+            // for OpenGL, but it is a good idea to avoid them in general.
+            const alloc_len = @max(data.len, 1);
+
+            // If the buffer size does not match our data size, we need to reallocate.
+            if (alloc_len != self.len) {
+                // Reallocate the buffer to hold exactly what we require.
+                self.len = alloc_len;
+                try binding.setDataNullManual(
+                    self.len * @sizeOf(T),
+                    self.opts.usage,
+                );
+            }
+
+            // We can fit within the buffer so we can just replace bytes.
+            if (data.len > 0) {
+                try binding.setSubData(0, data);
+            }
+        }
+
+        /// Like Buffer.syncRetainCapacity but takes data from an array of ArrayLists,
         /// rather than a single array. Returns the number of items synced.
-        pub fn syncFromArrayLists(self: *Self, lists: []const std.ArrayListUnmanaged(T)) !usize {
+        pub fn syncFromArrayListsRetainCapacity(self: *Self, lists: []const std.ArrayListUnmanaged(T)) !usize {
             const binding = try self.buffer.bind(self.opts.target);
             defer binding.unbind();
 
@@ -106,6 +133,42 @@ pub fn Buffer(comptime T: type) type {
             if (total_len > self.len) {
                 // Reallocate the buffer to hold double what we require.
                 self.len = total_len * 2;
+                try binding.setDataNullManual(
+                    self.len * @sizeOf(T),
+                    self.opts.usage,
+                );
+            }
+
+            // We can fit within the buffer so we can just replace bytes.
+            var i: usize = 0;
+
+            for (lists) |list| {
+                try binding.setSubData(i, list.items);
+                i += list.items.len * @sizeOf(T);
+            }
+
+            return total_len;
+        }
+
+        /// Like Buffer.sync but takes data from an array of ArrayLists,
+        /// rather than a single array. Returns the number of items synced.
+        pub fn syncFromArrayLists(self: *Self, lists: []const std.ArrayListUnmanaged(T)) !usize {
+            const binding = try self.buffer.bind(self.opts.target);
+            defer binding.unbind();
+
+            var total_len: usize = 0;
+            for (lists) |list| {
+                total_len += list.items.len;
+            }
+
+            // Prevent zero-length allocations, not strictly necessary
+            // for OpenGL, but it is a good idea to avoid them in general.
+            const alloc_len = @max(total_len, 1);
+
+            // If the buffer size does not match our data size, reallocate.
+            if (alloc_len != self.len) {
+                // Reallocate the buffer to hold exactly what we require.
+                self.len = alloc_len;
                 try binding.setDataNullManual(
                     self.len * @sizeOf(T),
                     self.opts.usage,


### PR DESCRIPTION
### Summary

Updates `Buffer.sync()` for Metal and OpenGL to use exact-fit buffer allocation, this to allow the buffers to shrink when needed which stops them from being grow-only. The previous behavior is still available under the renamed function `Buffer.syncRetainCapacity()`. The variants for the data array lists inputs were also updated to follow this convention. The decision on what variant to use `exact-fit` or `retain-capacity` is done by:

- uniforms: always `exact-fit`
- images: always `exact-fit`
- cells (bg and fg):
  - `exact-fit` if the grid size changed
  - `retain-capacity`  used when the grid is the same size as before

In general the idea is that changes that are not expected to happen that frequent use `exact-fit` in contrary to volatile changes. 

Relates to https://github.com/ghostty-org/ghostty/issues/10355 and hopefully closes it :)  

### Changelog

- Updates `Buffer.sync()` to reallocate the exact amount of data requested. 
- Added safeguard to prevent a 0 byte length allocation. This is forbidden in Metal.
- Renames the old sync contract to `Buffer.syncRetainCapacity()`.
- Extracts common logic for the Metal memcpy to a new private helper function.
- Adds grid size knowledge to the FrameState to allow keeping track of grid size changes from the swap chain. This is used to then decide if using `sync` or `syncRetainCapacity` for cell buffers.

### Tests

Tested manually OpenGL ( tested on a Linux machine ). We care about the output of the temp debug logs:

- exact buffer resize
- retain buffer grow

It tells us which sync function was called and they should be based on the conditions defined above. I also added comments with the actions I performed during the manual test.

**In summary in this test the buffers behaved as expected:**

- Retain capacity growth on added text:
  -  246 -> 580 for 290 required (double the data size as original)
  - 580 -> 1258 for 629 required
 - Clearing (clear command) produced no change (retain capacity as well)
 - Exact-fit on grid change:
   - Background 1896 -> 1872, matching grid size `78 x 24`
   - Foreground 1258 -> 28 (here the fg cell buffer shrink a lot because I did a clear before the grid change)   
   
<details>
  <summary>Click to expand for evidence</summary>

```sh

# Writing text to the terminal

warning(gtk_ghostty_surface): failed to activate the on-screen keyboard
debug(opengl): retain buffer grow type=renderer.opengl.shaders.CellText old=246 required=290 allocated=580
debug(io_thread): mailbox message=write_small
debug(opengl): retain buffer grow type=renderer.opengl.shaders.CellText old=580 required=629 allocated=1258


# Clearing the terminal


debug(renderer_thread): mailbox message=.{ .focus = true }
debug(io_thread): mailbox message=focused
debug(io_thread): mailbox message=write_small


# Making the grid smaller


debug(gtk_ghostty_surface): gl resize width=799 height=511 scale=1 window_scale=1
debug(io_thread): mailbox message=resize
debug(renderer_thread): mailbox message=.{ .resize = .{ .screen = .{ .width = 799, .height = 511 }, .cell = .{ .width = 10, .height = 21 }, .padding = .{ .top = 2, .bottom = 2, .right = 2, .left = 2 } } }
debug(generic_renderer): screen size size=.{ .screen = .{ .width = 799, .height = 511 }, .cell = .{ .width = 10, .height = 21 }, .padding = .{ .top = 2, .bottom = 2, .right = 2, .left = 2 } }
debug(gtk_ghostty_surface): gl resize width=790 height=509 scale=1 window_scale=1
debug(io_thread): mailbox message=resize
debug(renderer_thread): mailbox message=.{ .resize = .{ .screen = .{ .width = 790, .height = 509 }, .cell = .{ .width = 10, .height = 21 }, .padding = .{ .top = 2, .bottom = 2, .right = 2, .left = 2 } } }
debug(generic_renderer): screen size size=.{ .screen = .{ .width = 790, .height = 509 }, .cell = .{ .width = 10, .height = 21 }, .padding = .{ .top = 2, .bottom = 2, .right = 2, .left = 2 } }
debug(renderer_thread): mailbox message=.{ .reset_cursor_blink = void }
debug(gtk_ghostty_surface): gl resize width=768 height=503 scale=1 window_scale=1
debug(io_thread): mailbox message=resize
debug(generic_renderer): cell grid changed old=.{ .columns = 79, .rows = 24 } new=.{ .columns = 78, .rows = 24 }
debug(opengl): exact buffer resize type=[4]u8 old=1896 new=1872
debug(opengl): exact buffer resize type=renderer.opengl.shaders.CellText old=1258 new=28
debug(renderer_thread): mailbox message=.{ .resize = .{ .screen = .{ .width = 768, .height = 503 }, .cell = .{ .width = 10, .height = 21 }, .padding = .{ .top = 2, .bottom = 2, .right = 2, .left = 2 } } }
debug(generic_renderer): screen size size=.{ .screen = .{ .width = 768, .height = 503 }, .cell = .{ .width = 10, .height = 21 }, .padding = .{ .top = 2, .bottom = 2, .right = 2, .left = 2 } }
debug(generic_renderer): cell grid changed old=.{ .columns = 78, .rows = 24 } new=.{ .columns = 76, .rows = 23 }
debug(opengl): exact buffer resize type=[4]u8 old=1872 new=1748
debug(gtk_ghostty_surface): gl resize width=753 height=499 scale=1 window_scale=1
debug(io_thread): mailbox message=resize
debug(renderer_thread): mailbox message=.{ .resize = .{ .screen = .{ .width = 753, .height = 499 }, .cell = .{ .width = 10, .height = 21 }, .padding = .{ .top = 2, .bottom = 2, .right = 2, .left = 2 } } }
debug(generic_renderer): screen size size=.{ .screen = .{ .width = 753, .height = 499 }, .cell = .{ .width = 10, .height = 21 }, .padding = .{ .top = 2, .bottom = 2, .right = 2, .left = 2 } }
debug(generic_renderer): cell grid changed old=.{ .columns = 76, .rows = 23 } new=.{ .columns = 74, .rows = 23 }
debug(opengl): exact buffer resize type=[4]u8 old=1748 new=1702
debug(gtk_ghostty_surface): gl resize width=739 height=495 scale=1 window_scale=1
debug(io_thread): mailbox message=resize
debug(renderer_thread): mailbox message=.{ .resize = .{ .screen = .{ .width = 739, .height = 495 }, .cell = .{ .width = 10, .height = 21 }, .padding = .{ .top = 2, .bottom = 2, .right = 2, .left = 2 } } }
debug(generic_renderer): screen size size=.{ .screen = .{ .width = 739, .height = 495 }, .cell = .{ .width = 10, .height = 21 }, .padding = .{ .top = 2, .bottom = 2, .right = 2, .left = 2 } }
debug(generic_renderer): cell grid changed old=.{ .columns = 74, .rows = 23 } new=.{ .columns = 73, .rows = 23 }
debug(opengl): exact buffer resize type=[4]u8 old=1702 new=1679


# Writing more text


debug(opengl): retain buffer grow type=renderer.opengl.shaders.CellText old=28 required=33 allocated=66
debug(opengl): retain buffer grow type=renderer.opengl.shaders.CellText old=66 required=82 allocated=164
debug(opengl): retain buffer grow type=renderer.opengl.shaders.CellText old=164 required=195 allocated=390
debug(opengl): retain buffer grow type=renderer.opengl.shaders.CellText old=390 required=421 allocated=842



# Making the grid bigger


debug(gtk_ghostty_surface): gl resize width=740 height=495 scale=1 window_scale=1
debug(io_thread): mailbox message=resize
debug(renderer_thread): mailbox message=.{ .resize = .{ .screen = .{ .width = 740, .height = 495 }, .cell = .{ .width = 10, .height = 21 }, .padding = .{ .top = 2, .bottom = 2, .right = 2, .left = 2 } } }
debug(generic_renderer): screen size size=.{ .screen = .{ .width = 740, .height = 495 }, .cell = .{ .width = 10, .height = 21 }, .padding = .{ .top = 2, .bottom = 2, .right = 2, .left = 2 } }
debug(gtk_ghostty_surface): gl resize width=742 height=495 scale=1 window_scale=1
debug(io_thread): mailbox message=resize
debug(renderer_thread): mailbox message=.{ .resize = .{ .screen = .{ .width = 742, .height = 495 }, .cell = .{ .width = 10, .height = 21 }, .padding = .{ .top = 2, .bottom = 2, .right = 2, .left = 2 } } }
debug(generic_renderer): screen size size=.{ .screen = .{ .width = 742, .height = 495 }, .cell = .{ .width = 10, .height = 21 }, .padding = .{ .top = 2, .bottom = 2, .right = 2, .left = 2 } }
debug(gtk_ghostty_surface): gl resize width=746 height=497 scale=1 window_scale=1
debug(io_thread): mailbox message=resize
debug(renderer_thread): mailbox message=.{ .resize = .{ .screen = .{ .width = 746, .height = 497 }, .cell = .{ .width = 10, .height = 21 }, .padding = .{ .top = 2, .bottom = 2, .right = 2, .left = 2 } } }
debug(generic_renderer): screen size size=.{ .screen = .{ .width = 746, .height = 497 }, .cell = .{ .width = 10, .height = 21 }, .padding = .{ .top = 2, .bottom = 2, .right = 2, .left = 2 } }
debug(renderer_thread): mailbox message=.{ .reset_cursor_blink = void }
debug(generic_renderer): cell grid changed old=.{ .columns = 73, .rows = 23 } new=.{ .columns = 74, .rows = 23 }
debug(opengl): exact buffer resize type=[4]u8 old=1679 new=1702
debug(opengl): exact buffer resize type=renderer.opengl.shaders.CellText old=842 new=593
```

</details>


## AI usage

AI was particularly useful to learn about the render engine, the context of this project, make suggestions and as reviewer of the changes introduced. 