### PR TITLE
macos: replace legacy aspectRatio with scaledToFit in clipboard preview

### DIFF
--- a/macos/Sources/Features/ClipboardConfirmation/ClipboardConfirmationView.swift
+++ b/macos/Sources/Features/ClipboardConfirmation/ClipboardConfirmationView.swift
@@ -71,7 +71,7 @@ struct ClipboardConfirmationView: View {
             if let previewImage {
                 Image(nsImage: previewImage)
                     .resizable()
-                    .aspectRatio(contentMode: .fit)
+                    .scaledToFit()
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .padding(.horizontal)
             } else {


### PR DESCRIPTION
Fixes the swiftlint legacy_swiftui_aspect_ratio violation.

### AI Disclosure

By Claude, but it's really simple.