### PR TITLE
cli: update list-themes preview sample to valid Zig 0.16 syntax

### DIFF
--- a/src/cli/list_themes.zig
+++ b/src/cli/list_themes.zig
@@ -1205,7 +1205,7 @@ const Preview = struct {
                         .x_off = x_off,
                         .y_off = next_start,
                         .width = width,
-                        .height = 24,
+                        .height = 28,
                     },
                 );
                 const bold: vaxis.Style = .{
@@ -1382,7 +1382,9 @@ const Preview = struct {
                         .{ .text = "pub ", .style = color5 },
                         .{ .text = "fn ", .style = color12 },
                         .{ .text = "main", .style = color2 },
-                        .{ .text = "() ", .style = standard },
+                        .{ .text = "(init: ", .style = standard },
+                        .{ .text = "std.process.Init", .style = color12 },
+                        .{ .text = ") ", .style = standard },
                         .{ .text = "!", .style = color5 },
                         .{ .text = "void", .style = color12 },
                         .{ .text = " {", .style = standard },
@@ -1395,10 +1397,11 @@ const Preview = struct {
                 _ = child.print(
                     &.{
                         .{ .text = "   4   │     ", .style = color238 },
-                        .{ .text = "const ", .style = color5 },
-                        .{ .text = "stdout ", .style = standard },
-                        .{ .text = "=", .style = color5 },
-                        .{ .text = " std.Io.getStdOut().writer();", .style = standard },
+                        .{ .text = "var ", .style = color5 },
+                        .{ .text = "buf:", .style = standard },
+                        .{ .text = " [1024]u8", .style = color12 },
+                        .{ .text = " =", .style = color5 },
+                        .{ .text = " undefined;", .style = standard },
                     },
                     .{
                         .row_offset = 7,
@@ -1409,11 +1412,9 @@ const Preview = struct {
                     &.{
                         .{ .text = "   5   │     ", .style = color238 },
                         .{ .text = "var ", .style = color5 },
-                        .{ .text = "i:", .style = standard },
-                        .{ .text = " usize", .style = color12 },
-                        .{ .text = " =", .style = color5 },
-                        .{ .text = " 1", .style = color4 },
-                        .{ .text = ";", .style = standard },
+                        .{ .text = "stdout ", .style = standard },
+                        .{ .text = "=", .style = color5 },
+                        .{ .text = " std.Io.File.stdout().writer(init.io, &buf);", .style = standard },
                     },
                     .{
                         .row_offset = 8,
@@ -1423,6 +1424,43 @@ const Preview = struct {
                 _ = child.print(
                     &.{
                         .{ .text = "   6   │     ", .style = color238 },
+                        .{ .text = "const ", .style = color5 },
+                        .{ .text = "w ", .style = standard },
+                        .{ .text = "=", .style = color5 },
+                        .{ .text = " &stdout.interface;", .style = standard },
+                    },
+                    .{
+                        .row_offset = 9,
+                        .col_offset = 2,
+                    },
+                );
+                _ = child.print(
+                    &.{
+                        .{ .text = "   7   │", .style = color238 },
+                    },
+                    .{
+                        .row_offset = 10,
+                        .col_offset = 2,
+                    },
+                );
+                _ = child.print(
+                    &.{
+                        .{ .text = "   8   │     ", .style = color238 },
+                        .{ .text = "var ", .style = color5 },
+                        .{ .text = "i:", .style = standard },
+                        .{ .text = " usize", .style = color12 },
+                        .{ .text = " =", .style = color5 },
+                        .{ .text = " 1", .style = color4 },
+                        .{ .text = ";", .style = standard },
+                    },
+                    .{
+                        .row_offset = 11,
+                        .col_offset = 2,
+                    },
+                );
+                _ = child.print(
+                    &.{
+                        .{ .text = "   9   │     ", .style = color238 },
                         .{ .text = "while ", .style = color5 },
                         .{ .text = "(i ", .style = standard },
                         .{ .text = "<= ", .style = color5 },
@@ -1433,13 +1471,13 @@ const Preview = struct {
                         .{ .text = ") {", .style = standard },
                     },
                     .{
-                        .row_offset = 9,
+                        .row_offset = 12,
                         .col_offset = 2,
                     },
                 );
                 _ = child.print(
                     &.{
-                        .{ .text = "   7   │         ", .style = color238 },
+                        .{ .text = "  10   │         ", .style = color238 },
                         .{ .text = "if ", .style = color5 },
                         .{ .text = "(i ", .style = standard },
                         .{ .text = "% ", .style = color5 },
@@ -1449,28 +1487,28 @@ const Preview = struct {
                         .{ .text = ") {", .style = standard },
                     },
                     .{
-                        .row_offset = 10,
+                        .row_offset = 13,
                         .col_offset = 2,
                     },
                 );
                 _ = child.print(
                     &.{
-                        .{ .text = "   8   │             ", .style = color238 },
+                        .{ .text = "  11   │             ", .style = color238 },
                         .{ .text = "try ", .style = color5 },
-                        .{ .text = "stdout.writeAll(", .style = standard },
+                        .{ .text = "w.writeAll(", .style = standard },
                         .{ .text = "\"ZiggZagg", .style = color10 },
                         .{ .text = "\\n", .style = color12 },
                         .{ .text = "\"", .style = color10 },
                         .{ .text = ");", .style = standard },
                     },
                     .{
-                        .row_offset = 11,
+                        .row_offset = 14,
                         .col_offset = 2,
                     },
                 );
                 _ = child.print(
                     &.{
-                        .{ .text = "   9   │         ", .style = color238 },
+                        .{ .text = "  12   │         ", .style = color238 },
                         .{ .text = "} ", .style = standard },
                         .{ .text = "else if ", .style = color5 },
                         .{ .text = "(i ", .style = standard },
@@ -1481,28 +1519,28 @@ const Preview = struct {
                         .{ .text = ") {", .style = standard },
                     },
                     .{
-                        .row_offset = 12,
+                        .row_offset = 15,
                         .col_offset = 2,
                     },
                 );
                 _ = child.print(
                     &.{
-                        .{ .text = "  10   │             ", .style = color238 },
+                        .{ .text = "  13   │             ", .style = color238 },
                         .{ .text = "try ", .style = color5 },
-                        .{ .text = "stdout.writeAll(", .style = standard },
+                        .{ .text = "w.writeAll(", .style = standard },
                         .{ .text = "\"Zigg", .style = color10 },
                         .{ .text = "\\n", .style = color12 },
                         .{ .text = "\"", .style = color10 },
                         .{ .text = ");", .style = standard },
                     },
                     .{
-                        .row_offset = 13,
+                        .row_offset = 16,
                         .col_offset = 2,
                     },
                 );
                 _ = child.print(
                     &.{
-                        .{ .text = "  11   │         ", .style = color238 },
+                        .{ .text = "  14   │         ", .style = color238 },
                         .{ .text = "} ", .style = standard },
                         .{ .text = "else if ", .style = color5 },
                         .{ .text = "(i ", .style = standard },
@@ -1513,53 +1551,19 @@ const Preview = struct {
                         .{ .text = ") {", .style = standard },
                     },
                     .{
-                        .row_offset = 14,
-                        .col_offset = 2,
-                    },
-                );
-                _ = child.print(
-                    &.{
-                        .{ .text = "  12   │             ", .style = color238 },
-                        .{ .text = "try ", .style = color5 },
-                        .{ .text = "stdout.writeAll(", .style = standard },
-                        .{ .text = "\"Zagg", .style = color10 },
-                        .{ .text = "\\n", .style = color12 },
-                        .{ .text = "\"", .style = color10 },
-                        .{ .text = ");", .style = standard },
-                    },
-                    .{
-                        .row_offset = 15,
-                        .col_offset = 2,
-                    },
-                );
-                _ = child.print(
-                    &.{
-                        .{ .text = "  13   │         ", .style = color238 },
-                        .{ .text = "} ", .style = standard },
-                        .{ .text = "else ", .style = color5 },
-                        .{ .text = "{", .style = standard },
-                    },
-                    .{
-                        .row_offset = 16,
-                        .col_offset = 2,
-                    },
-                );
-                _ = child.print(
-                    &.{
-                        .{ .text = "  14   │             ", .style = color238 },
-                        .{ .text = "try ", .style = color5 },
-                        .{ .text = "stdout.print(\"{d}\\n\", .{i})", .style = standard_selection },
-                        .{ .text = ";", .style = cursor },
-                    },
-                    .{
                         .row_offset = 17,
                         .col_offset = 2,
                     },
                 );
                 _ = child.print(
                     &.{
-                        .{ .text = "  15   │         ", .style = color238 },
-                        .{ .text = "}", .style = standard },
+                        .{ .text = "  15   │             ", .style = color238 },
+                        .{ .text = "try ", .style = color5 },
+                        .{ .text = "w.writeAll(", .style = standard },
+                        .{ .text = "\"Zagg", .style = color10 },
+                        .{ .text = "\\n", .style = color12 },
+                        .{ .text = "\"", .style = color10 },
+                        .{ .text = ");", .style = standard },
                     },
                     .{
                         .row_offset = 18,
@@ -1568,8 +1572,10 @@ const Preview = struct {
                 );
                 _ = child.print(
                     &.{
-                        .{ .text = "  16   │     ", .style = color238 },
-                        .{ .text = "}", .style = standard },
+                        .{ .text = "  16   │         ", .style = color238 },
+                        .{ .text = "} ", .style = standard },
+                        .{ .text = "else ", .style = color5 },
+                        .{ .text = "{", .style = standard },
                     },
                     .{
                         .row_offset = 19,
@@ -1578,11 +1584,54 @@ const Preview = struct {
                 );
                 _ = child.print(
                     &.{
-                        .{ .text = "  17   │ ", .style = color238 },
-                        .{ .text = "}", .style = standard },
+                        .{ .text = "  17   │             ", .style = color238 },
+                        .{ .text = "try ", .style = color5 },
+                        .{ .text = "w.print(\"{d}\\n\", .{i})", .style = standard_selection },
+                        .{ .text = ";", .style = cursor },
                     },
                     .{
                         .row_offset = 20,
+                        .col_offset = 2,
+                    },
+                );
+                _ = child.print(
+                    &.{
+                        .{ .text = "  18   │         ", .style = color238 },
+                        .{ .text = "}", .style = standard },
+                    },
+                    .{
+                        .row_offset = 21,
+                        .col_offset = 2,
+                    },
+                );
+                _ = child.print(
+                    &.{
+                        .{ .text = "  19   │     ", .style = color238 },
+                        .{ .text = "}", .style = standard },
+                    },
+                    .{
+                        .row_offset = 22,
+                        .col_offset = 2,
+                    },
+                );
+                _ = child.print(
+                    &.{
+                        .{ .text = "  20   │     ", .style = color238 },
+                        .{ .text = "try ", .style = color5 },
+                        .{ .text = "w.flush();", .style = standard },
+                    },
+                    .{
+                        .row_offset = 23,
+                        .col_offset = 2,
+                    },
+                );
+                _ = child.print(
+                    &.{
+                        .{ .text = "  21   │ ", .style = color238 },
+                        .{ .text = "}", .style = standard },
+                    },
+                    .{
+                        .row_offset = 24,
                         .col_offset = 2,
                     },
                 );
@@ -1595,7 +1644,7 @@ const Preview = struct {
                             },
                         },
                         .{
-                            .row_offset = 21,
+                            .row_offset = 25,
                             .col_offset = 2,
                         },
                     );
@@ -1610,7 +1659,7 @@ const Preview = struct {
                                     },
                                 },
                                 .{
-                                    .row_offset = 21,
+                                    .row_offset = 25,
                                     .col_offset = col,
                                 },
                             );
@@ -1624,12 +1673,12 @@ const Preview = struct {
                         .{ .text = " main ", .style = color4 },
                         .{ .text = "[+] ", .style = color1 },
                         .{ .text = "via ", .style = standard },
-                        .{ .text = " v0.13.0 ", .style = color3 },
+                        .{ .text = " v0.16.0 ", .style = color3 },
                         .{ .text = "via ", .style = standard },
                         .{ .text = "  impure (ghostty-env)", .style = color4 },
                     },
                     .{
-                        .row_offset = 22,
+                        .row_offset = 26,
                         .col_offset = 2,
                     },
                 );
@@ -1641,7 +1690,7 @@ const Preview = struct {
                         .{ .text = "→", .style = color2 },
                     },
                     .{
-                        .row_offset = 23,
+                        .row_offset = 27,
                         .col_offset = 2,
                     },
                 );


### PR DESCRIPTION
The demo code shown in the `+list-themes` theme preview was stale from before the Zig 0.16 migration (context: #12228). It referenced `std.Io.getStdOut().writer()`, which never existed in any Zig release, and `pub fn main() !void`. This rewrites the rendered sample to valid Zig 0.16 idioms:

```zig
const std = @import("std");

pub fn main(init: std.process.Init) !void {
    var buf: [1024]u8 = undefined;
    var stdout = std.Io.File.stdout().writer(init.io, &buf);
    const w = &stdout.interface;

    var i: usize = 1;
    while (i <= 16) : (i += 1) {
        if (i % 15 == 0) {
            try w.writeAll("ZiggZagg\n");
        } else if (i % 3 == 0) {
            try w.writeAll("Zigg\n");
        } else if (i % 5 == 0) {
            try w.writeAll("Zagg\n");
        } else {
            try w.print("{d}\n", .{i});
        }
    }
    try w.flush();
}
```

The gutter line numbers, row offsets, and child window height were renumbered to match, and the zig version shown in the demo prompt line was updated from v0.13.0 to v0.16.0.