### PR TITLE
terminal/snapshot: use stack fallback for record scratch

### DIFF
--- a/src/terminal/snapshot/snapshot.zig
+++ b/src/terminal/snapshot/snapshot.zig
@@ -50,7 +50,10 @@ pub fn encode(
     // Continuation errors must not emit even the snapshot envelope.
     try continuation.validate(options.continuation);
 
-    var stream: record.Writer = .init(alloc, destination);
+    // A measured 512-byte buffer handles our smallest records on the stack
+    // before larger records fall back to the heap.
+    var stack_alloc = std.heap.stackFallback(512, alloc);
+    var stream: record.Writer = .init(stack_alloc.get(), destination);
     defer stream.deinit();
 
     // 1. Envelope


### PR DESCRIPTION
Use a bounded 512-byte stack fallback for complete-snapshot record scratch. Small records avoid heap growth while larger records continue through the heap allocator.

This usually means 2 fewer allocations per encode, resulting in a small performance improvement in a local benchmark:

| Workload | `main` median | Branch median | Change |
|---|---:|---:|---:|
| Empty, 50k encodes | 135.06 ms | 130.76 ms | **3.2% faster** |
| 1 MiB ASCII, 500 encodes | 280.75 ms | 281.25 ms | **0.2% slower**, within noise |
| 1 MiB styled, 200 encodes | 1,023.02 ms | 996.32 ms | **2.6% faster** |