### PR TITLE
renderer: run DisplayLink only while a frame is pending

### DIFF
--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -1191,10 +1191,13 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 };
             }
 
-            // If we're not visible, then we want to stop the display link
-            // because it is a waste of resources and we can move to pure
-            // change-driven updates.
-            if (self.visible and self.focused) {
+            // Keep the link running only while a focused, visible surface
+            // has a frame to paint. Idle, unfocused, and occluded surfaces
+            // stop the link and stay change-driven so vsync does not tick
+            // for no-op.
+            if (self.visible and self.focused and
+                (self.cells_rebuilt or self.animationWake() != null))
+            {
                 display_link.start() catch {};
             } else {
                 display_link.stop() catch {};
@@ -1593,6 +1596,8 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 // Update custom shader uniforms that depend on terminal state.
                 self.updateCustomShaderUniformsFromState();
             }
+
+            self.syncDisplayLink(null, null);
         }
 
         /// Draw the frame to the screen.
@@ -1670,6 +1675,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 // apprt may be swapping buffers and display an outdated frame
                 // if we don't draw something new.
                 try self.api.presentLastTarget();
+                self.syncDisplayLink(null, null);
                 return;
             }
             self.cells_rebuilt = false;
@@ -1903,6 +1909,8 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     });
                 }
             }
+
+            self.syncDisplayLink(null, null);
         }
 
         // Callback from the graphics API when a frame is completed.


### PR DESCRIPTION
A focused vsync window currently keeps CVDisplayLink running at the display cadence. Idle frames still hop the render thread for a Metal no-op presentLastTarget.

Start the link from updateFrame when cells_rebuilt or an animation wake is set, so Thread.drawFrame(false) still waits for vsync. Stop it after a draw that leaves nothing pending. Unfocused, occluded, and window-vsync=false are unchanged.

Idle focused Time Profiler (t ≥ 5s): renderer plus CVDisplayLink went from 0.80% of one core on main to 0.13% on this branch (6.3×; 257 ms / 32 s vs 29 ms / 23 s).

This is from https://github.com/ghostty-org/ghostty/discussions/14030#discussioncomment-18165199, this looks like a clean win with minimal change for focused window efficiency.

AI - extensive use of grok 4.6 and some Claude in the experiments, this small change was all human after the research.
