### PR TITLE
macOS: move bell to title/tab bar

### DIFF
--- a/macos/Sources/Features/Splits/SplitTree.swift
+++ b/macos/Sources/Features/Splits/SplitTree.swift
@@ -1219,20 +1219,23 @@ extension SplitTree: Collection {
 // MARK: SplitTree Combine
 
 extension SplitTree {
-    /// Builds a publisher that emits current values for all leaf views keyed by view ID.
+    /// Builds a publisher that emits current values for all leaf views grouped by view ID.
     ///
-    /// The returned publisher emits a full `[ViewType.ID: Value]` snapshot whenever any leaf view
+    /// The returned publisher emits a full `[(id, value)]` snapshot whenever any leaf view
     /// publishes through the provided publisher key path.
+    ///
+    /// - Note: The result array is ordered as the order we traverse the tree.
     func valuesPublisher<Value>(
         valueKeyPath: KeyPath<ViewType, Value>,
         publisherKeyPath: KeyPath<ViewType, Published<Value>.Publisher>
-    ) -> AnyPublisher<[ViewType.ID: Value], Never> {
+    ) -> AnyPublisher<[(id: ViewType.ID, value: Value)], Never> {
         // Flatten the split tree into a list of current leaf views.
         let views = map { $0 }
+        let viewIDs = views.map(\.id)
         guard !views.isEmpty else {
             // If there are no leaves, immediately publish an empty snapshot.
-            // `Just([:])` keeps the return type simple and makes downstream usage easy.
-            return Just([:]).eraseToAnyPublisher()
+            // `Just([])` keeps the return type simple and makes downstream usage easy.
+            return Just([]).eraseToAnyPublisher()
         }
 
         // Capture each view's current value up front.
@@ -1262,6 +1265,15 @@ extension SplitTree {
             // Emit the initial snapshot first so subscribers always get a
             // complete value dictionary immediately upon subscription.
             .prepend(initial)
+            .map { dictionary in
+                viewIDs.compactMap {
+                    if let value = dictionary[$0] {
+                        return (id: $0, value: value)
+                    } else {
+                        return nil
+                    }
+                }
+            }
             // Hide implementation details and expose a stable API type.
             .eraseToAnyPublisher()
     }

--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -889,23 +889,12 @@ class BaseTerminalController: NSWindowController,
            surfaceTree.contains(titleSurface) {
             // If we have a surface, we want to listen for title changes.
             titleSurface.$title
-                .combineLatest(titleSurface.$bell)
-                .map { [weak self] in self?.computeTitle(title: $0, bell: $1) ?? "" }
                 .sink { [weak self] in self?.titleDidChange(to: $0) }
                 .store(in: &focusedSurfaceCancellables)
         } else {
             // There is no surface to listen to titles for.
             titleDidChange(to: "👻")
         }
-    }
-
-    private func computeTitle(title: String, bell: Bool) -> String {
-        var result = title
-        if bell && ghostty.config.bellFeatures.contains(.title) {
-            result = "🔔 \(result)"
-        }
-
-        return result
     }
 
     private func titleDidChange(to: String) {
@@ -917,9 +906,7 @@ class BaseTerminalController: NSWindowController,
         guard let window else { return }
 
         if let titleOverride {
-            window.title = computeTitle(
-                title: titleOverride,
-                bell: focusedSurface?.bell ?? false)
+            window.title = titleOverride
             return
         }
 
@@ -1693,11 +1680,18 @@ extension BaseTerminalController {
     /// bell state changes.
     private func setupBellNotificationPublisher() {
         bellStateCancellable = surfaceValuesPublisher(valueKeyPath: \.bell, publisherKeyPath: \.$bell)
-            .map { $0.values.contains(true) }
+            .map { $0.filter(\.value).map(\.id) }
             .removeDuplicates()
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] hasBell in
+            .sink { [weak self] surfaceIDs in
                 guard let self else { return }
+                if let terminalWindow = window as? TerminalWindow {
+                    terminalWindow.updateAlertedSurfaces(surfaceIDs, delegate: self)
+                }
+                let hasBell = !surfaceIDs.isEmpty
+                guard hasBell != bell else {
+                    return
+                }
                 bell = hasBell
                 NotificationCenter.default.post(
                     name: .terminalWindowBellDidChangeNotification,
@@ -1709,12 +1703,12 @@ extension BaseTerminalController {
 
     /// Creates a publisher for values on all surfaces in this controller's tree.
     ///
-    /// The publisher emits a dictionary of surface IDs to values whenever the tree changes
+    /// The publisher emits a `[(id, value)]` snapshot whenever the tree changes
     /// or any surface publishes a new value for the key path.
     func surfaceValuesPublisher<Value>(
         valueKeyPath: KeyPath<Ghostty.SurfaceView, Value>,
         publisherKeyPath: KeyPath<Ghostty.SurfaceView, Published<Value>.Publisher>
-    ) -> AnyPublisher<[Ghostty.SurfaceView.ID: Value], Never> {
+    ) -> AnyPublisher<[(id: Ghostty.SurfaceView.ID, value: Value)], Never> {
         // `surfaceTree` can be replaced entirely when splits are added/removed/closed.
         // For each tree snapshot we build a fresh publisher that watches all surfaces
         // in that snapshot.
@@ -1729,6 +1723,63 @@ extension BaseTerminalController {
             // subscriptions for old/removed surfaces when the tree changes.
             .switchToLatest()
             .eraseToAnyPublisher()
+    }
+}
+
+extension BaseTerminalController: BellAccessoryButtonDelegate {
+    func alertedSurfaceTitle(id: Ghostty.SurfaceView.ID) -> String? {
+        surfaceTree.first(where: { $0.id == id })?.title
+    }
+
+    func highlightAlertedSurface(id: Ghostty.SurfaceView.ID) {
+        guard
+            let surfaceView = surfaceTree.first(where: { $0.id == id }),
+            surfaceView.window != nil
+        else {
+            return
+        }
+        surfaceView.highlight()
+    }
+
+    func focusAlertedSurface(id: Ghostty.SurfaceView.ID?) {
+        let target = if let id {
+            surfaceTree.first(where: { $0.id == id })
+        } else {
+            surfaceTree.first(where: { $0.bell })
+        }
+
+        guard let target else {
+            return
+        }
+
+        var shouldHighlight = id == nil
+
+        switch surfaceTree.zoomed {
+        case .leaf(view: let zoomedView):
+            // If the target is invisible because other split is zoomed,
+            // then we reset zoom and focus and highlight the target split.
+            if zoomedView !== target {
+                surfaceTree = .init(root: surfaceTree.root, zoomed: nil)
+                shouldHighlight = true
+            }
+        default:
+            break
+        }
+
+        // If we're focusing by selecting a menu item and the target's tab
+        // is not selected, then we should select it to focus the target properly.
+        //
+        // When left-clicking the tab will be selected while we try to focus,
+        // so we don't need to do anything.
+        if id != nil, target.window == nil {
+            window?.tabGroup?.selectedWindow = window
+        }
+
+        focusSurface(target)
+        target.clearBell()
+        if shouldHighlight {
+            target.highlight()
+        }
     }
 }
 

--- a/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Combine
 import SwiftUI
 import GhosttyKit
 
@@ -23,6 +24,9 @@ class TerminalWindow: NSWindow {
 
     /// Update notification UI in titlebar
     private let updateAccessory = NSTitlebarAccessoryViewController()
+
+    /// Bell in titlebar
+    private let titlebarBellAccessory = NSTitlebarAccessoryViewController()
 
     /// Visual indicator that mirrors the selected tab color.
     private lazy var tabColorIndicator: NSHostingView<TabColorIndicatorView> = {
@@ -153,6 +157,13 @@ class TerminalWindow: NSWindow {
                 addTitlebarAccessoryViewController(updateAccessory)
                 updateAccessory.view.translatesAutoresizingMaskIntoConstraints = false
             }
+
+            titlebarBellAccessory.layoutAttribute = .right
+            // See `TitlebarBellAccessoryView` on why we don't use
+            // the same NSButton here.
+            titlebarBellAccessory.view = NSHostingView(rootView: TitlebarBellAccessoryView(viewModel: viewModel))
+            addTitlebarAccessoryViewController(titlebarBellAccessory)
+            titlebarBellAccessory.view.translatesAutoresizingMaskIntoConstraints = false
         }
 
         // Setup the accessory view for tabs that shows our keyboard shortcuts,
@@ -167,6 +178,7 @@ class TerminalWindow: NSWindow {
         stackView.alignment = .centerY
         stackView.addArrangedSubview(tabColorIndicator)
         stackView.addArrangedSubview(keyEquivalentLabel)
+        stackView.addArrangedSubview(bellTabButton)
         stackView.addArrangedSubview(resetZoomTabButton)
         tab.accessoryView = stackView
 
@@ -314,6 +326,9 @@ class TerminalWindow: NSWindow {
         if let idx = titlebarAccessoryViewControllers.firstIndex(of: resetZoomAccessory) {
             removeTitlebarAccessoryViewController(at: idx)
         }
+        if let idx = titlebarAccessoryViewControllers.firstIndex(of: titlebarBellAccessory) {
+            removeTitlebarAccessoryViewController(at: idx)
+        }
 
         // We don't need to do this with the update accessory. I don't know why but
         // everything works fine.
@@ -323,6 +338,9 @@ class TerminalWindow: NSWindow {
         if styleMask.contains(.titled) {
             if titlebarAccessoryViewControllers.firstIndex(of: resetZoomAccessory) == nil {
                 addTitlebarAccessoryViewController(resetZoomAccessory)
+            }
+            if titlebarAccessoryViewControllers.firstIndex(of: titlebarBellAccessory) == nil {
+                addTitlebarAccessoryViewController(titlebarBellAccessory)
             }
         }
     }
@@ -461,6 +479,15 @@ class TerminalWindow: NSWindow {
         return nil
     }
 
+    // MARK: - Bell Button
+
+    private lazy var bellTabButton = BellAccessoryButton(viewModel: viewModel)
+
+    @MainActor func updateAlertedSurfaces(_ surfaceIDs: [Ghostty.SurfaceView.ID], delegate bellAccessoryDelegate: BellAccessoryButtonDelegate?) {
+        viewModel.alertedSurfaceIDs = surfaceIDs
+        viewModel.bellAccessoryDelegate = bellAccessoryDelegate
+    }
+
     // MARK: Positioning And Styling
 
     /// This is called by the controller when there is a need to reset the window appearance.
@@ -470,6 +497,9 @@ class TerminalWindow: NSWindow {
         // at some point when a surface becomes focused.
         guard isVisible else { return }
         defer { updateColorSchemeForSurfaceTree() }
+
+        // Bells
+        viewModel.isBellSupported = surfaceConfig.bellFeatures.contains(.title)
 
         // Basic properties
         appearance = surfaceConfig.windowAppearance
@@ -629,6 +659,17 @@ extension TerminalWindow {
         @Published var hasToolbar: Bool = false
         @Published var isMainWindow: Bool = true
 
+        // MARK: - Bell
+
+        @MainActor @Published var isBellSupported = false
+        @MainActor @Published var alertedSurfaceIDs: [Ghostty.SurfaceView.ID] = []
+
+        fileprivate weak var bellAccessoryDelegate: BellAccessoryButtonDelegate?
+
+        @MainActor var isBellVisible: Bool {
+            isBellSupported && alertedSurfaceIDs.count > 0
+        }
+
         /// Calculates the top padding based on toolbar visibility and macOS version
         fileprivate var accessoryTopPadding: CGFloat {
             if #available(macOS 26.0, *) {
@@ -637,7 +678,20 @@ extension TerminalWindow {
                 return hasToolbar ? 9 : 4
             }
         }
+
+        /// Slightly adjust the bottom space to align them in the center.
+        fileprivate var accessoryTopMinBottomSpace: CGFloat {
+            if #available(macOS 26.0, *) {
+                return hasToolbar ? 10 : 6
+            } else {
+                return hasToolbar ? 9 : 4
+            }
+        }
     }
+
+    // TODO: In the future, we should be able to merge all these
+    // accessory views in to one SwiftUI group, and display them
+    // conditionally. But you'll need to test them thoroughly.
 
     struct ResetZoomAccessoryView: View {
         @ObservedObject var viewModel: ViewModel
@@ -653,7 +707,8 @@ extension TerminalWindow {
                     .buttonStyle(.plain)
                     .help("Reset Split Zoom")
                     .frame(width: 20, height: 20)
-                    Spacer()
+
+                    Spacer(minLength: viewModel.accessoryTopMinBottomSpace)
                 }
                 // With a toolbar, the window title is taller, so we need more padding
                 // to properly align.
@@ -664,19 +719,221 @@ extension TerminalWindow {
         }
     }
 
+    /// BellAccessoryButton in the titlebar
+    ///
+    /// - Note: Tried with unifying with both AppKit/SwiftUI so we don't need duplicate it.
+    ///   But there's always some problems on macOS 15.
+    struct TitlebarBellAccessoryView: View {
+        @ObservedObject var viewModel: ViewModel
+
+        var body: some View {
+            // Always visible for the sake of wiggle animation on appear.
+            VStack {
+                RepresentableView { _ in
+                    BellAccessoryButton(viewModel: viewModel)
+                } update: { _, _ in }
+                // Align with the reset zoom button
+                .padding(.top, viewModel.accessoryTopPadding)
+                .padding(.trailing, 10)
+
+                Spacer(minLength: viewModel.accessoryTopMinBottomSpace)
+            }
+        }
+    }
+
     /// A pill-shaped button that displays update status and provides access to update actions.
     struct UpdateAccessoryView: View {
         @ObservedObject var viewModel: ViewModel
         @ObservedObject var model: UpdateViewModel
 
         var body: some View {
-            // We use the same top/trailing padding so that it hugs the same.
-            UpdatePill(model: model)
+            VStack {
+                UpdatePill(model: model)
+                // We use the same top/trailing padding so that it hugs the same in the corner.
                 .padding(.top, viewModel.accessoryTopPadding)
-                .padding(.trailing, viewModel.accessoryTopPadding)
+                .padding(.trailing, isResetZoomButtonAvailable ? 10 : viewModel.accessoryTopPadding)
+
+                // Slightly up to align with other buttons
+                Spacer(minLength: viewModel.accessoryTopMinBottomSpace - 2)
+            }
+        }
+
+        /// When reset zoom button is on the right we use fixed padding to distribute buttons evenly
+        var isResetZoomButtonAvailable: Bool {
+            viewModel.isSurfaceZoomed && viewModel.hasToolbar
         }
     }
+}
 
+protocol BellAccessoryButtonDelegate: AnyObject {
+    func alertedSurfaceTitle(id: Ghostty.SurfaceView.ID) -> String?
+    @MainActor func highlightAlertedSurface(id: Ghostty.SurfaceView.ID)
+    /// Focus first surface with bell if `id` is nil
+    @MainActor func focusAlertedSurface(id: Ghostty.SurfaceView.ID?)
+}
+
+private class BellAccessoryButton: NSButton, NSMenuDelegate {
+    private let viewModel: TerminalWindow.ViewModel
+    private let symbolImageView: NSImageView
+    private var cancellables: Set<AnyCancellable> = []
+    private var alertedSurfaceCount: Int = 0
+
+    init(viewModel: TerminalWindow.ViewModel) {
+        self.viewModel = viewModel
+        self.symbolImageView = NSImageView(frame: .zero)
+        super.init(frame: CGRect(x: 0, y: 0, width: 20, height: 20))
+
+        title = ""
+        isBordered = false
+        setButtonType(.momentaryChange)
+        target = self
+        action = #selector(focusFirstAlertedSurface(_:))
+        toolTip = "Focus First Terminal With Bell"
+        isHidden = !viewModel.isBellVisible
+
+        setAccessibilityLabel("Bell")
+
+        symbolImageView.image = NSImage(systemSymbolName: "bell.badge.fill", accessibilityDescription: "Bell")
+        symbolImageView.frame = bounds
+        symbolImageView.autoresizingMask = [.width, .height]
+        addSubview(symbolImageView)
+
+        // Simulate NSButton's tracking
+        (cell as? HighlightTrackingButtonCell)?.onHighlightChanged = { [weak self] highlighted in
+            self?.isPressed = highlighted
+        }
+
+        viewModel.$isMainWindow
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] isMainWindow in
+                self?.baseTint = isMainWindow ? .systemYellow : .secondaryLabelColor
+            }
+            .store(in: &cancellables)
+
+        viewModel.$isBellSupported
+            .combineLatest(viewModel.$alertedSurfaceIDs)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.updateVisibility()
+            }
+            .store(in: &cancellables)
+
+        viewModel.$alertedSurfaceIDs
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] surfaces in
+                guard let self else { return }
+                if surfaces.count > alertedSurfaceCount {
+                    wiggle()
+                }
+                alertedSurfaceCount = surfaces.count
+            }
+            .store(in: &cancellables)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) is not supported")
+    }
+
+    /// Note: isHighlighted doesn't get reset when mouse button is up,
+    /// so adding a custom cell to track changes.
+    override class var cellClass: AnyClass? {
+        get { HighlightTrackingButtonCell.self }
+        set {}
+    }
+
+    override var intrinsicContentSize: NSSize {
+        .init(width: 20, height: 20)
+    }
+
+    // Just to be safe on every OS, making sure clicks are always for the button.
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        super.hitTest(point) != nil ? self : nil
+    }
+
+    // MARK: Highlight
+
+    private var isPressed = false {
+        didSet { updateTint() }
+    }
+
+    private var baseTint: NSColor = .systemYellow {
+        didSet { updateTint() }
+    }
+
+    private func updateTint() {
+        symbolImageView.contentTintColor = isPressed
+            ? baseTint.withSystemEffect(.pressed)
+            : baseTint
+    }
+
+    private func updateVisibility() {
+        let newIsHidden = !viewModel.isBellVisible
+        guard newIsHidden != isHidden else { return }
+        // Using a simple animation here
+        animator().isHidden = newIsHidden
+    }
+
+    private func wiggle() {
+        // We only animate when the view is actually visible
+        guard window != nil else { return }
+        guard #available(macOS 15.0, *) else { return }
+        // Cancel previously incomplete wiggle during fast bell change.
+        symbolImageView.removeSymbolEffect(ofType: .wiggle)
+        symbolImageView.addSymbolEffect(.wiggle, options: .nonRepeating)
+    }
+
+    @objc private func focusFirstAlertedSurface(_ sender: Any?) {
+        viewModel.bellAccessoryDelegate?.focusAlertedSurface(id: nil)
+    }
+
+    @objc private func focusAlertedSurface(_ sender: NSMenuItem) {
+        guard let id = sender.representedObject as? Ghostty.SurfaceView.ID else { return }
+        viewModel.bellAccessoryDelegate?.focusAlertedSurface(id: id)
+    }
+
+    // MARK: Context Menu
+
+    override func menu(for event: NSEvent) -> NSMenu? {
+        guard let delegate = viewModel.bellAccessoryDelegate else { return nil }
+
+        let menu = NSMenu()
+        menu.delegate = self
+
+        let headerTitle = "Select a terminal you want to focus"
+        if #available(macOS 14.0, *) {
+            menu.addItem(.sectionHeader(title: headerTitle))
+        } else {
+            menu.addItem(NSMenuItem(title: headerTitle, action: nil, keyEquivalent: ""))
+        }
+
+        for id in viewModel.alertedSurfaceIDs {
+            guard let title = delegate.alertedSurfaceTitle(id: id), !title.isEmpty else { continue }
+            let item = NSMenuItem(title: title, action: #selector(focusAlertedSurface(_:)), keyEquivalent: "")
+            item.target = self
+            item.representedObject = id
+            menu.addItem(item)
+        }
+
+        return menu
+    }
+
+    func menu(_ menu: NSMenu, willHighlight item: NSMenuItem?) {
+        guard viewModel.isMainWindow,
+              let id = item?.representedObject as? Ghostty.SurfaceView.ID else { return }
+        viewModel.bellAccessoryDelegate?.highlightAlertedSurface(id: id)
+    }
+}
+
+/// An NSButtonCell that reports highlight (pressed) state changes so the
+/// owning button can mirror the pressed effect onto content the cell doesn't
+/// draw itself, such as a nested NSImageView used for symbol effects.
+private class HighlightTrackingButtonCell: NSButtonCell {
+    var onHighlightChanged: ((Bool) -> Void)?
+
+    override func highlight(_ flag: Bool, withFrame cellFrame: NSRect, in controlView: NSView) {
+        super.highlight(flag, withFrame: cellFrame, in: controlView)
+        onHighlightChanged?(flag)
+    }
 }
 
 /// A small circle indicator displayed in the tab accessory view that shows

--- a/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
@@ -437,6 +437,11 @@ extension Ghostty {
             progressReportTimer?.invalidate()
         }
 
+        /// This is only used for bell button for now.
+        @MainActor func clearBell() {
+            self.bell = false
+        }
+
         override func endSearch() {
             Ghostty.moveFocus(to: self)
             super.endSearch()
@@ -1835,6 +1840,7 @@ extension Ghostty {
             let windowTitleFontFamily: String?
             let windowAppearance: NSAppearance?
             let scrollbar: Ghostty.Config.Scrollbar
+            let bellFeatures: Ghostty.Config.BellFeatures
 
             init() {
                 self.backgroundColor = Color(NSColor.windowBackgroundColor)
@@ -1844,6 +1850,7 @@ extension Ghostty {
                 self.windowTitleFontFamily = nil
                 self.windowAppearance = nil
                 self.scrollbar = .system
+                self.bellFeatures = .defaultValue
             }
 
             init(_ config: Ghostty.Config) {
@@ -1854,6 +1861,7 @@ extension Ghostty {
                 self.windowTitleFontFamily = config.windowTitleFontFamily
                 self.windowAppearance = .init(ghosttyConfig: config)
                 self.scrollbar = config.scrollbar
+                self.bellFeatures = config.bellFeatures
             }
         }
 

--- a/macos/Sources/Helpers/Extensions/NSView+Extension.swift
+++ b/macos/Sources/Helpers/Extensions/NSView+Extension.swift
@@ -220,3 +220,16 @@ extension NSView {
 		return result
 	}
 }
+
+struct RepresentableView<NSViewType: NSView>: NSViewRepresentable {
+    let creation: (Context) -> NSViewType
+    let update: (_ nsView: NSViewType, _ context: Context) -> Void
+
+    func makeNSView(context: Context) -> NSViewType {
+        creation(context)
+    }
+
+    func updateNSView(_ nsView: NSViewType, context: Context) {
+        update(nsView, context)
+    }
+}

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -3224,8 +3224,19 @@ keybind: Keybinds = .{},
 ///
 ///  * `title` *(enabled by default)*
 ///
-///    Prepend a bell emoji (🔔) to the title of the alerted surface until the
-///    terminal is re-focused or interacted with (such as on keyboard input).
+///    On macOS, display a bell icon in the title/tab bar of the alerted
+///    surface until the terminal is re-focused or interacted with (such as
+///    on keyboard input). Prior to 1.4.0, this prepended a bell emoji (🔔)
+///    to the title instead.
+///
+///    > [!NOTE]
+///    > If multiple surfaces have been alerted, you can left click the icon
+///    > to focus the first alerted surface in the tree from root to leaf.
+///    > Or you can right click to select which surface you want to focus.
+///
+///    On GTK, prepend a bell emoji (🔔) to the title of the alerted surface
+///    until the terminal is re-focused or interacted with (such as on
+///    keyboard input).
 ///
 ///  * `border`
 ///


### PR DESCRIPTION
This changes current 🔔 emoji prepending in the title to a symbol in the title bar or the tab bar depending on the window's style. The bell symbol will also wiggle to indicate there’s a new bell triggered from one of the terminals in the current window.

This should be able to close these related discussions: #10692, #12926, #2871.

Changed `valuesPublisher`'s output type from Dictionary to Array, to provide menu options for the bell icon. In the future, we can also add terminal previews when one menu item is highlighted.

Also tweeked the accessory positions in the title bar to align them in the center.

---

Here are the final previews (Table format generated by AI):


| Scenario | macOS 15 | macOS 27 |
|---|---|---|
| Native title bar, bells + update + zoomed, no tab bar | ![macOS 15 native, no tab bar](https://github.com/user-attachments/assets/400390b0-fc5f-4587-aad7-8edb08f608b0) | ![macOS 27 native, no tab bar](https://github.com/user-attachments/assets/6f75a7fe-45db-4f41-bdab-7d822279e7e5) |
| Native title bar, bells + update + zoomed, tab bar | ![macOS 15 native, tab bar](https://github.com/user-attachments/assets/a10d22e8-4e4a-416b-9196-e13c818f13b5) | ![macOS 27 native, tab bar](https://github.com/user-attachments/assets/d55f2329-903f-4407-be80-10071b57d156) |
| Titlebar tabs, bells + zoomed, no tab bar | ![macOS 15 tabs, no tab bar](https://github.com/user-attachments/assets/eb94dda5-4d67-4cba-8c4c-52d722b68a11) | ![macOS 27 tabs, no tab bar](https://github.com/user-attachments/assets/c0f025ac-f7ea-491e-8430-c1727bc69e82) |
| Titlebar tabs, bells + zoomed, tab bar | ![macOS 15 tabs, tab bar](https://github.com/user-attachments/assets/24cd0785-a50f-4df1-8273-8a002f79a3b9) | ![macOS 27 tabs, tab bar](https://github.com/user-attachments/assets/3bf1acca-b1e4-4a3c-b5c9-7acdf949efeb) |



### AI Disclosure

Claude helped me draft the views, judged, and reviewed my final changes. I tested on both macOS 27 and 15. 27 should behave the same as 26.

 