### PR TITLE
macos: normalize action working directory paths

### DIFF
--- a/macos/Sources/Features/App Intents/NewTerminalIntent.swift
+++ b/macos/Sources/Features/App Intents/NewTerminalIntent.swift
@@ -74,7 +74,7 @@ struct NewTerminalIntent: AppIntent {
         // If we were given a working directory then open that directory
         if let url = workingDirectory?.fileURL {
             let dir = url.hasDirectoryPath ? url : url.deletingLastPathComponent()
-            config.workingDirectory = dir.path(percentEncoded: false)
+            config.workingDirectory = dir.pathWithoutTrailingSlash
         }
 
         // Parse environment variables from KEY=VALUE format

--- a/macos/Sources/Features/Services/ServiceProvider.swift
+++ b/macos/Sources/Features/Services/ServiceProvider.swift
@@ -59,7 +59,7 @@ class ServiceProvider: NSObject {
 
         for url in directoryURLs {
             var config = Ghostty.SurfaceConfiguration()
-            config.workingDirectory = url.path(percentEncoded: false)
+            config.workingDirectory = url.pathWithoutTrailingSlash
 
             switch target {
             case .window:

--- a/macos/Sources/Helpers/Extensions/URL+Extension.swift
+++ b/macos/Sources/Helpers/Extensions/URL+Extension.swift
@@ -3,10 +3,6 @@ import Foundation
 extension URL {
     /// The decoded path with trailing separators removed, except for the root path.
     var pathWithoutTrailingSlash: String {
-        var result = path(percentEncoded: false)
-        while result.count > 1 && result.hasSuffix("/") {
-            result.removeLast()
-        }
-        return result
+        FilePath(path(percentEncoded: false)).string
     }
 }

--- a/macos/Sources/Helpers/Extensions/URL+Extension.swift
+++ b/macos/Sources/Helpers/Extensions/URL+Extension.swift
@@ -1,4 +1,5 @@
 import Foundation
+import System
 
 extension URL {
     /// The decoded path with trailing separators removed, except for the root path.

--- a/macos/Sources/Helpers/Extensions/URL+Extension.swift
+++ b/macos/Sources/Helpers/Extensions/URL+Extension.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+extension URL {
+    /// The decoded path with trailing separators removed, except for the root path.
+    var pathWithoutTrailingSlash: String {
+        var result = path(percentEncoded: false)
+        while result.count > 1 && result.hasSuffix("/") {
+            result.removeLast()
+        }
+        return result
+    }
+}

--- a/macos/Tests/URLTests.swift
+++ b/macos/Tests/URLTests.swift
@@ -1,0 +1,25 @@
+import Foundation
+import Testing
+@testable import Ghostty
+
+struct URLTests {
+    @Test func pathWithoutTrailingSlash() {
+        let url = URL(string: "file:///tmp/example/")!
+        #expect(url.pathWithoutTrailingSlash == "/tmp/example")
+    }
+
+    @Test func pathWithoutMultipleTrailingSlashes() {
+        let url = URL(string: "file:///tmp/example///")!
+        #expect(url.pathWithoutTrailingSlash == "/tmp/example")
+    }
+
+    @Test func pathWithoutTrailingSlashDecodesPath() {
+        let url = URL(string: "file:///tmp/example%20directory/")!
+        #expect(url.pathWithoutTrailingSlash == "/tmp/example directory")
+    }
+
+    @Test func pathWithoutTrailingSlashPreservesRoot() {
+        let url = URL(string: "file:///")!
+        #expect(url.pathWithoutTrailingSlash == "/")
+    }
+}


### PR DESCRIPTION
Discussion #14048

Directory URLs no longer export a trailing slash through PWD, which keeps zsh's %1~ prompt expansion from resolving to an empty string.

A shared URL helper removes trailing separators while preserving the filesystem root and percent-decoding behavior. Tests cover normal, repeated, encoded, and root paths.