### PR TITLE
renderer: instance cell backgrounds and skip default-bg cells

### DIFF
--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -157,6 +157,10 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
         /// cells for the draw call.
         cells_rebuilt: bool = false,
 
+        /// True if any cell bg has partial alpha (0 < a < 255). Those
+        /// cells need blending; otherwise the cell_bg pass is opaque.
+        cell_bg_needs_blend: bool = false,
+
         /// The current GPU uniform values.
         uniforms: shaderpkg.Uniforms,
 
@@ -1835,12 +1839,21 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     .kitty_below_bg,
                 );
 
-                // Then we draw any opaque cell backgrounds.
+                // Alpha-0 (default bg) instances are skipped so the GPU
+                // bg_color pass, bg image, or kitty-below-bg shows through.
                 pass.step(.{
-                    .pipeline = self.shaders.pipelines.cell_bg,
+                    .pipeline = if (self.cell_bg_needs_blend)
+                        self.shaders.pipelines.cell_bg
+                    else
+                        self.shaders.pipelines.cell_bg_opaque,
                     .uniforms = frame.uniforms.buffer,
                     .buffers = &.{ null, frame.cells_bg.buffer },
-                    .draw = .{ .type = .triangle, .vertex_count = 3 },
+                    .draw = .{
+                        .type = .triangle_strip,
+                        .vertex_count = 4,
+                        .instance_count = @as(usize, self.cells.size.columns) *
+                            @as(usize, self.cells.size.rows),
+                    },
                 });
 
                 // Kitty images between cell backgrounds and text.
@@ -2784,6 +2797,18 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     };
 
                     x += if (cp.wide) 2 else 1;
+                }
+            }
+
+            // Partial-alpha cell backgrounds (background-opacity-cells)
+            // still need blending. Opaque cells replace the dest, so we
+            // can use a blend-off pipeline. Scan the dense grid so dirty
+            // row rebuilds still see translucent cells on clean rows.
+            self.cell_bg_needs_blend = false;
+            for (self.cells.bg_cells) |c| {
+                if (c[3] > 0 and c[3] < 255) {
+                    self.cell_bg_needs_blend = true;
+                    break;
                 }
             }
 

--- a/src/renderer/metal/shaders.zig
+++ b/src/renderer/metal/shaders.zig
@@ -18,9 +18,14 @@ const pipeline_descs: []const struct { [:0]const u8, PipelineDescription } =
             .blending_enabled = false,
         } },
         .{ "cell_bg", .{
-            .vertex_fn = "full_screen_vertex",
+            .vertex_fn = "cell_bg_vertex",
             .fragment_fn = "cell_bg_fragment",
             .blending_enabled = true,
+        } },
+        .{ "cell_bg_opaque", .{
+            .vertex_fn = "cell_bg_vertex",
+            .fragment_fn = "cell_bg_fragment",
+            .blending_enabled = false,
         } },
         .{ "cell_text", .{
             .vertex_attributes = CellText,

--- a/src/renderer/opengl/shaders.zig
+++ b/src/renderer/opengl/shaders.zig
@@ -15,9 +15,14 @@ const pipeline_descs: []const struct { [:0]const u8, PipelineDescription } =
             .blending_enabled = false,
         } },
         .{ "cell_bg", .{
-            .vertex_fn = loadShaderCode("../shaders/glsl/full_screen.v.glsl"),
+            .vertex_fn = loadShaderCode("../shaders/glsl/cell_bg.v.glsl"),
             .fragment_fn = loadShaderCode("../shaders/glsl/cell_bg.f.glsl"),
             .blending_enabled = true,
+        } },
+        .{ "cell_bg_opaque", .{
+            .vertex_fn = loadShaderCode("../shaders/glsl/cell_bg.v.glsl"),
+            .fragment_fn = loadShaderCode("../shaders/glsl/cell_bg.f.glsl"),
+            .blending_enabled = false,
         } },
         .{ "cell_text", .{
             .vertex_attributes = CellText,

--- a/src/renderer/shaders/glsl/cell_bg.f.glsl
+++ b/src/renderer/shaders/glsl/cell_bg.f.glsl
@@ -1,61 +1,11 @@
-#include "common.glsl"
+#version 430 core
 
-// Position the origin to the upper left
-layout(origin_upper_left) in vec4 gl_FragCoord;
+in CellBgVertexOut {
+    flat vec4 color;
+} in_data;
 
-// Must declare this output for some versions of OpenGL.
 layout(location = 0) out vec4 out_FragColor;
 
-layout(binding = 1, std430) readonly buffer bg_cells {
-    uint cells[];
-};
-
-vec4 cell_bg() {
-    uvec2 grid_size = unpack2u16(grid_size_packed_2u16);
-    ivec2 grid_pos = ivec2(floor((gl_FragCoord.xy - grid_padding.wx) / cell_size));
-    bool use_linear_blending = (bools & USE_LINEAR_BLENDING) != 0;
-
-    vec4 bg = vec4(0.0);
-
-    // Clamp x position, extends edge bg colors in to padding on sides.
-    if (grid_pos.x < 0) {
-        if ((padding_extend & EXTEND_LEFT) != 0) {
-            grid_pos.x = 0;
-        } else {
-            return bg;
-        }
-    } else if (grid_pos.x > grid_size.x - 1) {
-        if ((padding_extend & EXTEND_RIGHT) != 0) {
-            grid_pos.x = int(grid_size.x) - 1;
-        } else {
-            return bg;
-        }
-    }
-
-    // Clamp y position if we should extend, otherwise discard if out of bounds.
-    if (grid_pos.y < 0) {
-        if ((padding_extend & EXTEND_UP) != 0) {
-            grid_pos.y = 0;
-        } else {
-            return bg;
-        }
-    } else if (grid_pos.y > grid_size.y - 1) {
-        if ((padding_extend & EXTEND_DOWN) != 0) {
-            grid_pos.y = int(grid_size.y) - 1;
-        } else {
-            return bg;
-        }
-    }
-
-    // Load the color for the cell.
-    vec4 cell_color = load_color(
-            unpack4u8(cells[grid_pos.y * grid_size.x + grid_pos.x]),
-            use_linear_blending
-        );
-
-    return cell_color;
-}
-
 void main() {
-    out_FragColor = cell_bg();
+    out_FragColor = in_data.color;
 }

--- a/src/renderer/shaders/glsl/cell_bg.v.glsl
+++ b/src/renderer/shaders/glsl/cell_bg.v.glsl
@@ -1,0 +1,64 @@
+#include "common.glsl"
+
+layout(binding = 1, std430) readonly buffer bg_cells {
+    uint cells[];
+};
+
+out CellBgVertexOut {
+    flat vec4 color;
+} out_data;
+
+void main() {
+    uvec2 grid_size = unpack2u16(grid_size_packed_2u16);
+    uint cols = grid_size.x;
+    uint rows = grid_size.y;
+    uint iid = uint(gl_InstanceID);
+    uint x = iid % cols;
+    uint y = iid / cols;
+    uvec4 cell_color = unpack4u8(cells[iid]);
+
+    // Default-bg cells are alpha 0. Degenerate so they are not rasterized;
+    // the GPU bg_color pass, background image, or kitty-below-bg shows through.
+    if (cell_color.a == 0u || y >= rows) {
+        gl_Position = vec4(2.0, 2.0, 0.0, 1.0);
+        out_data.color = vec4(0.0);
+        return;
+    }
+
+    // Same triangle strip corners as cell_text:
+    //   0 --> 1
+    //   |   .'|
+    //   |  /  |
+    //   | L   |
+    //   2 --> 3
+    int vid = gl_VertexID;
+    vec2 corner;
+    corner.x = float(vid == 1 || vid == 3);
+    corner.y = float(vid == 2 || vid == 3);
+
+    vec2 origin = cell_size * vec2(x, y);
+    vec2 size = cell_size;
+
+    // Extend edge cells into window padding when padding_extend is set.
+    // grid_padding is (top, right, bottom, left).
+    if (x == 0u && (padding_extend & EXTEND_LEFT) != 0u) {
+        origin.x -= grid_padding.w;
+        size.x += grid_padding.w;
+    }
+    if (x == cols - 1u && (padding_extend & EXTEND_RIGHT) != 0u) {
+        size.x += grid_padding.y;
+    }
+    if (y == 0u && (padding_extend & EXTEND_UP) != 0u) {
+        origin.y -= grid_padding.x;
+        size.y += grid_padding.x;
+    }
+    if (y == rows - 1u && (padding_extend & EXTEND_DOWN) != 0u) {
+        size.y += grid_padding.z;
+    }
+
+    vec2 pos = origin + size * corner;
+    gl_Position = projection_matrix * vec4(pos.x, pos.y, 0.0, 1.0);
+
+    bool use_linear_blending = (bools & USE_LINEAR_BLENDING) != 0;
+    out_data.color = load_color(cell_color, use_linear_blending);
+}

--- a/src/renderer/shaders/shaders.metal
+++ b/src/renderer/shaders/shaders.metal
@@ -448,60 +448,78 @@ fragment float4 bg_image_fragment(
 //-------------------------------------------------------------------
 #pragma mark - Cell BG Shader
 
-fragment float4 cell_bg_fragment(
-  FullScreenVertexOut in [[stage_in]],
+struct CellBgVertexOut {
+  float4 position [[position]];
+  float4 color [[flat]];
+};
+
+vertex CellBgVertexOut cell_bg_vertex(
+  uint vid [[vertex_id]],
+  uint iid [[instance_id]],
   constant Uniforms& uniforms [[buffer(1)]],
   constant uchar4 *cells [[buffer(2)]]
 ) {
-  int2 grid_pos = int2(floor((in.position.xy - uniforms.grid_padding.wx) / uniforms.cell_size));
+  CellBgVertexOut out;
 
-  float4 bg = float4(0.0);
+  uint cols = uniforms.grid_size.x;
+  uint rows = uniforms.grid_size.y;
+  uint x = iid % cols;
+  uint y = iid / cols;
+  uchar4 cell_color = cells[iid];
 
-  // Clamp x position, extends edge bg colors in to padding on sides.
-  if (grid_pos.x < 0) {
-    if (uniforms.padding_extend & EXTEND_LEFT) {
-      grid_pos.x = 0;
-    } else {
-      return bg;
-    }
-  } else if (grid_pos.x > uniforms.grid_size.x - 1) {
-    if (uniforms.padding_extend & EXTEND_RIGHT) {
-      grid_pos.x = uniforms.grid_size.x - 1;
-    } else {
-      return bg;
-    }
+  // Default-bg cells are alpha 0. Degenerate so they are not rasterized;
+  // the GPU bg_color pass, background image, or kitty-below-bg shows through.
+  if (cell_color.a == 0 || y >= rows) {
+    out.position = float4(2.0, 2.0, 0.0, 1.0);
+    out.color = float4(0.0);
+    return out;
   }
 
-  // Clamp y position if we should extend, otherwise discard if out of bounds.
-  if (grid_pos.y < 0) {
-    if (uniforms.padding_extend & EXTEND_UP) {
-      grid_pos.y = 0;
-    } else {
-      return bg;
-    }
-  } else if (grid_pos.y > uniforms.grid_size.y - 1) {
-    if (uniforms.padding_extend & EXTEND_DOWN) {
-      grid_pos.y = uniforms.grid_size.y - 1;
-    } else {
-      return bg;
-    }
+  // Same triangle strip corners as cell_text:
+  //   0 --> 1
+  //   |   .'|
+  //   |  /  |
+  //   | L   |
+  //   2 --> 3
+  float2 corner;
+  corner.x = float(vid == 1 || vid == 3);
+  corner.y = float(vid == 2 || vid == 3);
+
+  float2 origin = uniforms.cell_size * float2(x, y);
+  float2 size = uniforms.cell_size;
+
+  // Extend edge cells into window padding when padding_extend is set.
+  // grid_padding is (top, right, bottom, left).
+  if (x == 0 && (uniforms.padding_extend & EXTEND_LEFT)) {
+    origin.x -= uniforms.grid_padding.w;
+    size.x += uniforms.grid_padding.w;
+  }
+  if (x == cols - 1 && (uniforms.padding_extend & EXTEND_RIGHT)) {
+    size.x += uniforms.grid_padding.y;
+  }
+  if (y == 0 && (uniforms.padding_extend & EXTEND_UP)) {
+    origin.y -= uniforms.grid_padding.x;
+    size.y += uniforms.grid_padding.x;
+  }
+  if (y == rows - 1 && (uniforms.padding_extend & EXTEND_DOWN)) {
+    size.y += uniforms.grid_padding.z;
   }
 
-  // Load the color for the cell.
-  uchar4 cell_color = cells[grid_pos.y * uniforms.grid_size.x + grid_pos.x];
-
-  // Convert the color and return it.
-  //
-  // TODO: It might be a good idea to do a pass before this
-  //       to convert all of the bg colors, so we don't waste
-  //       a bunch of work converting the cell color in every
-  //       fragment of each cell. It's not the most epxensive
-  //       operation, but it is still wasted work.
-  return load_color(
+  float2 pos = origin + size * corner;
+  out.position =
+      uniforms.projection_matrix * float4(pos.x, pos.y, 0.0f, 1.0f);
+  out.color = load_color(
     cell_color,
     uniforms.use_display_p3,
     uniforms.use_linear_blending
   );
+  return out;
+}
+
+fragment float4 cell_bg_fragment(
+  CellBgVertexOut in [[stage_in]]
+) {
+  return in.color;
 }
 
 //-------------------------------------------------------------------


### PR DESCRIPTION
"The Good Half" of the PR from https://github.com/ghostty-org/ghostty/pull/14039

This PR only does the per cell background shader vs the existing per-pixel shader. (CPU based color calculations, loadlColor clearColor removed). Performance improvements are still excellent.

This is the benchmark I traced for performance improvement: https://github.com/ghostty-org/ghostty/blob/1fdcb4104f145828904b6ef1d8261fbd445a73b5/src/benchmark/cell_bg_trace.py


cell_bg was a fullscreen triangle that converted and blended every pixel, including default-bg cells that are alpha 0 and should show the GPU window background. That is the bulk of idle TUI GPU cost.

Draw one cell-sized quad per grid cell instead. The vertex shader converts the color once, degenerates alpha-0 instances so the bg_color pass or background image shows through, and stretches edge quads when window-padding-color extends into padding. CellBg stays 4-byte RGBA; cell_text still indexes the dense grid for min-contrast. Src-over of a fully opaque premultiplied color is a replace, so skip blending unless any cell has 0 < a < 255.

Window background stays a GPU fullscreen triangle so color-space conversion remains in the shader.

Metal System Trace vs main on an M2 at 1369×914. Main fragment kicks clustered at ~534 µs. This branch is ~96 to 110 µs on a default-bg grid (about 5×) and ~257 µs on a full opaque grid (about 2.1×). Fragment GPU time fell from 4.33 ms/s to 3.06 ms/s.