### PR TITLE
i18n: command palette - Focus and Untitled translation support

### DIFF
--- a/po/be.po
+++ b/po/be.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-08-28 11:17+0300\n"
 "PO-Revision-Date: 2026-04-14 00:00+0000\n"
 "Last-Translator: Illia Krauchanka <illiakrauchanka@gmail.com>\n"
 "Language-Team: Belarusian\n"
@@ -350,6 +350,14 @@ msgstr "Усе сесіі тэрмінала ў гэтым акне будуць
 #: src/apprt/gtk/class/close_confirmation_dialog.zig:196
 msgid "The currently running process in this split will be terminated."
 msgstr "Бягучы працэс у гэтым падзеле будзе завершаны."
+
+#: src/apprt/gtk/class/command_palette.zig:694
+msgid "Untitled"
+msgstr ""
+
+#: src/apprt/gtk/class/command_palette.zig:699
+msgid "Focus"
+msgstr ""
 
 #: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"

--- a/po/bg.po
+++ b/po/bg.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-08-28 11:17+0300\n"
 "PO-Revision-Date: 2026-08-13 13:40+0300\n"
 "Last-Translator: reo101 <pavel.atanasov2001@gmail.com>\n"
 "Language-Team: Bulgarian <dict@ludost.net>\n"
@@ -350,6 +350,14 @@ msgstr "Всички терминални сесии в този прозоре�
 #: src/apprt/gtk/class/close_confirmation_dialog.zig:196
 msgid "The currently running process in this split will be terminated."
 msgstr "Текущият процес в това разделяне ще бъде прекратен."
+
+#: src/apprt/gtk/class/command_palette.zig:694
+msgid "Untitled"
+msgstr ""
+
+#: src/apprt/gtk/class/command_palette.zig:699
+msgid "Focus"
+msgstr ""
 
 #: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"

--- a/po/ca.po
+++ b/po/ca.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-08-28 11:17+0300\n"
 "PO-Revision-Date: 2025-08-24 19:22+0200\n"
 "Last-Translator: Kristofer Soler "
 "<31729650+KristoferSoler@users.noreply.github.com>\n"
@@ -352,6 +352,14 @@ msgstr "Totes les sessions del terminal en aquesta finestra es tancaran."
 #: src/apprt/gtk/class/close_confirmation_dialog.zig:196
 msgid "The currently running process in this split will be terminated."
 msgstr "El procés actualment en execució en aquesta divisió es tancarà."
+
+#: src/apprt/gtk/class/command_palette.zig:694
+msgid "Untitled"
+msgstr ""
+
+#: src/apprt/gtk/class/command_palette.zig:699
+msgid "Focus"
+msgstr ""
 
 #: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"

--- a/po/com.mitchellh.ghostty.pot
+++ b/po/com.mitchellh.ghostty.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-08-28 11:17+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -336,6 +336,14 @@ msgstr ""
 
 #: src/apprt/gtk/class/close_confirmation_dialog.zig:196
 msgid "The currently running process in this split will be terminated."
+msgstr ""
+
+#: src/apprt/gtk/class/command_palette.zig:694
+msgid "Untitled"
+msgstr ""
+
+#: src/apprt/gtk/class/command_palette.zig:699
+msgid "Focus"
 msgstr ""
 
 #: src/apprt/gtk/class/surface.zig:1181

--- a/po/da.po
+++ b/po/da.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-08-28 11:17+0300\n"
 "PO-Revision-Date: 2026-08-13 12:00+0200\n"
 "Last-Translator: Carl Villads Priisholm <carl.priisholm@gmail.com>\n"
 "Language-Team: Danish <dansk@dansk-gruppen.dk>\n"
@@ -353,6 +353,14 @@ msgstr "Alle terminalsessioner i dette vindue vil blive afsluttet."
 #: src/apprt/gtk/class/close_confirmation_dialog.zig:196
 msgid "The currently running process in this split will be terminated."
 msgstr "Den kørende proces i denne opdeling vil blive afsluttet."
+
+#: src/apprt/gtk/class/command_palette.zig:694
+msgid "Untitled"
+msgstr ""
+
+#: src/apprt/gtk/class/command_palette.zig:699
+msgid "Focus"
+msgstr ""
 
 #: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"

--- a/po/de.po
+++ b/po/de.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-08-28 11:17+0300\n"
 "PO-Revision-Date: 2026-02-13 08:05+0100\n"
 "Last-Translator: Klaus Hipp <khipp@users.noreply.github.com>\n"
 "Language-Team: German <translation-team-de@lists.sourceforge.net>\n"
@@ -355,6 +355,14 @@ msgstr "Alle Terminalsitzungen in diesem Fenster werden beendet."
 #: src/apprt/gtk/class/close_confirmation_dialog.zig:196
 msgid "The currently running process in this split will be terminated."
 msgstr "Der aktuell laufende Prozess in diesem geteilten Fenster wird beendet."
+
+#: src/apprt/gtk/class/command_palette.zig:694
+msgid "Untitled"
+msgstr ""
+
+#: src/apprt/gtk/class/command_palette.zig:699
+msgid "Focus"
+msgstr ""
 
 #: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"

--- a/po/es_AR.po
+++ b/po/es_AR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-08-28 11:17+0300\n"
 "PO-Revision-Date: 2026-08-13 12:56-0300\n"
 "Last-Translator: Alan Moyano <alanmoyano203@gmail.com>\n"
 "Language-Team: Argentinian <es@tp.org.es>\n"
@@ -350,6 +350,14 @@ msgstr "Todas las sesiones de terminal en esta ventana se finalizarán."
 #: src/apprt/gtk/class/close_confirmation_dialog.zig:196
 msgid "The currently running process in this split will be terminated."
 msgstr "El proceso en ejecución en esta división se finalizará."
+
+#: src/apprt/gtk/class/command_palette.zig:694
+msgid "Untitled"
+msgstr ""
+
+#: src/apprt/gtk/class/command_palette.zig:699
+msgid "Focus"
+msgstr ""
 
 #: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"

--- a/po/es_BO.po
+++ b/po/es_BO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-08-28 11:17+0300\n"
 "PO-Revision-Date: 2026-08-13 17:33+0300\n"
 "Last-Translator: Miguel Peredo <miguelp@quientienemail.com>\n"
 "Language-Team: Spanish <es@tp.org.es>\n"
@@ -350,6 +350,14 @@ msgstr "Todas las sesiones de terminal en esta ventana serán terminadas."
 #: src/apprt/gtk/class/close_confirmation_dialog.zig:196
 msgid "The currently running process in this split will be terminated."
 msgstr "El proceso actualmente en ejecución en esta división será terminado."
+
+#: src/apprt/gtk/class/command_palette.zig:694
+msgid "Untitled"
+msgstr ""
+
+#: src/apprt/gtk/class/command_palette.zig:699
+msgid "Focus"
+msgstr ""
 
 #: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"

--- a/po/es_ES.po
+++ b/po/es_ES.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-08-28 11:17+0300\n"
 "PO-Revision-Date: 2026-08-13 21:24+0200\n"
 "Last-Translator: José Miguel Sarasola <alosarjos@gmail.com>\n"
 "Language-Team: \n"
@@ -351,6 +351,14 @@ msgstr "Todas las sesiones del terminal en esta ventana serán finalizadas."
 #: src/apprt/gtk/class/close_confirmation_dialog.zig:196
 msgid "The currently running process in this split will be terminated."
 msgstr "El proceso ejecutándose en esta división será finalizado."
+
+#: src/apprt/gtk/class/command_palette.zig:694
+msgid "Untitled"
+msgstr ""
+
+#: src/apprt/gtk/class/command_palette.zig:699
+msgid "Focus"
+msgstr ""
 
 #: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"

--- a/po/eu.po
+++ b/po/eu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-08-28 11:17+0300\n"
 "PO-Revision-Date: 2026-05-01 12:56+0200\n"
 "Last-Translator: Mikel Larreategi <mlarreategi@codesyntax.com>\n"
 "Language-Team: Language eu\n"
@@ -347,6 +347,14 @@ msgstr "Leiho honetako terminal saio guztiak itxi egingo dira."
 #: src/apprt/gtk/class/close_confirmation_dialog.zig:196
 msgid "The currently running process in this split will be terminated."
 msgstr "Zatikatze honetan martxan dagoen prozesua itxi egingo da."
+
+#: src/apprt/gtk/class/command_palette.zig:694
+msgid "Untitled"
+msgstr ""
+
+#: src/apprt/gtk/class/command_palette.zig:699
+msgid "Focus"
+msgstr ""
 
 #: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"

--- a/po/fr.po
+++ b/po/fr.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-08-28 11:17+0300\n"
 "PO-Revision-Date: 2026-08-22 11:30+0200\n"
 "Last-Translator: flou <flou@proton.me>\n"
 "Language-Team: French <traduc@traduc.org>\n"
@@ -353,6 +353,14 @@ msgstr "Toutes les sessions de cette fenêtre vont être arrêtées."
 #: src/apprt/gtk/class/close_confirmation_dialog.zig:196
 msgid "The currently running process in this split will be terminated."
 msgstr "Le processus en cours dans ce panneau va être arrêté."
+
+#: src/apprt/gtk/class/command_palette.zig:694
+msgid "Untitled"
+msgstr ""
+
+#: src/apprt/gtk/class/command_palette.zig:699
+msgid "Focus"
+msgstr ""
 
 #: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"

--- a/po/ga.po
+++ b/po/ga.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-08-28 11:17+0300\n"
 "PO-Revision-Date: 2026-02-18 14:32+0000\n"
 "Last-Translator: Aindriú Mac Giolla Eoin <aindriu80@yahoo.com>\n"
 "Language-Team: Irish <gaeilge-gnulinux@lists.sourceforge.net>\n"
@@ -350,6 +350,14 @@ msgstr "Cuirfear deireadh le gach seisiún teirminéil san fhuinneog seo."
 msgid "The currently running process in this split will be terminated."
 msgstr ""
 "Cuirfear deireadh leis an bpróiseas atá ar siúl faoi láthair sa scoilt seo."
+
+#: src/apprt/gtk/class/command_palette.zig:694
+msgid "Untitled"
+msgstr ""
+
+#: src/apprt/gtk/class/command_palette.zig:699
+msgid "Focus"
+msgstr ""
 
 #: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-08-28 11:17+0300\n"
 "PO-Revision-Date: 2026-08-13 19:14+0300\n"
 "Last-Translator: Sl (Shahaf Levi), Sl's Repository Ltd "
 "<ghostty@slsrepo.com>\n"
@@ -347,6 +347,14 @@ msgstr "כל הפעלות המסוף בחלון זה יסתיימו."
 #: src/apprt/gtk/class/close_confirmation_dialog.zig:196
 msgid "The currently running process in this split will be terminated."
 msgstr "התהליך שרץ כרגע בפיצול זה יסתיים."
+
+#: src/apprt/gtk/class/command_palette.zig:694
+msgid "Untitled"
+msgstr ""
+
+#: src/apprt/gtk/class/command_palette.zig:699
+msgid "Focus"
+msgstr ""
 
 #: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"

--- a/po/hr.po
+++ b/po/hr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-08-28 11:17+0300\n"
 "PO-Revision-Date: 2026-02-18 21:00+0200\n"
 "Last-Translator: Filip7 <filipm7@protonmail.com>\n"
 "Language-Team: Croatian <lokalizacija@linux.hr>\n"
@@ -350,6 +350,14 @@ msgstr "Sve sesije terminala u ovom prozoru će biti prekinute."
 #: src/apprt/gtk/class/close_confirmation_dialog.zig:196
 msgid "The currently running process in this split will be terminated."
 msgstr "Pokrenuti procesi u ovoj podjeli će biti prekinuti."
+
+#: src/apprt/gtk/class/command_palette.zig:694
+msgid "Untitled"
+msgstr ""
+
+#: src/apprt/gtk/class/command_palette.zig:699
+msgid "Focus"
+msgstr ""
 
 #: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-08-28 11:17+0300\n"
 "PO-Revision-Date: 2026-08-13 21:23+0200\n"
 "Last-Translator: Balázs Szücs <bszucs1209@gmail.com>\n"
 "Language-Team: Hungarian <translation-team-hu@lists.sourceforge.net>\n"
@@ -350,6 +350,14 @@ msgstr "Ebben az ablakban minden terminál munkamenet lezárul."
 #: src/apprt/gtk/class/close_confirmation_dialog.zig:196
 msgid "The currently running process in this split will be terminated."
 msgstr "Ebben a felosztásban a jelenleg futó folyamat lezárul."
+
+#: src/apprt/gtk/class/command_palette.zig:694
+msgid "Untitled"
+msgstr ""
+
+#: src/apprt/gtk/class/command_palette.zig:699
+msgid "Focus"
+msgstr ""
 
 #: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"

--- a/po/id.po
+++ b/po/id.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-08-28 11:17+0300\n"
 "PO-Revision-Date: 2026-03-08 20:23+0700\n"
 "Last-Translator: Mikail Muzakki <mikailmmuzakki@gmail.com>\n"
 "Language-Team: Indonesian <translation-team-id@lists.sourceforge.net>\n"
@@ -350,6 +350,14 @@ msgstr "Semua sesi terminal di jendela ini akan diakhiri."
 #: src/apprt/gtk/class/close_confirmation_dialog.zig:196
 msgid "The currently running process in this split will be terminated."
 msgstr "Proses yang sedang berjalan dalam belahan ini akan diakhiri."
+
+#: src/apprt/gtk/class/command_palette.zig:694
+msgid "Untitled"
+msgstr ""
+
+#: src/apprt/gtk/class/command_palette.zig:699
+msgid "Focus"
+msgstr ""
 
 #: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"

--- a/po/it.po
+++ b/po/it.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-08-28 11:17+0300\n"
 "PO-Revision-Date: 2025-09-06 19:40+0200\n"
 "Last-Translator: Giacomo Bettini <giaco.bettini@gmail.com>\n"
 "Language-Team: Italian <tp@lists.linux.it>\n"
@@ -352,6 +352,14 @@ msgstr "Tutte le sessioni del terminale in questa finestra saranno terminate."
 msgid "The currently running process in this split will be terminated."
 msgstr ""
 "Il processo attualmente in esecuzione in questa divisione sarà terminato."
+
+#: src/apprt/gtk/class/command_palette.zig:694
+msgid "Untitled"
+msgstr ""
+
+#: src/apprt/gtk/class/command_palette.zig:699
+msgid "Focus"
+msgstr ""
 
 #: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"

--- a/po/ja.po
+++ b/po/ja.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-08-28 11:17+0300\n"
 "PO-Revision-Date: 2026-02-11 12:02+0900\n"
 "Last-Translator: Takayuki Nagatomi <tnagatomi@okweird.net>\n"
 "Language-Team: Japanese\n"
@@ -349,6 +349,14 @@ msgstr "ウィンドウ内のすべてのターミナルセッションが終了
 #: src/apprt/gtk/class/close_confirmation_dialog.zig:196
 msgid "The currently running process in this split will be terminated."
 msgstr "分割ウィンドウ内のすべてのプロセスが終了します。"
+
+#: src/apprt/gtk/class/command_palette.zig:694
+msgid "Untitled"
+msgstr ""
+
+#: src/apprt/gtk/class/command_palette.zig:699
+msgid "Focus"
+msgstr ""
 
 #: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"

--- a/po/kk.po
+++ b/po/kk.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-08-28 11:17+0300\n"
 "PO-Revision-Date: 2026-08-13 00:00+0500\n"
 "Last-Translator: AnmiTaliDev <anmitalidev@nuros.org>\n"
 "Language-Team: Kazakh <kk_KZ@googlegroups.com>\n"
@@ -351,6 +351,14 @@ msgstr "Осы терезедегі барлық терминал сессиял
 #: src/apprt/gtk/class/close_confirmation_dialog.zig:196
 msgid "The currently running process in this split will be terminated."
 msgstr "Осы бөлудегі ағымдағы орындалып жатқан процесс тоқтатылады."
+
+#: src/apprt/gtk/class/command_palette.zig:694
+msgid "Untitled"
+msgstr ""
+
+#: src/apprt/gtk/class/command_palette.zig:699
+msgid "Focus"
+msgstr ""
 
 #: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-08-28 11:17+0300\n"
 "PO-Revision-Date: 2026-08-14 23:43+0900\n"
 "Last-Translator: dobbylee <leekw1245@gmail.com>\n"
 "Language-Team: Korean <translation-team-ko@googlegroups.com>\n"
@@ -349,6 +349,14 @@ msgstr "이 창의 모든 터미널 세션이 종료됩니다."
 #: src/apprt/gtk/class/close_confirmation_dialog.zig:196
 msgid "The currently running process in this split will be terminated."
 msgstr "이 분할에서 현재 실행 중인 프로세스가 종료됩니다."
+
+#: src/apprt/gtk/class/command_palette.zig:694
+msgid "Untitled"
+msgstr ""
+
+#: src/apprt/gtk/class/command_palette.zig:699
+msgid "Focus"
+msgstr ""
 
 #: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"

--- a/po/lt.po
+++ b/po/lt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-08-28 11:17+0300\n"
 "PO-Revision-Date: 2026-02-20 12:13+0100\n"
 "Last-Translator: Tadas Lotuzas <tdslot@gmail.com>\n"
 "Language-Team: Language LT\n"
@@ -350,6 +350,14 @@ msgstr "Visos terminalo sesijos šiame lange bus nutrauktos."
 #: src/apprt/gtk/class/close_confirmation_dialog.zig:196
 msgid "The currently running process in this split will be terminated."
 msgstr "Šiuo metu vykdomas procesas šiame padalijime bus nutrauktas."
+
+#: src/apprt/gtk/class/command_palette.zig:694
+msgid "Untitled"
+msgstr ""
+
+#: src/apprt/gtk/class/command_palette.zig:699
+msgid "Focus"
+msgstr ""
 
 #: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-08-28 11:17+0300\n"
 "PO-Revision-Date: 2026-08-10 17:32+0300\n"
 "Last-Translator: Ēriks Remess <eriks@remess.lv>\n"
 "Language-Team: Latvian\n"
@@ -347,6 +347,14 @@ msgstr "Visas termināļa sesijas šajā logā tiks pārtrauktas."
 #: src/apprt/gtk/class/close_confirmation_dialog.zig:196
 msgid "The currently running process in this split will be terminated."
 msgstr "Pašlaik palaistais process šajā nodalījumā tiks pārtraukts."
+
+#: src/apprt/gtk/class/command_palette.zig:694
+msgid "Untitled"
+msgstr ""
+
+#: src/apprt/gtk/class/command_palette.zig:699
+msgid "Focus"
+msgstr ""
 
 #: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"

--- a/po/mk.po
+++ b/po/mk.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-08-28 11:17+0300\n"
 "PO-Revision-Date: 2026-02-12 17:00+0100\n"
 "Last-Translator: Andrej Daskalov <andrej.daskalov@gmail.com>\n"
 "Language-Team: Macedonian\n"
@@ -350,6 +350,14 @@ msgstr "Сите сесии во овој прозорец ќе бидат пр�
 #: src/apprt/gtk/class/close_confirmation_dialog.zig:196
 msgid "The currently running process in this split will be terminated."
 msgstr "Процесот кој моментално се извршува во оваа поделба ќе биде прекинат."
+
+#: src/apprt/gtk/class/command_palette.zig:694
+msgid "Untitled"
+msgstr ""
+
+#: src/apprt/gtk/class/command_palette.zig:699
+msgid "Focus"
+msgstr ""
 
 #: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"

--- a/po/nb.po
+++ b/po/nb.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-08-28 11:17+0300\n"
 "PO-Revision-Date: 2026-08-12 21:34+0200\n"
 "Last-Translator: Uzair Aftab <u@uzaaft.me>\n"
 "Language-Team: Norwegian Bokmal <l10n-no@lister.huftis.org>\n"
@@ -351,6 +351,14 @@ msgstr "Alle terminaløkter i dette vinduet vil bli avsluttet."
 #: src/apprt/gtk/class/close_confirmation_dialog.zig:196
 msgid "The currently running process in this split will be terminated."
 msgstr "Den kjørende prosessen for denne splitten vil bli avsluttet."
+
+#: src/apprt/gtk/class/command_palette.zig:694
+msgid "Untitled"
+msgstr ""
+
+#: src/apprt/gtk/class/command_palette.zig:699
+msgid "Focus"
+msgstr ""
 
 #: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"

--- a/po/nl.po
+++ b/po/nl.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-08-28 11:17+0300\n"
 "PO-Revision-Date: 2026-08-14 18:30+0200\n"
 "Last-Translator: Kris van der Ven <306806+kjvdven@users.noreply.github.com>\n"
 "Language-Team: Dutch <vertaling@vrijschrift.org>\n"
@@ -352,6 +352,14 @@ msgstr "Alle terminalsessies binnen dit venster zullen worden beëindigd."
 #: src/apprt/gtk/class/close_confirmation_dialog.zig:196
 msgid "The currently running process in this split will be terminated."
 msgstr "Alle processen in deze splitsing zullen worden beëindigd."
+
+#: src/apprt/gtk/class/command_palette.zig:694
+msgid "Untitled"
+msgstr ""
+
+#: src/apprt/gtk/class/command_palette.zig:699
+msgid "Focus"
+msgstr ""
 
 #: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"

--- a/po/pl.po
+++ b/po/pl.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-08-28 11:17+0300\n"
 "PO-Revision-Date: 2026-08-13 21:08+0100\n"
 "Last-Translator: trag1c <dev@jakubr.me>\n"
 "Language-Team: Polish <translation-team-pl@lists.sourceforge.net>\n"
@@ -351,6 +351,14 @@ msgstr "Wszystkie sesje terminala w obecnym oknie zostaną zakończone."
 #: src/apprt/gtk/class/close_confirmation_dialog.zig:196
 msgid "The currently running process in this split will be terminated."
 msgstr "Wszystkie trwające procesy w obecnym podziale zostaną zakończone."
+
+#: src/apprt/gtk/class/command_palette.zig:694
+msgid "Untitled"
+msgstr ""
+
+#: src/apprt/gtk/class/command_palette.zig:699
+msgid "Focus"
+msgstr ""
 
 #: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-08-28 11:17+0300\n"
 "PO-Revision-Date: 2026-08-17 11:57-0500\n"
 "Last-Translator: Guilherme Tiscoski <github@guilhermetiscoski.com>\n"
 "Language-Team: Brazilian Portuguese <ldpbr-"
@@ -353,6 +353,14 @@ msgstr "Todas as sessões de terminal nessa janela serão finalizadas."
 #: src/apprt/gtk/class/close_confirmation_dialog.zig:196
 msgid "The currently running process in this split will be terminated."
 msgstr "O processo atual rodando nessa divisão será finalizado."
+
+#: src/apprt/gtk/class/command_palette.zig:694
+msgid "Untitled"
+msgstr ""
+
+#: src/apprt/gtk/class/command_palette.zig:699
+msgid "Focus"
+msgstr ""
 
 #: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"

--- a/po/ru.po
+++ b/po/ru.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-08-28 11:17+0300\n"
 "PO-Revision-Date: 2026-08-23 12:00+0200\n"
 "Last-Translator: derVedro <dervedro@googlemail.com>\n"
 "Language-Team: Russian\n"
@@ -353,6 +353,14 @@ msgstr "Все сессии терминала в этом окне будут �
 #: src/apprt/gtk/class/close_confirmation_dialog.zig:196
 msgid "The currently running process in this split will be terminated."
 msgstr "Процесс, работающий в этой области, будет остановлен."
+
+#: src/apprt/gtk/class/command_palette.zig:694
+msgid "Untitled"
+msgstr ""
+
+#: src/apprt/gtk/class/command_palette.zig:699
+msgid "Focus"
+msgstr ""
 
 #: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-08-28 11:17+0300\n"
 "PO-Revision-Date: 2026-08-13 20:33+0300\n"
 "Last-Translator: Emir SARI <emir_sari@icloud.com>\n"
 "Language-Team: Turkish\n"
@@ -351,6 +351,14 @@ msgstr "Bu penceredeki tüm uçbirim oturumları sonlandırılacaktır."
 #: src/apprt/gtk/class/close_confirmation_dialog.zig:196
 msgid "The currently running process in this split will be terminated."
 msgstr "Bu bölmedeki şu anda çalışan süreç sonlandırılacaktır."
+
+#: src/apprt/gtk/class/command_palette.zig:694
+msgid "Untitled"
+msgstr ""
+
+#: src/apprt/gtk/class/command_palette.zig:699
+msgid "Focus"
+msgstr ""
 
 #: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-08-28 11:17+0300\n"
 "PO-Revision-Date: 2026-02-18 13:14+0100\n"
 "Last-Translator: Volodymyr Chernetskyi "
 "<19735328+chernetskyi@users.noreply.github.com>\n"
@@ -350,6 +350,14 @@ msgstr "Всі сесії терміналу в цьому вікні будут
 #: src/apprt/gtk/class/close_confirmation_dialog.zig:196
 msgid "The currently running process in this split will be terminated."
 msgstr "Процес, що виконується в цій панелі, буде завершено."
+
+#: src/apprt/gtk/class/command_palette.zig:694
+msgid "Untitled"
+msgstr ""
+
+#: src/apprt/gtk/class/command_palette.zig:699
+msgid "Focus"
+msgstr ""
 
 #: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-08-28 11:17+0300\n"
 "PO-Revision-Date: 2026-03-04 09:32+0700\n"
 "Last-Translator: Anh Thang <buianhthang89@gmail.com>\n"
 "Language-Team: Vietnamese <translation-team-vi@lists.sourceforge.net>\n"
@@ -349,6 +349,14 @@ msgstr "Tất cả các phiên làm việc terminal trong cửa sổ này sẽ b
 #: src/apprt/gtk/class/close_confirmation_dialog.zig:196
 msgid "The currently running process in this split will be terminated."
 msgstr "Tiến trình đang chạy trong phần chia này sẽ bị chấm dứt."
+
+#: src/apprt/gtk/class/command_palette.zig:694
+msgid "Untitled"
+msgstr ""
+
+#: src/apprt/gtk/class/command_palette.zig:699
+msgid "Focus"
+msgstr ""
 
 #: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-08-28 11:17+0300\n"
 "PO-Revision-Date: 2026-02-12 01:56+0800\n"
 "Last-Translator: Leah <hi@pluie.me>\n"
 "Language-Team: Chinese (simplified) <i18n-zh@googlegroups.com>\n"
@@ -341,6 +341,14 @@ msgstr "窗口内所有运行中的进程将被终止。"
 #: src/apprt/gtk/class/close_confirmation_dialog.zig:196
 msgid "The currently running process in this split will be terminated."
 msgstr "分屏内正在运行中的进程将被终止。"
+
+#: src/apprt/gtk/class/command_palette.zig:694
+msgid "Untitled"
+msgstr ""
+
+#: src/apprt/gtk/class/command_palette.zig:699
+msgid "Focus"
+msgstr ""
 
 #: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-08-28 11:17+0300\n"
 "PO-Revision-Date: 2026-08-14 10:59+0800\n"
 "Last-Translator: Alang Hsu <alang.hsu@gmail.com>\n"
 "Language-Team: Chinese (traditional)\n"
@@ -341,6 +341,14 @@ msgstr "此視窗中的所有終端機工作階段都將被終止。"
 #: src/apprt/gtk/class/close_confirmation_dialog.zig:196
 msgid "The currently running process in this split will be terminated."
 msgstr "此窗格中目前執行的處理程序將被終止。"
+
+#: src/apprt/gtk/class/command_palette.zig:694
+msgid "Untitled"
+msgstr ""
+
+#: src/apprt/gtk/class/command_palette.zig:699
+msgid "Focus"
+msgstr ""
 
 #: src/apprt/gtk/class/surface.zig:1181
 msgid "Command Finished"

--- a/src/apprt/gtk/class/command_palette.zig
+++ b/src/apprt/gtk/class/command_palette.zig
@@ -8,6 +8,7 @@ const gobject = @import("gobject");
 const gtk = @import("gtk");
 
 const input = @import("../../../input.zig");
+const i18n = @import("../../../os/main.zig").i18n;
 const gresource = @import("../build/gresource.zig");
 const key = @import("../key.zig");
 const WeakRef = @import("../weak_ref.zig").WeakRef;
@@ -689,12 +690,13 @@ const Command = extern struct {
                 defer surface.unref();
 
                 const alloc = priv.arena.allocator();
-                const effective_title = surface.getEffectiveTitle() orelse "Untitled";
+                const effective_title = surface.getEffectiveTitle() orelse
+                    std.mem.span(i18n._("Untitled"));
 
                 j.title = std.fmt.allocPrintSentinel(
                     alloc,
-                    "Focus: {s}",
-                    .{effective_title},
+                    "{s}: {s}",
+                    .{ i18n._("Focus"), effective_title },
                     0,
                 ) catch null;
 


### PR DESCRIPTION
"Focus: {s}" and "Untitled" was not included in command palette translations. This PR adds support and placeholders in .po files for those strings.