### PR TITLE
renderer: vsync unfocused surfaces while dirty

### DIFF
--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -1194,8 +1194,6 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             const should_run =
                 // Non-visible windows never vsync
                 self.visible and
-                // Non-focused windows only render on-demand
-                self.focused and
                 // Only vsync if we have cell changes or animation
                 (self.cells_rebuilt or self.animationWake() != null);
 


### PR DESCRIPTION
A follow on for #14035, we can now fix a long standing effiency/performance bug now that we park the display link while idle. This actually could cause "animated" un-focused windows to use more GPU than their focused counterparts. (AI Agent interfaces seem to love animation).

6ae1784f4

Unfocused surfaces stopped the CVDisplayLink and encoded a GPU frame on every PTY wakeup. A burst of close writes became that many Metal submits instead of one vsync.

Keep the link running while the surface is visible and dirty or animating, whether or not it is focused. Idle surfaces still park.