### PR TITLE
main: fix inverted allow_stack_tracing condition

### DIFF
--- a/src/main_ghostty.zig
+++ b/src/main_ghostty.zig
@@ -228,7 +228,7 @@ pub const std_options: std.Options = .{
     .allow_stack_tracing = if (builtin.target.os.tag.isDarwin() and builtin.target.os.tag != .macos)
         false
     else
-        builtin.strip_debug_info,
+        !builtin.strip_debug_info,
 };
 
 test {


### PR DESCRIPTION
The Zig 0.16.0 update dropped the negation from the std default (!strip_debug_info), disabling stack traces in every unstripped build.

AI disclosure: Claude Fable was used to diagnose the problem and find the fix. Commit message was written by me.


Claude-Session: https://claude.ai/code/session_01QfzQME46DQXwMWa43bQaa3