### PR TITLE
build: update Sparkle to 2.9.4

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -160,7 +160,7 @@ jobs:
 
       - name: Setup Sparkle
         env:
-          SPARKLE_VERSION: 2.9.0
+          SPARKLE_VERSION: 2.9.4
         run: |
           mkdir -p .action/sparkle
           cd .action/sparkle
@@ -328,7 +328,7 @@ jobs:
 
       - name: Setup Sparkle
         env:
-          SPARKLE_VERSION: 2.9.0
+          SPARKLE_VERSION: 2.9.4
         run: |
           mkdir -p .action/sparkle
           cd .action/sparkle

--- a/.github/workflows/release-tip.yml
+++ b/.github/workflows/release-tip.yml
@@ -591,7 +591,7 @@ jobs:
       # Setup Sparkle
       - name: Setup Sparkle
         env:
-          SPARKLE_VERSION: 2.9.0
+          SPARKLE_VERSION: 2.9.4
         run: |
           mkdir -p .action/sparkle
           cd .action/sparkle
@@ -847,7 +847,7 @@ jobs:
       # Setup Sparkle
       - name: Setup Sparkle
         env:
-          SPARKLE_VERSION: 2.9.0
+          SPARKLE_VERSION: 2.9.4
         run: |
           mkdir -p .action/sparkle
           cd .action/sparkle
@@ -1044,7 +1044,7 @@ jobs:
       # Setup Sparkle
       - name: Setup Sparkle
         env:
-          SPARKLE_VERSION: 2.9.0
+          SPARKLE_VERSION: 2.9.4
         run: |
           mkdir -p .action/sparkle
           cd .action/sparkle

--- a/macos/Ghostty.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macos/Ghostty.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle",
       "state" : {
-        "revision" : "21d8df80440b1ca3b65fa82e40782f1e5a9e6ba2",
-        "version" : "2.9.0"
+        "revision" : "b6496a74a087257ef5e6da1c5b29a447a60f5bd7",
+        "version" : "2.9.4"
       }
     }
   ],


### PR DESCRIPTION
Update the macOS Sparkle dependency from 2.9.0 to 2.9.4.

This keeps the Swift package resolution and all tag/tip release workflow downloads aligned on the same version. Sparkle 2.9.2 included fixes for GHSA-g3hp-f6mg-559v and GHSA-hg88-v3cw-3qrh; 2.9.4 is the current stable release.

Validation:
- verified the 2.9.4 release contains `Sparkle-for-Swift-Package-Manager.zip`
- verified the lockfile revision matches the 2.9.4 tag
- `jq empty` on `Package.resolved`
- `git diff --check`

I could not run Xcode package resolution locally because the active developer directory is Command Line Tools rather than a full Xcode installation.