### PR TITLE
macOS: fix crash after toggling inspector

### DIFF
--- a/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView_AppKit.swift
@@ -160,6 +160,7 @@ extension Ghostty {
         // surface has been closed or no inspector is active.
         var inspector: Ghostty.Inspector? {
             guard let surface = self.surface else { return nil }
+            guard inspectorVisible else { return nil }
             guard let cInspector = ghostty_surface_inspector(surface) else { return nil }
             return Ghostty.Inspector(cInspector: cInspector)
         }


### PR DESCRIPTION
**The crash only happens when toggling from the surface's context menu, for around 1–6 times**

This should be around for a while, at least 1.3.1 can also reproduce it.

RC: When toggling the inspector off, `InspectorViewRepresentable.updateNSView` will be called, which will create a fresh inspector with `backend = null`. If one more `draw` during the tearing down is called, it will then cause the assert to panic.

<img width="1352" height="849" alt="image" src="https://github.com/user-attachments/assets/daa23e34-f6e8-412b-abba-f18cf0e7a104" />

> I could also delete the set in `updateNSView`, but that could lead to other issues I’m not sure of.


### AI Disclosure

I used Claude to investigate the rc. Its reasoning sounds solid, but its changes involve a lot of changes, I did and tested the final change myself.
