### PR TITLE
terminal: fix RefCountedSet living drift in addWithId resurrection

### DIFF
--- a/src/terminal/ref_counted_set.zig
+++ b/src/terminal/ref_counted_set.zig
@@ -339,9 +339,9 @@ pub fn RefCountedSet(
                     self.deleteItem(base, id, ctx);
                     const added_id = self.insert(base, value, id, ctx);
 
+                    const was_dead = items[added_id].meta.ref == 0;
                     items[added_id].meta.ref += 1;
-
-                    self.living += 1;
+                    if (was_dead) self.living += 1;
 
                     return if (added_id == id) null else added_id;
                 } else if (ctx.eql(value, items[id].value)) {
@@ -860,4 +860,57 @@ test "iterator visits live entries in ID order" {
     try testing.expectEqual(@as(u32, 33), last_entry.value_ptr.*);
 
     try testing.expect(it.next() == null);
+}
+
+test "addWithId preserves living count for a duplicate resurrection" {
+    const alloc = testing.allocator;
+    const TestSet = RefCountedSet(
+        u32,
+        u16,
+        u16,
+        struct {
+            pub fn hash(_: *const @This(), value: u32) u64 {
+                return std.hash.int(value);
+            }
+
+            pub fn eql(_: *const @This(), a: u32, b: u32) bool {
+                return a == b;
+            }
+        },
+    );
+
+    const layout: TestSet.Layout = .init(8);
+    const buf = try alloc.alignedAlloc(
+        u8,
+        TestSet.base_align,
+        layout.total_size,
+    );
+    defer alloc.free(buf);
+
+    var set: TestSet = .init(.init(buf), layout, .{});
+    const id_a = try set.add(buf, 11);
+    const id_b = try set.add(buf, 22);
+    set.release(buf, id_b);
+
+    const expected_count: usize = 1;
+    try testing.expectEqual(expected_count, set.count());
+
+    const added_id = try set.addWithId(buf, 11, id_b);
+    try testing.expectEqual(@as(?TestSet.Id, id_a), added_id);
+    try testing.expectEqual(expected_count, set.count());
+
+    for (0..256) |_| {
+        const before = set.count();
+        try testing.expectEqual(@as(?TestSet.Id, id_a), try set.addWithId(buf, 11, id_b));
+        try testing.expectEqual(before, set.count());
+
+        var it = set.iterator(buf);
+        var iterator_count: usize = 0;
+        while (it.next()) |_| iterator_count += 1;
+        try testing.expectEqual(set.count(), iterator_count);
+        try testing.expectEqual(
+            TestSet.capacityForCount(expected_count),
+            TestSet.capacityForCount(set.count()),
+        );
+    }
 }

--- a/src/terminal/snapshot/page.zig
+++ b/src/terminal/snapshot/page.zig
@@ -866,6 +866,81 @@ test "framed PAGE encode and decode a sparse native page" {
     );
 }
 
+test "PAGE style table count matches header after duplicate resurrection" {
+    var source = try TerminalPage.init(.{
+        .cols = 1,
+        .rows = 1,
+        .styles = 8,
+    });
+    defer source.deinit();
+
+    var destination = try TerminalPage.init(.{
+        .cols = 1,
+        .rows = 1,
+        .styles = 8,
+    });
+    defer destination.deinit();
+
+    const source_dead_id = try source.styles.add(
+        source.memory,
+        .{ .flags = .{ .italic = true } },
+    );
+    const source_style_id = try source.styles.add(
+        source.memory,
+        .{ .flags = .{ .bold = true } },
+    );
+    source.styles.release(source.memory, source_dead_id);
+
+    const source_rac = source.getRowAndCell(0, 0);
+    source_rac.row.styled = true;
+    source_rac.cell.* = .{
+        .content_tag = .codepoint,
+        .content = .{ .codepoint = .{ .data = 'A' } },
+        .style_id = source_style_id,
+    };
+
+    const destination_style_id = try destination.styles.add(
+        destination.memory,
+        .{ .flags = .{ .bold = true } },
+    );
+    const destination_dead_id = try destination.styles.add(
+        destination.memory,
+        .{ .flags = .{ .italic = true } },
+    );
+    destination.styles.release(destination.memory, destination_dead_id);
+    try std.testing.expectEqual(source_style_id, destination_dead_id);
+
+    try destination.cloneRowFrom(
+        &source,
+        destination.getRow(0),
+        source.getRow(0),
+    );
+    try std.testing.expectEqual(@as(usize, 1), destination.styles.count());
+    try std.testing.expectEqual(
+        destination_style_id,
+        destination.getRowAndCell(0, 0).cell.style_id,
+    );
+
+    var encoded: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer encoded.deinit();
+    try encodePayload(&destination, &encoded.writer);
+
+    var reader: std.Io.Reader = .fixed(encoded.written());
+    const header = try Header.decode(&reader);
+
+    var grid_counter: std.Io.Writer.Discarding = .init(&.{});
+    try grid.encode(&destination, &grid_counter.writer);
+
+    const style_entry_len = @sizeOf(TerminalStyleId) + style.len;
+    const grid_len: usize = @intCast(grid_counter.count);
+    const style_table_len = encoded.written().len - Header.len - grid_len;
+    try std.testing.expectEqual(@as(usize, 0), style_table_len % style_entry_len);
+    try std.testing.expectEqual(
+        header.style_count,
+        @as(u16, @intCast(style_table_len / style_entry_len)),
+    );
+}
+
 test "framed PAGE golden empty record" {
     const capacity: TerminalPageCapacity = .{
         .cols = 1,


### PR DESCRIPTION
## Summary

Fixes a reference-count drift bug in `RefCountedSet.addWithIdContext` when the dead-slot resurrection path encounters an already-live value under a different id.

### Root cause

The `living` counter is unconditionally incremented after `upsert()` in the resurrection branch. When `upsert` returns an already-live entry (the same value already exists under another id), no new live entry is created — the existing one is just referenced again. The unconditional increment causes `living` to permanently drift above the actual number of live entries yielded by `iterator()`.

### Impact

- `count()` returns inflated values, breaking the invariant `count() == iterator().len()`
- Downstream consumers that size buffers by `count()` (e.g. snapshot encoding) declare more entries than they actually write, causing decoders to reject the data
- Real-world symptom: terminal snapshot PAGE records declare `style_count=N` but encode fewer style entries, causing atomic restore to fail with a black screen

### Fix

Check whether the slot was dead (`meta.ref == 0`) before incrementing `living`. If `upsert` returned an already-live entry, `living` must not change.

```zig
// Before (buggy):
items[added_id].meta.ref += 1;
self.living += 1;

// After (fixed):
const was_dead = items[added_id].meta.ref == 0;
items[added_id].meta.ref += 1;
if (was_dead) self.living += 1;
```

### Tests

- Regression test in `ref_counted_set.zig`: dead-slot resurrection with existing live value; verifies `count() == iterator` length
- Snapshot-level test in `snapshot/page.zig`: PAGE encode output has `style_count` in header matching actual style table entry count
- Full test suite passes: 3749 pass, 18 skip
- Both regression tests fail on the unfixed code