### PR TITLE
macos: pulse osc 9;4 progress on a layer sibling

### DIFF
--- a/macos/Sources/Ghostty/Surface View/SurfaceProgressBar.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceProgressBar.swift
@@ -1,20 +1,29 @@
-import SwiftUI
+import AppKit
 
 /// The progress bar to show a surface progress report. We implement this from scratch because the
 /// standard ProgressView is broken on macOS 26 and this is simple anyways and gives us a ton of
 /// control.
-struct SurfaceProgressBar: View {
-    let report: Ghostty.Action.ProgressReport
+///
+/// A 2px sibling of the scroll view (not a Metal overlay) so WindowServer does
+/// not composite the terminal. Uses this view's own layer.
+final class SurfaceProgressBar: NSView {
+    static let hairlineHeight: CGFloat = 2
 
-    private var color: Color {
+    private var report: Ghostty.Action.ProgressReport?
+    private var timer: Timer?
+    private var pulse = PulsingProgressBar()
+
+    private var color: NSColor {
+        guard let report else { return .controlAccentColor }
         switch report.state {
-        case .error: return .red
-        case .pause: return .orange
-        default: return .accentColor
+        case .error: return .systemRed
+        case .pause: return .systemOrange
+        default: return .controlAccentColor
         }
     }
 
     private var progress: UInt8? {
+        guard let report else { return nil }
         // If we have an explicit progress use that.
         if let v = report.progress { return v }
 
@@ -25,6 +34,7 @@ struct SurfaceProgressBar: View {
     }
 
     private var accessibilityLabel: String {
+        guard let report else { return "Terminal progress" }
         switch report.state {
         case .error: return "Terminal progress - Error"
         case .pause: return "Terminal progress - Paused"
@@ -37,6 +47,7 @@ struct SurfaceProgressBar: View {
         if let progress {
             return "\(progress) percent complete"
         } else {
+            guard let report else { return "Indeterminate progress" }
             switch report.state {
             case .error: return "Operation failed"
             case .pause: return "Operation paused at completion"
@@ -46,67 +57,150 @@ struct SurfaceProgressBar: View {
         }
     }
 
-    var body: some View {
-        GeometryReader { geometry in
-            ZStack(alignment: .leading) {
-                if let progress {
-                    // Determinate progress bar with specific percentage
-                    Rectangle()
-                        .fill(color)
-                        .frame(
-                            width: geometry.size.width * CGFloat(progress) / 100,
-                            height: geometry.size.height
-                        )
-                        .animation(.easeInOut(duration: 0.2), value: progress)
-                } else {
-                    // Indeterminate states without specific progress - all use bouncing animation
-                    BouncingProgressBar(color: color)
-                }
-            }
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+        isHidden = true
+        setAccessibilityElement(true)
+        setAccessibilityRole(.progressIndicator)
+        setAccessibilityHidden(true)
+        // VoiceOver polls AXUpdatesFrequently instead of waiting on notifications.
+        _ = accessibilitySetOverrideValue(
+            true,
+            forAttribute: NSAccessibility.Attribute(rawValue: "AXUpdatesFrequently"))
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) is not supported for this view")
+    }
+
+    deinit {
+        timer?.invalidate()
+    }
+
+    override func hitTest(_ point: NSPoint) -> NSView? { nil }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        applyAppearance()
+    }
+
+    func setReport(_ report: Ghostty.Action.ProgressReport?) {
+        guard let report, report.state != .remove else {
+            self.report = nil
+            stopPulse()
+            isHidden = true
+            setAccessibilityHidden(true)
+            return
         }
-        .frame(height: 2)
-        .clipped()
-        .allowsHitTesting(false)
-        .accessibilityElement(children: .ignore)
-        .accessibilityAddTraits(.updatesFrequently)
-        .accessibilityLabel(accessibilityLabel)
-        .accessibilityValue(accessibilityValue)
+
+        self.report = report
+        isHidden = false
+        setAccessibilityHidden(false)
+        if let superview {
+            layoutHairline(in: superview.bounds)
+        } else {
+            applyAppearance()
+        }
+    }
+
+    /// Parent passes the surface bounds. Determinate shrinks width to the
+    /// percentage; indeterminate keeps the full width.
+    func layoutHairline(in container: NSRect) {
+        let y = container.height - Self.hairlineHeight
+        var width = container.width
+        if let progress {
+            width = container.width * CGFloat(progress) / 100
+        }
+        frame = CGRect(x: 0, y: y, width: width, height: Self.hairlineHeight)
+        applyAppearance()
+    }
+
+    private func applyAppearance() {
+        guard report != nil, !isHidden else { return }
+        setAccessibilityLabel(accessibilityLabel)
+        setAccessibilityValue(accessibilityValue)
+
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        if progress == nil {
+            layer?.backgroundColor = cgColor(color.withAlphaComponent(pulse.alpha))
+            CATransaction.commit()
+            if timer == nil {
+                startPulse()
+            }
+        } else {
+            stopPulse()
+            layer?.backgroundColor = cgColor(color)
+            CATransaction.commit()
+        }
+    }
+
+    private func startPulse() {
+        timer?.invalidate()
+        timer = nil
+        pulse.reset()
+        applyPulseColor()
+        let timer = Timer(timeInterval: PulsingProgressBar.interval, repeats: true) { [weak self] _ in
+            self?.stepPulse()
+        }
+        timer.tolerance = 0.01
+        RunLoop.main.add(timer, forMode: .common)
+        self.timer = timer
+    }
+
+    private func stopPulse() {
+        timer?.invalidate()
+        timer = nil
+        layer?.removeAllAnimations()
+    }
+
+    private func stepPulse() {
+        pulse.step()
+        applyPulseColor()
+    }
+
+    private func applyPulseColor() {
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        layer?.backgroundColor = cgColor(color.withAlphaComponent(pulse.alpha))
+        CATransaction.commit()
+    }
+
+    private func cgColor(_ color: NSColor) -> CGColor {
+        var result = color.cgColor
+        effectiveAppearance.performAsCurrentDrawingAppearance {
+            result = color.cgColor
+        }
+        return result
     }
 }
 
-/// Bouncing progress bar for indeterminate states
-private struct BouncingProgressBar: View {
-    let color: Color
-    @State private var position: CGFloat = 0
+/// Indeterminate full-width opacity pulse, 24 levels at 12 Hz.
+private struct PulsingProgressBar {
+    static let hz: Double = 12
+    static let steps: Int = 24
+    static let alphaOn: CGFloat = 1.0
+    static let alphaOff: CGFloat = 0.35
+    static var interval: TimeInterval { 1.0 / hz }
 
-    private let barWidthRatio: CGFloat = 0.25
+    var tick: Int = 0
 
-    var body: some View {
-        GeometryReader { geometry in
-            ZStack(alignment: .leading) {
-                Rectangle()
-                    .fill(color.opacity(0.3))
+    mutating func reset() {
+        tick = Self.steps - 1
+    }
 
-                Rectangle()
-                    .fill(color)
-                    .frame(
-                        width: geometry.size.width * barWidthRatio,
-                        height: geometry.size.height
-                    )
-                    .offset(x: position * (geometry.size.width * (1 - barWidthRatio)))
-            }
-        }
-        .onAppear {
-            withAnimation(
-                .easeInOut(duration: 1.2)
-                .repeatForever(autoreverses: true)
-            ) {
-                position = 1
-            }
-        }
-        .onDisappear {
-            position = 0
-        }
+    mutating func step() {
+        tick += 1
+    }
+
+    var alpha: CGFloat {
+        let n = Self.steps - 1
+        let period = 2 * n
+        let i = tick % period
+        let step = i <= n ? i : period - i
+        let t = CGFloat(step) / CGFloat(n)
+        return Self.alphaOff + (Self.alphaOn - Self.alphaOff) * t
     }
 }
-

--- a/macos/Sources/Ghostty/Surface View/SurfaceScrollView.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceScrollView.swift
@@ -12,10 +12,12 @@ import Combine
 /// - `scrollView`: The outermost NSScrollView that manages scrollbar rendering and behavior
 /// - `documentView`: A blank NSView whose height represents total scrollback (in pixels)
 /// - `surfaceView`: The actual Ghostty renderer, positioned to fill the visible rect
+/// - `progressBar`: 2px OSC 9;4 hairline, a sibling of `scrollView` (SurfaceView is layer-hosting)
 class SurfaceScrollView: NSView {
     private let scrollView: NSScrollView
     private let documentView: NSView
     private let surfaceView: Ghostty.SurfaceView
+    private let progressBar: SurfaceProgressBar
     private var observers: [NSObjectProtocol] = []
     private var cancellables: Set<AnyCancellable> = []
     private var isLiveScrolling = false
@@ -56,10 +58,15 @@ class SurfaceScrollView: NSView {
         // so that our primary Ghostty renderer only needs to render the viewport.
         documentView.addSubview(surfaceView)
 
+        progressBar = SurfaceProgressBar()
+
         super.init(frame: .zero)
 
-        // Our scroll view is our only view
+        // SurfaceView is layer-hosting (IOSurfaceLayer), so the progress
+        // bar is a sibling of the scroll view rather than a subview of it.
         addSubview(scrollView)
+        addSubview(progressBar)
+        progressBar.setReport(surfaceView.progressReport)
 
         // Apply initial scrollbar settings
         synchronizeAppearance()
@@ -149,6 +156,12 @@ class SurfaceScrollView: NSView {
                 self?.scrollView.documentCursor = newStyle.cursor
             }
             .store(in: &cancellables)
+        surfaceView.$progressReport
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] report in
+                self?.progressBar.setReport(report)
+            }
+            .store(in: &cancellables)
     }
 
     required init?(coder: NSCoder) {
@@ -170,6 +183,7 @@ class SurfaceScrollView: NSView {
         // Fill entire bounds with scroll view
         scrollView.frame = bounds
         surfaceView.frame.size = scrollView.bounds.size
+        progressBar.layoutHairline(in: bounds)
 
         // We only set the width of the documentView here, as the height depends
         // on the scrollbar state and is updated in synchronizeScrollView

--- a/macos/Sources/Ghostty/Surface View/SurfaceView.swift
+++ b/macos/Sources/Ghostty/Surface View/SurfaceView.swift
@@ -72,17 +72,6 @@ extension Ghostty {
                 }
                 .ghosttySurfaceView(surfaceView)
 
-                // Progress report
-                if let progressReport = surfaceView.progressReport, progressReport.state != .remove {
-                    VStack(spacing: 0) {
-                        SurfaceProgressBar(report: progressReport)
-                        Spacer()
-                    }
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-                    .allowsHitTesting(false)
-                    .transition(.opacity)
-                }
-
                 // Readonly indicator badge
                 if surfaceView.readonly {
                     ReadonlyBadge {


### PR DESCRIPTION
This PR dramatically reduces the resources used by a window displaying an indeterminate progress bar on macOS. Previously Ghostty would use ~6% and WindowServer ~40% when display a `printf '\033]9;4;3'` (indeterminate) progress bar, this change reduces that to Ghostty negligible and WindowServer ~5%. It does help with other progress bars as well, but they simply are much less animated to begin with.

---

Indeterminate OSC 9;4 progress used a SwiftUI repeatForever overlay on top of the Metal surface. That kept WindowServer compositing the whole terminal at display refresh for as long as a tool reported progress.

The bar is now a 2px NSView sibling of the scroll view, drawn with the view's own layer. Indeterminate is a full-width opacity pulse instead of a bouncing chunk: it changes opacity in 24 steps at 12 Hz with no interpolation between ticks, so the layer is not animated at display refresh.

AI: Grok & Claude used, code review, cleanup and manual tests performed the old fashioned way.