### PR TITLE
renderer: smooth scrollback

### DIFF
--- a/src/Surface.zig
+++ b/src/Surface.zig
@@ -316,6 +316,7 @@ const DerivedConfig = struct {
     mouse_hide_while_typing: bool,
     mouse_reporting: bool,
     mouse_scroll_multiplier: configpkg.MouseScrollMultiplier,
+    smooth_scrollback: configpkg.Config.SmoothScrollback,
     mouse_shift_capture: configpkg.MouseShiftCapture,
     fullscreen: configpkg.Fullscreen,
     macos_non_native_fullscreen: configpkg.NonNativeFullscreen,
@@ -396,6 +397,7 @@ const DerivedConfig = struct {
             .mouse_hide_while_typing = config.@"mouse-hide-while-typing",
             .mouse_reporting = config.@"mouse-reporting",
             .mouse_scroll_multiplier = config.@"mouse-scroll-multiplier",
+            .smooth_scrollback = config.@"smooth-scrollback",
             .mouse_shift_capture = config.@"mouse-shift-capture",
             .fullscreen = config.fullscreen,
             .macos_non_native_fullscreen = config.@"macos-non-native-fullscreen",
@@ -2843,7 +2845,12 @@ pub fn keyCallback(
             try self.setSelection(null);
         }
 
-        if (self.config.scroll_to_bottom.keystroke) self.io.terminal.scrollViewport(.bottom);
+        if (self.config.scroll_to_bottom.keystroke) {
+            self.io.terminal.scrollViewport(.bottom);
+            if (self.config.smooth_scrollback.any()) {
+                self.renderer_state.scroll.pinBottom(self.scrollbarMaxOffsetLocked());
+            }
+        }
 
         try self.queueRender();
     }
@@ -3466,37 +3473,37 @@ pub fn scrollCallback(
     // Always show the mouse again if it is hidden
     if (self.mouse.hidden) self.showMouse();
 
+    // We use cell height to determine if we have accumulated enough to trigger a scroll
+    const cell_height: f64 = @floatFromInt(self.size.cell.height);
+
+    // If we have precision scroll, yoff is the number of pixels to scroll. In non-precision
+    // scroll, yoff is the number of wheel ticks. Some mice are capable of reporting fractional
+    // wheel ticks, which don't necessarily get reported as precision scrolls. We normalize all
+    // scroll events to pixels by multiplying the wheel tick value and the cell size. This means
+    // that a wheel tick of 1 results in single scroll event.
+    const yoff_adjusted: f64 = if (yoff == 0) 0 else if (scroll_mods.precision)
+        yoff * self.config.mouse_scroll_multiplier.precision
+    else yoff_adjusted: {
+        if (comptime builtin.target.os.tag.isDarwin()) {
+            // Round out the yoff to an absolute minimum of 1. macos tries to
+            // simulate precision scrolling with non precision events by
+            // ramping up the magnitude of the offsets as it detects faster
+            // scrolling. Single click (very slow) scrolls are reported with a
+            // magnitude of 0.1 which would normally require a few clicks
+            // before we register an actual scroll event (depending on cell
+            // height and the mouse_scroll_multiplier setting).
+            const yoff_max: f64 = if (yoff > 0)
+                @max(yoff, 1)
+            else
+                @min(yoff, -1);
+
+            break :yoff_adjusted yoff_max * cell_height * self.config.mouse_scroll_multiplier.discrete;
+        } else {
+            break :yoff_adjusted yoff * cell_height * self.config.mouse_scroll_multiplier.discrete;
+        }
+    };
+
     const y: ScrollAmount = if (yoff == 0) .{} else y: {
-        // We use cell_size to determine if we have accumulated enough to trigger a scroll
-        const cell_size: f64 = @floatFromInt(self.size.cell.height);
-
-        // If we have precision scroll, yoff is the number of pixels to scroll. In non-precision
-        // scroll, yoff is the number of wheel ticks. Some mice are capable of reporting fractional
-        // wheel ticks, which don't necessarily get reported as precision scrolls. We normalize all
-        // scroll events to pixels by multiplying the wheel tick value and the cell size. This means
-        // that a wheel tick of 1 results in single scroll event.
-        const yoff_adjusted: f64 = if (scroll_mods.precision)
-            yoff * self.config.mouse_scroll_multiplier.precision
-        else yoff_adjusted: {
-            if (comptime builtin.target.os.tag.isDarwin()) {
-                // Round out the yoff to an absolute minimum of 1. macos tries to
-                // simulate precision scrolling with non precision events by
-                // ramping up the magnitude of the offsets as it detects faster
-                // scrolling. Single click (very slow) scrolls are reported with a
-                // magnitude of 0.1 which would normally require a few clicks
-                // before we register an actual scroll event (depending on cell
-                // height and the mouse_scroll_multiplier setting).
-                const yoff_max: f64 = if (yoff > 0)
-                    @max(yoff, 1)
-                else
-                    @min(yoff, -1);
-
-                break :yoff_adjusted yoff_max * cell_size * self.config.mouse_scroll_multiplier.discrete;
-            } else {
-                break :yoff_adjusted yoff * cell_size * self.config.mouse_scroll_multiplier.discrete;
-            }
-        };
-
         // Add our previously saved pending amount to the offset to get the
         // new offset value. The signs of the pending and yoff should match
         // so that we move further away from zero, but we don't assert
@@ -3506,15 +3513,15 @@ pub fn scrollCallback(
 
         // If the new offset is less than a single unit of scroll, we save
         // the new pending value and do not scroll yet.
-        if (@abs(poff) < cell_size) {
+        if (@abs(poff) < cell_height) {
             self.mouse.pending_scroll_y = poff;
             break :y .{};
         }
 
         // We scroll by the number of rows in the offset and save the remainder
-        const amount = poff / cell_size;
+        const amount = poff / cell_height;
         assert(@abs(amount) >= 1);
-        self.mouse.pending_scroll_y = poff - (amount * cell_size);
+        self.mouse.pending_scroll_y = poff - (amount * cell_height);
 
         // Round towards zero.
         const delta: isize = @intFromFloat(@trunc(amount));
@@ -3619,7 +3626,26 @@ pub fn scrollCallback(
             return;
         }
 
-        if (y.delta != 0) {
+        if (self.smoothScrollbackLocked(.mouse)) {
+            switch (scroll_mods.momentum) {
+                // Tap-to-stop (or a rest) interrupted OS inertia.
+                .cancelled, .stationary => {
+                    self.renderer_state.scroll.brake();
+                    self.mouse.pending_scroll_y = 0;
+                },
+                // Finger-down and OS momentum: follow the pixel delta.
+                // Discrete wheels still use velocity so they can coast.
+                .none, .began, .changed, .ended, .may_begin => if (yoff_adjusted != 0) {
+                    const delta_rows = yoff_adjusted / cell_height;
+                    if (scroll_mods.precision) {
+                        self.renderer_state.scroll.applyMousePan(delta_rows);
+                    } else {
+                        self.renderer_state.scroll.applyMouseImpulse(delta_rows);
+                    }
+                    self.mouse.pending_scroll_y = 0;
+                },
+            }
+        } else if (y.delta != 0) {
             // Modify our viewport, this requires a lock since it affects
             // rendering. We have to switch signs here because our delta
             // is negative down but our viewport is positive down.
@@ -4742,10 +4768,68 @@ pub fn colorSchemeCallback(self: *Surface, scheme: apprt.ColorScheme) !void {
 }
 
 pub fn posToViewport(self: Surface, xpos: f64, ypos: f64) terminal.point.Coordinate {
-    // Get our grid cell
+    // Get our grid cell. Fractional scroll shifts glyphs; hit testing
+    // uses the same pixel offset. A nonzero offset may include one
+    // extra row below the viewport.
     const coord: rendererpkg.Coordinate = .{ .surface = .{ .x = xpos, .y = ypos } };
-    const grid = coord.convert(.grid, self.size).grid;
-    return .{ .x = grid.x, .y = grid.y };
+    const offset_px: f64 = @as(f32, @bitCast(self.renderer_state.visual_offset_y.load(.monotonic)));
+    const term = coord.convert(.terminal, self.size).terminal;
+    const grid = self.size.grid();
+    const cell_width: f64 = @floatFromInt(self.size.cell.width);
+    const cell_height: f64 = @floatFromInt(self.size.cell.height);
+    const col: rendererpkg.GridSize.Unit = @intFromFloat(@max(0, term.x) / cell_width);
+    const row: rendererpkg.GridSize.Unit = @intFromFloat(@max(0, term.y - offset_px) / cell_height);
+    const max_row: rendererpkg.GridSize.Unit = if (offset_px == 0)
+        grid.rows - 1
+    else
+        grid.rows;
+    return .{
+        .x = @min(col, grid.columns - 1),
+        .y = @min(row, max_row),
+    };
+}
+
+/// Max scroll offset in rows (`scrollbar.total - scrollbar.len`).
+/// Precondition: renderer_state.mutex is held.
+fn scrollbarMaxOffsetLocked(self: *Surface) f64 {
+    const sb = self.io.terminal.screens.active.pages.scrollbar();
+    return @floatFromInt(sb.total -| sb.len);
+}
+
+/// True when this input should drive physics instead of snapping.
+/// Precondition: renderer_state.mutex is held.
+fn smoothScrollbackLocked(self: *const Surface, source: enum { mouse, key }) bool {
+    const enabled = switch (source) {
+        .mouse => self.config.smooth_scrollback.mouse,
+        .key => self.config.smooth_scrollback.key,
+    };
+    if (!enabled) return false;
+    if (self.io.terminal.screens.active_key == .alternate) return false;
+    if (self.isMouseReporting()) return false;
+    return true;
+}
+
+/// Apply a scrollback physics gesture. Returns true if consumed.
+fn smoothScrollback(self: *Surface, action: union(enum) {
+    top,
+    bottom,
+    page_up,
+    page_down,
+    impulse: f64,
+}) !bool {
+    self.renderer_state.mutex.lockUncancelable(global.io());
+    defer self.renderer_state.mutex.unlock(global.io());
+    if (!self.smoothScrollbackLocked(.key)) return false;
+    const rows: f64 = @floatFromInt(@max(self.size.grid().rows, 1));
+    switch (action) {
+        .top => self.renderer_state.scroll.seekExtreme(1),
+        .bottom => self.renderer_state.scroll.seekExtreme(-1),
+        .page_up => self.renderer_state.scroll.applyPageImpulse(1, rows),
+        .page_down => self.renderer_state.scroll.applyPageImpulse(-1, rows),
+        .impulse => |d| self.renderer_state.scroll.applyImpulse(d),
+    }
+    try self.queueRender();
+    return true;
 }
 
 /// Scroll to the bottom of the viewport.
@@ -4753,6 +4837,9 @@ pub fn posToViewport(self: Surface, xpos: f64, ypos: f64) terminal.point.Coordin
 /// Precondition: the render_state mutex must be held.
 fn scrollToBottom(self: *Surface) !void {
     self.io.terminal.scrollViewport(.{ .bottom = {} });
+    if (self.config.smooth_scrollback.any()) {
+        self.renderer_state.scroll.pinBottom(self.scrollbarMaxOffsetLocked());
+    }
     try self.queueRender();
 }
 
@@ -5215,13 +5302,13 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
         },
 
         .scroll_to_top => {
-            self.queueIo(.{
+            if (!try self.smoothScrollback(.top)) self.queueIo(.{
                 .scroll_viewport = .{ .top = {} },
             }, .unlocked);
         },
 
         .scroll_to_bottom => {
-            self.queueIo(.{
+            if (!try self.smoothScrollback(.bottom)) self.queueIo(.{
                 .scroll_viewport = .{ .bottom = {} },
             }, .unlocked);
         },
@@ -5231,7 +5318,12 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
                 self.renderer_state.mutex.lockUncancelable(global.io());
                 defer self.renderer_state.mutex.unlock(global.io());
                 const t: *terminal.Terminal = self.renderer_state.terminal;
+                const max_o = self.scrollbarMaxOffsetLocked();
+                const row: f64 = @floatFromInt(n);
                 t.screens.active.scroll(.{ .row = n });
+                if (self.config.smooth_scrollback.any()) {
+                    self.renderer_state.scroll.snapTo(row, max_o);
+                }
             }
 
             try self.queueRender();
@@ -5250,31 +5342,40 @@ pub fn performBindingAction(self: *Surface, action: input.Binding.Action) !bool 
         },
 
         .scroll_page_up => {
-            const rows: isize = @intCast(self.size.grid().rows);
-            self.queueIo(.{
-                .scroll_viewport = .{ .delta = -1 * rows },
-            }, .unlocked);
+            if (!try self.smoothScrollback(.page_up)) {
+                const rows: isize = @intCast(self.size.grid().rows);
+                self.queueIo(.{
+                    .scroll_viewport = .{ .delta = -1 * rows },
+                }, .unlocked);
+            }
         },
 
         .scroll_page_down => {
-            const rows: isize = @intCast(self.size.grid().rows);
-            self.queueIo(.{
-                .scroll_viewport = .{ .delta = rows },
-            }, .unlocked);
+            if (!try self.smoothScrollback(.page_down)) {
+                const rows: isize = @intCast(self.size.grid().rows);
+                self.queueIo(.{
+                    .scroll_viewport = .{ .delta = rows },
+                }, .unlocked);
+            }
         },
 
         .scroll_page_fractional => |fraction| {
-            const rows: f32 = @floatFromInt(self.size.grid().rows);
-            const delta: isize = @intFromFloat(@trunc(fraction * rows));
-            self.queueIo(.{
-                .scroll_viewport = .{ .delta = delta },
-            }, .unlocked);
+            const rows: f64 = @floatFromInt(@max(self.size.grid().rows, 1));
+            if (!try self.smoothScrollback(.{ .impulse = -@as(f64, fraction) * rows })) {
+                const grid_rows: f32 = @floatFromInt(self.size.grid().rows);
+                const delta: isize = @intFromFloat(@trunc(fraction * grid_rows));
+                self.queueIo(.{
+                    .scroll_viewport = .{ .delta = delta },
+                }, .unlocked);
+            }
         },
 
         .scroll_page_lines => |lines| {
-            self.queueIo(.{
-                .scroll_viewport = .{ .delta = lines },
-            }, .unlocked);
+            if (!try self.smoothScrollback(.{ .impulse = @floatFromInt(-lines) })) {
+                self.queueIo(.{
+                    .scroll_viewport = .{ .delta = lines },
+                }, .unlocked);
+            }
         },
 
         .jump_to_prompt => |delta| {

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -1001,6 +1001,33 @@ palette: Palette = .{},
 /// The default value is "3" for discrete devices and "1" for precision devices.
 @"mouse-scroll-multiplier": MouseScrollMultiplier = .default,
 
+/// Enable inertial scrolling of host scrollback. Motion can sit
+/// between rows. The format is a comma-separated list of options.
+/// Prefix an option with `no-` to disable it. Omitted options keep
+/// their default.
+///
+/// Available options:
+///
+/// - `mouse` Wheel coasts with friction and rests on a row. Trackpad
+///   and other precision devices follow pixel deltas, including OS
+///   inertia after lift, and can rest partway through a row.
+///
+/// - `key` Viewport scroll keybinds (page up/down, scroll to
+///   top/bottom) use coasting physics. Page up/down snap to a whole
+///   row on settle. Scroll to top/bottom land on the extremes.
+///
+/// - `jump` Find next/previous and other programmatic jumps (jump to
+///   prompt, jump to selection) ease to the target with the same
+///   accelerating cap as scroll to top/bottom.
+///
+/// `true` enables all options. `false` disables all options.
+///
+/// This only affects host scrollback on the primary screen. Alternate
+/// screen buffers, mouse reporting, and live PTY output stay discrete.
+///
+/// The default is `mouse, no-key, no-jump`.
+@"smooth-scrollback": SmoothScrollback = .default,
+
 /// The opacity level (opposite of transparency) of the background. A value of
 /// 1 is fully opaque and a value of 0 is fully transparent. A value less than 0
 /// or greater than 1 will be clamped to the nearest valid value.
@@ -10420,6 +10447,19 @@ pub const ScrollToBottom = packed struct {
     output: bool = false,
 
     pub const default: ScrollToBottom = .{};
+};
+
+/// See smooth-scrollback
+pub const SmoothScrollback = packed struct {
+    mouse: bool = true,
+    key: bool = false,
+    jump: bool = false,
+
+    pub const default: SmoothScrollback = .{};
+
+    pub fn any(self: SmoothScrollback) bool {
+        return self.mouse or self.key or self.jump;
+    }
 };
 
 /// See notify-on-command-finish

--- a/src/renderer.zig
+++ b/src/renderer.zig
@@ -12,6 +12,7 @@ const build_config = @import("build_config.zig");
 const cursor = @import("renderer/cursor.zig");
 const message = @import("renderer/message.zig");
 const size = @import("renderer/size.zig");
+pub const ScrollPhysics = @import("renderer/ScrollPhysics.zig");
 pub const shadertoy = @import("renderer/shadertoy.zig");
 pub const Backend = @import("renderer/backend.zig").Backend;
 pub const GenericRenderer = @import("renderer/generic.zig").Renderer;
@@ -61,6 +62,7 @@ test {
     _ = message;
     _ = shadertoy;
     _ = size;
+    _ = ScrollPhysics;
     _ = Thread;
     _ = State;
 }

--- a/src/renderer/ScrollPhysics.zig
+++ b/src/renderer/ScrollPhysics.zig
@@ -1,0 +1,669 @@
+//! Continuous scroll position in row units.
+//!
+//! `position == 0` is the top of scrollback. `position == max_offset` is
+//! pinned to the active bottom. Motion stays inside `[0, max_offset]`.
+//!
+//! Host scrollback only. Live PTY output while pinned snaps with no cap.
+//! Alternate-screen and mouse reporting must not call these methods.
+
+const std = @import("std");
+
+const ScrollPhysics = @This();
+
+/// Continuous offset into the scrollable range (rows from top of history).
+position: f64 = 0,
+/// Rows per second.
+velocity: f64 = 0,
+/// When true, stick to the bottom as new output arrives.
+pinned_to_bottom: bool = true,
+
+friction: f64 = 2,
+/// Keybind impulse (`scroll_page_lines` and similar) → velocity scale.
+impulse_scale: f64 = 4,
+/// Decay for the active coast. Wheel and page use 3× `friction`;
+/// key impulse uses `friction`.
+coast_friction: f64 = 2,
+/// Page-key coast. Settle snaps to a whole row so floor() is not 1 off.
+page_coast: bool = false,
+/// Discrete-wheel coast. Skips `visualCap`.
+mouse_coast: bool = false,
+/// Starting visual cap (rows/frame). Grows with `run_time` until unrestricted.
+/// Key and jump seeks only; mouse/trackpad coasts ignore it.
+max_rows_per_frame: f64 = 1.0,
+/// Seconds for the cap to double. ~1.4s to pass 64 rows/frame.
+accel_halflife: f64 = 0.2,
+
+settle_pos: f64 = 0.02,
+settle_vel: f64 = 0.05,
+/// Absolute row offset to chase (`jump`). Same accelerating cap as
+/// `seekExtreme`; null = not chasing a point.
+seek_target: ?f64 = null,
+/// Chase the live bottom until we arrive (`scroll_to_bottom`).
+seek_follows_bottom: bool = false,
+/// Chase the top of history until we arrive (`scroll_to_top`).
+seek_follows_top: bool = false,
+/// Seconds of continuous scrollback motion. Zero after a real stop.
+run_time: f64 = 0,
+
+/// Integer row for the PageList viewport (clamped into range).
+pub fn integerRow(self: *const ScrollPhysics, max_offset: f64) u64 {
+    const max_o = @max(0, max_offset);
+    if (self.position <= 0) return 0;
+    if (self.position >= max_o) return @intFromFloat(@floor(max_o));
+    return @intFromFloat(@floor(self.position));
+}
+
+/// Fractional part in [0, 1). Pixel shift: `y += visualOffsetRows * cell_height`.
+pub fn visualOffsetRows(self: *const ScrollPhysics, max_offset: f64) f64 {
+    const max_o = @max(0, max_offset);
+    const p = std.math.clamp(self.position, 0, max_o);
+    const frac = p - @floor(p);
+    return -frac;
+}
+
+/// Wheel impulse. Not visual-capped. Coasts about `delta_rows` at page
+/// friction (3×). Positive `delta_rows` moves toward older history.
+pub fn applyMouseImpulse(self: *ScrollPhysics, delta_rows: f64) void {
+    self.impulse(delta_rows, true);
+}
+
+/// Trackpad/precision pan. Moves the viewport by `delta_rows` this event
+/// (finger-down and OS momentum). Does not add our own coast.
+pub fn applyMousePan(self: *ScrollPhysics, delta_rows: f64) void {
+    if (@abs(delta_rows) < 1e-9) return;
+    self.resetAccelIfChase();
+    self.seek_target = null;
+    self.seek_follows_bottom = false;
+    self.seek_follows_top = false;
+    self.pinned_to_bottom = false;
+    self.page_coast = false;
+    self.mouse_coast = true;
+    self.position -= delta_rows;
+    self.velocity = 0;
+}
+
+/// Keybind impulse (`scroll_page_lines` and similar). Visual-capped.
+pub fn applyImpulse(self: *ScrollPhysics, delta_rows: f64) void {
+    self.impulse(delta_rows, false);
+}
+
+fn impulse(self: *ScrollPhysics, delta_rows: f64, mouse: bool) void {
+    if (@abs(delta_rows) < 1e-9) return;
+    self.resetAccelIfChase();
+    self.seek_target = null;
+    self.seek_follows_bottom = false;
+    self.seek_follows_top = false;
+    self.pinned_to_bottom = false;
+    self.page_coast = false;
+    self.mouse_coast = mouse;
+    // +impulse → older history → lower position → negative velocity.
+    if (mouse) {
+        self.coast_friction = @max(self.friction, 0.05) * 3;
+        self.velocity -= delta_rows * self.coast_friction;
+    } else {
+        self.coast_friction = @max(self.friction, 0.05);
+        self.velocity -= delta_rows * self.impulse_scale;
+    }
+}
+
+/// Stop coasting. Keeps the current offset and pin state.
+pub fn brake(self: *ScrollPhysics) void {
+    self.velocity = 0;
+    self.page_coast = false;
+    self.clearAccel();
+}
+
+/// Page Up/Down: coast one viewport minus a row. `direction` +1 = older,
+/// −1 = toward bottom. Key-repeat stacks another kick on velocity.
+pub fn applyPageImpulse(
+    self: *ScrollPhysics,
+    direction: f64,
+    viewport_rows: f64,
+) void {
+    if (@abs(direction) < 1e-9) return;
+    self.resetAccelIfChase();
+    self.seek_target = null;
+    self.seek_follows_bottom = false;
+    self.seek_follows_top = false;
+    self.pinned_to_bottom = false;
+    self.page_coast = true;
+    self.mouse_coast = false;
+    self.coast_friction = @max(self.friction, 0.05) * 3;
+    const vp = @max(1, viewport_rows - 1);
+    self.velocity -= direction * vp * self.coast_friction;
+    self.run_time = @max(self.run_time, 1.5);
+}
+
+/// Coast to the top (`direction` +1) or bottom (−1). Always reaches the extreme.
+pub fn seekExtreme(self: *ScrollPhysics, direction: f64) void {
+    if (@abs(direction) < 1e-9) return;
+    self.resetAccelIfChase();
+    self.seek_target = null;
+    self.page_coast = false;
+    self.mouse_coast = false;
+    self.pinned_to_bottom = false;
+    self.seek_follows_top = direction > 0;
+    self.seek_follows_bottom = direction < 0;
+}
+
+/// Jump to top of scrollback.
+pub fn pinTop(self: *ScrollPhysics) void {
+    self.seek_target = null;
+    self.seek_follows_bottom = false;
+    self.seek_follows_top = false;
+    self.page_coast = false;
+    self.clearAccel();
+    self.position = 0;
+    self.velocity = 0;
+    self.pinned_to_bottom = false;
+}
+
+/// Jump to bottom and pin.
+pub fn pinBottom(self: *ScrollPhysics, max_offset: f64) void {
+    const max_o = @max(0, max_offset);
+    self.seek_target = null;
+    self.seek_follows_bottom = false;
+    self.seek_follows_top = false;
+    self.page_coast = false;
+    self.clearAccel();
+    self.position = max_o;
+    self.velocity = 0;
+    self.pinned_to_bottom = true;
+}
+
+/// Coast to an absolute offset. Same accelerating visual cap as `seekExtreme`.
+pub fn smoothTo(self: *ScrollPhysics, offset: f64, max_offset: f64) void {
+    const max_o = @max(0, max_offset);
+    const goal = std.math.clamp(offset, 0, max_o);
+    self.resetAccelIfChase();
+    self.pinned_to_bottom = false;
+    self.page_coast = false;
+    self.mouse_coast = false;
+    self.seek_follows_bottom = false;
+    self.seek_follows_top = false;
+    if (@abs(goal - self.position) < 0.35) {
+        self.seek_target = null;
+        self.position = goal;
+        self.velocity = 0;
+        if (@abs(goal - max_o) < self.settle_pos) {
+            self.pinBottom(max_o);
+        }
+        return;
+    }
+    self.seek_target = goal;
+}
+
+/// Drop the oldest `n` history rows (scrollback cap trim).
+/// The same lines stay on screen; their index in the remaining buffer
+/// is smaller. Does not pin.
+pub fn trimTop(self: *ScrollPhysics, n: f64) void {
+    if (n <= 0) return;
+    self.position = @max(0, self.position - n);
+    if (self.seek_target) |target| {
+        self.seek_target = @max(0, target - n);
+    }
+}
+
+/// When pinned, live output sticks to the bottom with no speed cap.
+pub fn followBottomIfPinned(self: *ScrollPhysics, max_offset: f64) void {
+    if (!self.pinned_to_bottom) return;
+    const max_o = @max(0, max_offset);
+    self.position = max_o;
+    self.velocity = 0;
+}
+
+/// Integrate one frame. Returns true if still moving (needs redraw).
+pub fn step(self: *ScrollPhysics, dt_raw: f64, max_offset: f64) bool {
+    const max_o = @max(0, max_offset);
+    const dt = std.math.clamp(dt_raw, 0, 0.05);
+
+    if (self.pinned_to_bottom) {
+        self.seek_target = null;
+        self.seek_follows_bottom = false;
+        self.seek_follows_top = false;
+        self.position = max_o;
+        self.velocity = 0;
+        self.clearAccel();
+        return false;
+    }
+
+    if (self.seek_follows_top) {
+        if (self.position <= self.settle_pos) {
+            self.position = 0;
+            self.velocity = 0;
+            self.seek_follows_top = false;
+            self.clearAccel();
+            return false;
+        }
+        self.velocity = -self.position / @max(dt, 1.0 / 240.0);
+    } else if (self.seek_follows_bottom) {
+        if (self.position >= max_o - self.settle_pos) {
+            self.pinBottom(max_o);
+            return false;
+        }
+        const remaining = max_o - self.position;
+        self.velocity = remaining / @max(dt, 1.0 / 240.0);
+    } else if (self.seek_target) |target| {
+        const goal = std.math.clamp(target, 0, max_o);
+        const remaining = goal - self.position;
+        if (@abs(remaining) <= self.settle_pos) {
+            self.position = goal;
+            self.velocity = 0;
+            self.seek_target = null;
+            self.clearAccel();
+            if (@abs(self.position - max_o) < self.settle_pos) {
+                self.pinBottom(max_o);
+            }
+            return false;
+        }
+        self.velocity = remaining / @max(dt, 1.0 / 240.0);
+    }
+
+    const seeking = self.seek_follows_bottom or self.seek_follows_top or self.seek_target != null;
+    // A coalesced wakeup can tick with dt ≈ 0. Do not treat that as settled.
+    if (dt <= 0) return self.stillMoving();
+
+    const max_delta = self.visualCap();
+    if (!seeking and @abs(self.velocity) < self.settle_vel) {
+        // Apply first so a sub-cell nudge off the prompt is not re-pinned.
+        const toward_history = self.velocity < 0;
+        self.finishCoast(max_o, toward_history);
+        return false;
+    }
+    const uncapped = if (seeking) self.velocity * dt else self.coastDisplacement(dt);
+    const delta = if (seeking or !self.mouse_coast)
+        std.math.clamp(uncapped, -max_delta, max_delta)
+    else
+        uncapped;
+    self.run_time += dt;
+    self.position += delta;
+    if (self.clampToRange(max_o)) {
+        self.velocity = 0;
+        self.page_coast = false;
+        self.seek_follows_top = false;
+        self.seek_target = null;
+        if (self.pinned_to_bottom) {
+            self.clearAccel();
+            return false;
+        }
+    } else if (!seeking) {
+        self.velocity *= @exp(-self.coast_friction * dt);
+        if (@abs(self.velocity) < self.settle_vel) {
+            self.finishCoast(max_o, self.velocity < 0);
+        }
+    }
+
+    if (self.stillMoving()) return true;
+    self.clearAccel();
+    return false;
+}
+
+/// Exact ∫ v e^{-μt} dt over this frame (exponential coast, not Euler).
+fn coastDisplacement(self: *const ScrollPhysics, dt: f64) f64 {
+    const mu = self.coast_friction;
+    if (mu <= 1e-12) return self.velocity * dt;
+    const decay = @exp(-mu * dt);
+    return self.velocity * (1.0 - decay) / mu;
+}
+
+fn finishCoast(self: *ScrollPhysics, max_o: f64, toward_history: bool) void {
+    if (self.page_coast) {
+        self.position = @round(self.position);
+        self.page_coast = false;
+    }
+    self.velocity = 0;
+    self.clearAccel();
+    if (self.position <= 0) {
+        self.position = 0;
+    } else if (self.position >= max_o - self.settle_pos and !toward_history) {
+        self.pinBottom(max_o);
+    }
+}
+
+fn stillMoving(self: *const ScrollPhysics) bool {
+    return @abs(self.velocity) > self.settle_vel or
+        self.seek_follows_bottom or
+        self.seek_follows_top or
+        self.seek_target != null;
+}
+
+/// Rows allowed this frame: 1 at t=0, doubles every `accel_halflife`.
+/// Used for key and jump seeks, not mouse/trackpad coasts.
+fn visualCap(self: *const ScrollPhysics) f64 {
+    const start = @max(self.max_rows_per_frame, 0.05);
+    const t = @max(self.run_time, 0);
+    const h = @max(self.accel_halflife, 0.05);
+    return start * std.math.pow(f64, 2.0, t / h);
+}
+
+/// Sync continuous position from the grid after an external change.
+/// Pin only when the viewport is actually at the live bottom. A leftover
+/// `pinned_to_bottom` must not jump a history view to the prompt.
+pub fn syncFromScrollbar(
+    self: *ScrollPhysics,
+    offset: f64,
+    max_offset: f64,
+    force_pin_if_active: bool,
+) void {
+    const max_o = @max(0, max_offset);
+    if (force_pin_if_active) {
+        self.pinBottom(max_o);
+        return;
+    }
+    // Don't fight an active chase with hard snaps from scrollbar growth.
+    if (self.seek_target != null) return;
+    self.snapTo(offset, max_o);
+}
+
+/// Instantly adopt an absolute offset (scrollbar thumb). Cancels seeks.
+pub fn snapTo(self: *ScrollPhysics, offset: f64, max_offset: f64) void {
+    const max_o = @max(0, max_offset);
+    const goal = std.math.clamp(offset, 0, max_o);
+    self.seek_target = null;
+    self.seek_follows_bottom = false;
+    self.seek_follows_top = false;
+    self.page_coast = false;
+    self.mouse_coast = false;
+    self.clearAccel();
+    if (@abs(goal - max_o) < self.settle_pos) {
+        self.pinBottom(max_o);
+        return;
+    }
+    self.pinned_to_bottom = false;
+    self.position = goal;
+    self.velocity = 0;
+}
+
+/// Returns true if an edge was hit.
+fn clampToRange(self: *ScrollPhysics, max_o: f64) bool {
+    if (self.position <= 0) {
+        self.position = 0;
+        return true;
+    }
+    // A short first frame from the prompt must not re-pin a history fling.
+    if (self.position >= max_o - self.settle_pos and self.velocity >= 0) {
+        self.pinBottom(max_o);
+        return true;
+    }
+    if (self.position > max_o) self.position = max_o;
+    return false;
+}
+
+fn clearAccel(self: *ScrollPhysics) void {
+    self.run_time = 0;
+}
+
+/// Restart the cap for a new gesture (chase, pin), not a continued fling
+/// or a retargeted chase (find next while already seeking).
+fn resetAccelIfChase(self: *ScrollPhysics) void {
+    if (self.seek_follows_bottom or self.seek_follows_top or self.pinned_to_bottom) {
+        self.clearAccel();
+        self.velocity = 0;
+    }
+}
+
+test "ScrollPhysics applyPageImpulse coasts about one viewport" {
+    const testing = std.testing;
+
+    var p: ScrollPhysics = .{};
+    p.pinBottom(400);
+    p.applyPageImpulse(1, 20);
+    var n: usize = 0;
+    while (n < 300 and p.step(1.0 / 60.0, 400)) : (n += 1) {}
+    try testing.expectEqual(@as(f64, 381), p.position);
+    try testing.expectEqual(@as(u64, 381), p.integerRow(400));
+}
+
+test "ScrollPhysics applyPageImpulse up then down returns" {
+    const testing = std.testing;
+
+    var p: ScrollPhysics = .{};
+    p.pinBottom(400);
+    p.applyPageImpulse(1, 20);
+    var n: usize = 0;
+    while (n < 300 and p.step(1.0 / 60.0, 400)) : (n += 1) {}
+    try testing.expectEqual(@as(f64, 381), p.position);
+    p.applyPageImpulse(-1, 20);
+    n = 0;
+    while (n < 300 and p.step(1.0 / 60.0, 400)) : (n += 1) {}
+    try testing.expect(p.pinned_to_bottom);
+    try testing.expectEqual(@as(f64, 400), p.position);
+}
+
+test "ScrollPhysics applyPageImpulse repeat adds another viewport" {
+    const testing = std.testing;
+
+    var p: ScrollPhysics = .{};
+    p.pinBottom(400);
+    p.applyPageImpulse(1, 20);
+    _ = p.step(1.0 / 60.0, 400);
+    p.applyPageImpulse(1, 20);
+    var n: usize = 0;
+    while (n < 120 and p.step(1.0 / 60.0, 400)) : (n += 1) {}
+    try testing.expectEqual(@as(f64, 362), p.position);
+}
+
+test "ScrollPhysics applyPageImpulse survives a zero-dt tick" {
+    const testing = std.testing;
+
+    var p: ScrollPhysics = .{};
+    p.pinBottom(400);
+    p.applyPageImpulse(1, 20);
+    try testing.expect(p.step(0, 400));
+    try testing.expect(!p.pinned_to_bottom);
+    try testing.expect(p.velocity != 0);
+    try testing.expectEqual(@as(f64, 400), p.position);
+}
+
+test "ScrollPhysics applyPageImpulse survives a sub-ms tick from bottom" {
+    const testing = std.testing;
+
+    var p: ScrollPhysics = .{};
+    p.pinBottom(400);
+    p.applyPageImpulse(1, 20);
+    try testing.expect(p.step(0.0001, 400));
+    try testing.expect(!p.pinned_to_bottom);
+    try testing.expect(p.velocity != 0);
+}
+
+test "ScrollPhysics applyMousePan follows delta" {
+    const testing = std.testing;
+
+    var p: ScrollPhysics = .{};
+    p.pinBottom(400);
+    p.applyMousePan(10);
+    try testing.expect(!p.pinned_to_bottom);
+    try testing.expectEqual(@as(f64, 390), p.position);
+    try testing.expectEqual(@as(f64, 0), p.velocity);
+    try testing.expect(p.step(1.0 / 60.0, 400) == false);
+    try testing.expectEqual(@as(f64, 390), p.position);
+}
+
+test "ScrollPhysics mouse impulse coasts about the delta" {
+    const testing = std.testing;
+
+    var p: ScrollPhysics = .{};
+    p.pinBottom(500);
+    p.applyMouseImpulse(8);
+    var n: usize = 0;
+    while (n < 400 and p.step(1.0 / 60.0, 500)) : (n += 1) {}
+    try testing.expectApproxEqAbs(@as(f64, 492), p.position, 0.25);
+    try testing.expect(!p.pinned_to_bottom);
+}
+
+test "ScrollPhysics mouse impulse is not visual-capped" {
+    const testing = std.testing;
+
+    var mouse: ScrollPhysics = .{};
+    mouse.pinBottom(400);
+    mouse.applyMouseImpulse(100);
+    try testing.expect(mouse.step(1.0 / 60.0, 400));
+    const mouse_moved = 400 - mouse.position;
+
+    var key: ScrollPhysics = .{};
+    key.pinBottom(400);
+    key.applyImpulse(100);
+    try testing.expect(key.step(1.0 / 60.0, 400));
+    const key_moved = 400 - key.position;
+
+    try testing.expect(mouse_moved > key_moved);
+    try testing.expect(key_moved <= 1.0 + 1e-9);
+    try testing.expect(mouse_moved > 1);
+}
+
+test "ScrollPhysics applyImpulse unpins from bottom" {
+    const testing = std.testing;
+
+    var p: ScrollPhysics = .{};
+    p.pinBottom(100);
+    p.applyImpulse(0.02);
+    try testing.expect(!p.pinned_to_bottom);
+    var n: usize = 0;
+    while (n < 300 and p.step(1.0 / 60.0, 100)) : (n += 1) {}
+    try testing.expect(!p.pinned_to_bottom);
+    try testing.expect(p.position < 100);
+}
+
+test "ScrollPhysics brake zeros velocity without pinning" {
+    const testing = std.testing;
+
+    var p: ScrollPhysics = .{};
+    p.pinBottom(100);
+    p.applyImpulse(2);
+    try testing.expect(p.step(1.0 / 60.0, 100));
+    try testing.expect(!p.pinned_to_bottom);
+    try testing.expect(p.velocity != 0);
+    const pos = p.position;
+    p.brake();
+    try testing.expectEqual(@as(f64, 0), p.velocity);
+    try testing.expectEqual(pos, p.position);
+    try testing.expect(!p.pinned_to_bottom);
+    try testing.expect(!p.step(1.0 / 60.0, 100));
+    try testing.expectEqual(pos, p.position);
+    try testing.expect(!p.pinned_to_bottom);
+}
+
+test "ScrollPhysics seekExtreme reaches bottom" {
+    const testing = std.testing;
+
+    var p: ScrollPhysics = .{};
+    p.pinTop();
+    p.seekExtreme(-1);
+    try testing.expect(p.seek_follows_bottom);
+    var n: usize = 0;
+    while (n < 120 and p.step(1.0 / 60.0, 80)) : (n += 1) {}
+    try testing.expect(p.pinned_to_bottom);
+    try testing.expectEqual(@as(f64, 80), p.position);
+}
+
+test "ScrollPhysics step stays in range" {
+    const testing = std.testing;
+
+    var p: ScrollPhysics = .{};
+    p.pinTop();
+    for (0..8) |_| p.applyPageImpulse(1, 20);
+    for (0..60) |_| {
+        _ = p.step(1.0 / 60.0, 50);
+        try testing.expect(p.position >= 0);
+        try testing.expect(p.position <= 50);
+    }
+    p.pinBottom(50);
+    for (0..8) |_| p.applyPageImpulse(-1, 20);
+    for (0..60) |_| {
+        _ = p.step(1.0 / 60.0, 50);
+        try testing.expect(p.position >= 0);
+        try testing.expect(p.position <= 50);
+    }
+}
+
+test "ScrollPhysics seekExtreme reaches top" {
+    const testing = std.testing;
+
+    var p: ScrollPhysics = .{};
+    p.pinBottom(80);
+    p.seekExtreme(1);
+    var n: usize = 0;
+    while (n < 120 and p.step(1.0 / 60.0, 80)) : (n += 1) {}
+    try testing.expect(!p.pinned_to_bottom);
+    try testing.expectEqual(@as(f64, 0), p.position);
+}
+
+test "ScrollPhysics visualOffsetRows is negated fraction" {
+    const testing = std.testing;
+
+    var p: ScrollPhysics = .{};
+    p.pinned_to_bottom = false;
+    p.position = 10.25;
+    try testing.expectEqual(@as(u64, 10), p.integerRow(100));
+    try testing.expectEqual(@as(f64, -0.25), p.visualOffsetRows(100));
+}
+
+test "ScrollPhysics smoothTo settles mid-history unpinned" {
+    const testing = std.testing;
+
+    var p: ScrollPhysics = .{};
+    p.pinBottom(100);
+    p.smoothTo(50, 100);
+    var n: usize = 0;
+    while (n < 240 and p.step(1.0 / 60.0, 100)) : (n += 1) {}
+    try testing.expect(!p.pinned_to_bottom);
+    try testing.expectEqual(@as(f64, 50), p.position);
+}
+
+test "ScrollPhysics trimTop past position stays at top" {
+    const testing = std.testing;
+
+    var p: ScrollPhysics = .{};
+    p.pinned_to_bottom = false;
+    p.position = 50;
+    p.trimTop(60);
+    try testing.expect(!p.pinned_to_bottom);
+    try testing.expectEqual(@as(f64, 0), p.position);
+    _ = p.step(1.0 / 60.0, 40);
+    try testing.expect(!p.pinned_to_bottom);
+    try testing.expectEqual(@as(f64, 0), p.position);
+}
+
+test "ScrollPhysics trimTop shifts seek target" {
+    const testing = std.testing;
+
+    var p: ScrollPhysics = .{};
+    p.pinned_to_bottom = false;
+    p.position = 80;
+    p.smoothTo(50, 100);
+    p.trimTop(10);
+    try testing.expectEqual(@as(f64, 70), p.position);
+    try testing.expectEqual(@as(f64, 40), p.seek_target.?);
+}
+
+test "ScrollPhysics syncFromScrollbar history does not pin" {
+    const testing = std.testing;
+
+    var p: ScrollPhysics = .{};
+    try testing.expect(p.pinned_to_bottom);
+    p.syncFromScrollbar(20, 100, false);
+    try testing.expect(!p.pinned_to_bottom);
+    try testing.expectEqual(@as(f64, 20), p.position);
+}
+
+test "ScrollPhysics syncFromScrollbar bottom pins" {
+    const testing = std.testing;
+
+    var p: ScrollPhysics = .{};
+    p.pinTop();
+    p.syncFromScrollbar(80, 80, true);
+    try testing.expect(p.pinned_to_bottom);
+    try testing.expectEqual(@as(f64, 80), p.position);
+}
+
+test "ScrollPhysics snapTo cancels seek" {
+    const testing = std.testing;
+
+    var p: ScrollPhysics = .{};
+    p.pinBottom(100);
+    p.smoothTo(0, 100);
+    p.snapTo(20, 100);
+    try testing.expect(!p.pinned_to_bottom);
+    try testing.expect(p.seek_target == null);
+    try testing.expectEqual(@as(f64, 20), p.position);
+}

--- a/src/renderer/State.zig
+++ b/src/renderer/State.zig
@@ -8,7 +8,7 @@ const Allocator = std.mem.Allocator;
 const Inspector = @import("../inspector/main.zig").Inspector;
 const terminalpkg = @import("../terminal/main.zig");
 const inputpkg = @import("../input.zig");
-const renderer = @import("../renderer.zig");
+const ScrollPhysics = @import("ScrollPhysics.zig");
 
 /// The mutex that must be held while reading any of the data in the
 /// members of this state. Note that the state itself is NOT protected
@@ -18,6 +18,14 @@ mutex: *std.Io.Mutex,
 
 /// The terminal data.
 terminal: *terminalpkg.Terminal,
+
+/// Host-scrollback physics. Mutated under `mutex` by the surface (impulses)
+/// and the renderer (integration). Unused when `smooth-scrollback` is off.
+scroll: ScrollPhysics = .{},
+
+/// Pixel Y offset for fractional scrolling, packed as f32 bits so the UI
+/// thread can read it without the terminal mutex. Written by the renderer.
+visual_offset_y: std.atomic.Value(u32) = .init(0),
 
 /// The terminal inspector, if any. This will be null while the inspector
 /// is not active and will be set when it is active.

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -255,6 +255,21 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
         /// wakeup.
         kitty_animation_next_ms: ?u64 = null,
 
+        /// True while scroll physics still has velocity or a seek in flight.
+        /// Drives animationWake so coasting continues after the grid is clean.
+        smooth_scrollback_moving: bool = false,
+        /// Fractional row offset from ScrollPhysics, applied as a pixel
+        /// shift in `uniforms.content_offset`.
+        smooth_visual_offset_rows: f64 = 0,
+        /// Last integer viewport row we applied from physics. Used to detect
+        /// external viewport changes (scrollbar, jump-to-prompt, etc.).
+        smooth_scrollback_applied_row: ?usize = null,
+        /// Last PageList `scrollbar.total`. Used to detect history-cap trims
+        /// from the top so physics can `trimTop` instead of seeking.
+        smooth_scrollback_last_total: ?usize = null,
+        /// Previous physics tick, for dt.
+        smooth_scrollback_last_tick: ?std.Io.Timestamp = null,
+
         const HighlightTag = enum(u8) {
             search_match,
             search_match_selected,
@@ -583,6 +598,8 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             background_blur: configpkg.Config.BackgroundBlur,
             scroll_to_bottom_on_output: bool,
             custom_shader_animation: configpkg.CustomShaderAnimation,
+            smooth_scrollback: configpkg.Config.SmoothScrollback,
+            mouse_reporting: bool,
 
             pub fn init(
                 alloc_gpa: Allocator,
@@ -658,6 +675,8 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     .background_blur = config.@"background-blur",
                     .scroll_to_bottom_on_output = config.@"scroll-to-bottom".output,
                     .custom_shader_animation = config.@"custom-shader-animation",
+                    .smooth_scrollback = config.@"smooth-scrollback",
+                    .mouse_reporting = config.@"mouse-reporting",
                     .arena = arena,
                 };
             }
@@ -1066,8 +1085,17 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 break :kitty @max(next -| now_ms, draw_interval_ms);
             };
 
+            const scroll_delay: ?u64 = if (self.smooth_scrollback_moving)
+                draw_interval_ms
+            else
+                null;
+
             // An update wake includes a draw, so it wins ties.
-            if (kitty_delay) |k| {
+            var update_delay: ?u64 = kitty_delay;
+            if (scroll_delay) |s| {
+                update_delay = if (update_delay) |k| @min(k, s) else s;
+            }
+            if (update_delay) |k| {
                 if (shader_delay == null or k <= shader_delay.?) {
                     return .{ .delay_ms = k, .kind = .update };
                 }
@@ -1342,6 +1370,11 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     state.terminal.scrollViewport(.bottom);
                 }
 
+                // Integrate host-scrollback physics and apply the integer
+                // viewport before we snapshot render state, so the extra
+                // row and pin match this frame.
+                self.tickSmoothScrollback(state);
+
                 // Begin the update of our terminal state. Work that
                 // doesn't require terminal access (e.g. style
                 // denormalization) is deferred to the endUpdate call
@@ -1598,10 +1631,106 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
 
                 // Update custom shader uniforms that depend on terminal state.
                 self.updateCustomShaderUniformsFromState();
+
+                // Fractional scroll pixel shift. Set every frame so coasting
+                // does not depend on a grid resize.
+                self.uniforms.content_offset = .{
+                    0,
+                    @floatCast(self.smooth_visual_offset_rows *
+                        @as(f64, @floatFromInt(self.grid_metrics.cell_height))),
+                };
             }
 
             // Start the display link now that the rebuilt frame is ready.
             self.syncDisplayLink(null, null);
+        }
+
+        /// Step host-scrollback physics and sync the integer viewport.
+        /// Caller must hold the terminal mutex (the updateFrame critical section).
+        fn tickSmoothScrollback(self: *Self, state: *renderer.State) void {
+            const now: std.Io.Timestamp = .now(global.io(), .awake);
+            const dt: f64 = dt: {
+                defer self.smooth_scrollback_last_tick = now;
+                const last = self.smooth_scrollback_last_tick orelse break :dt 1.0 / 60.0;
+                const ns: f64 = @floatFromInt(last.durationTo(now).nanoseconds);
+                break :dt std.math.clamp(ns / std.time.ns_per_s, 0, 0.05);
+            };
+
+            const t = state.terminal;
+            const alt = t.screens.active_key == .alternate;
+            // Same predicate as Surface.smoothScrollbackLocked: mouse tracking
+            // only takes over when reporting is actually enabled.
+            const mouse = self.config.mouse_reporting and t.flags.mouse_event != .none;
+            if (!self.config.smooth_scrollback.any() or alt or mouse) {
+                self.terminal_state.paint_extra_rows = 0;
+                self.smooth_visual_offset_rows = 0;
+                self.smooth_scrollback_moving = false;
+                self.smooth_scrollback_applied_row = null;
+                self.smooth_scrollback_last_total = null;
+                // Leave pin/position; the next enabled tick syncs from the grid.
+                state.visual_offset_y.store(0, .monotonic);
+                return;
+            }
+
+            const sb = t.screens.active.pages.scrollbar();
+            const max_o: f64 = @floatFromInt(sb.total -| sb.len);
+            self.applyHistoryTrim(state, sb);
+
+            if (self.smooth_scrollback_applied_row) |applied| {
+                if (applied != sb.offset) {
+                    // Find, jump-to-prompt, and similar paths move the
+                    // integer viewport out from under us. If we are pinned
+                    // to the bottom, syncFromScrollbar would snap back and
+                    // undo that. Chase the new offset with the same
+                    // accelerating cap as Home/End.
+                    if (t.screens.active.viewportIsBottom()) {
+                        state.scroll.pinBottom(max_o);
+                    } else if (self.config.smooth_scrollback.jump) {
+                        state.scroll.smoothTo(@floatFromInt(sb.offset), max_o);
+                    } else {
+                        state.scroll.snapTo(@floatFromInt(sb.offset), max_o);
+                    }
+                }
+            } else {
+                state.scroll.syncFromScrollbar(
+                    @floatFromInt(sb.offset),
+                    max_o,
+                    t.screens.active.viewportIsBottom(),
+                );
+            }
+
+            state.scroll.followBottomIfPinned(max_o);
+            const moving = state.scroll.step(dt, max_o);
+            const target: usize = @intCast(state.scroll.integerRow(max_o));
+            if (target != sb.offset) {
+                t.scrollViewport(.{ .row = target });
+            }
+            self.smooth_scrollback_applied_row = target;
+            self.smooth_visual_offset_rows = state.scroll.visualOffsetRows(max_o);
+            self.smooth_scrollback_moving = moving;
+
+            self.terminal_state.paint_extra_rows =
+                if (@abs(self.smooth_visual_offset_rows) < 1e-6) 0 else 1;
+
+            const px: f32 = @floatCast(
+                self.smooth_visual_offset_rows *
+                    @as(f64, @floatFromInt(self.grid_metrics.cell_height)),
+            );
+            state.visual_offset_y.store(@bitCast(px), .monotonic);
+        }
+
+        /// Trim physics only when PageList remapped `offset` by the same `n`.
+        fn applyHistoryTrim(self: *Self, state: *renderer.State, sb: terminal.Scrollbar) void {
+            const total = sb.total;
+            defer self.smooth_scrollback_last_total = total;
+            if (state.scroll.pinned_to_bottom) return;
+            const prev_total = self.smooth_scrollback_last_total orelse return;
+            if (total >= prev_total) return;
+            const n = prev_total - total;
+            const off = self.smooth_scrollback_applied_row orelse return;
+            if (off < n or off - n != sb.offset) return;
+            state.scroll.trimTop(@floatFromInt(n));
+            self.smooth_scrollback_applied_row = sb.offset;
         }
 
         /// Draw the frame to the screen.

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -727,6 +727,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     .grid_size = undefined,
                     .grid_padding = undefined,
                     .screen_size = undefined,
+                    .content_offset = .{ 0, 0 },
                     .padding_extend = .{},
                     .min_contrast = options.config.min_contrast,
                     .cursor_pos = .{ std.math.maxInt(u16), std.math.maxInt(u16) },
@@ -2148,7 +2149,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 self.size.padding,
                 .{
                     .columns = self.cells.size.columns,
-                    .rows = self.cells.size.rows,
+                    .rows = self.terminal_state.rows,
                 },
                 .{
                     .width = self.grid_metrics.cell_width,
@@ -2507,13 +2508,14 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
         ) Allocator.Error!void {
             const state: *terminal.RenderState = &self.terminal_state;
 
+            const paint_rows: u16 = @intCast(state.row_data.len);
             const grid_size_diff =
-                self.cells.size.rows != state.rows or
+                self.cells.size.rows != paint_rows or
                 self.cells.size.columns != state.cols;
 
             if (grid_size_diff) {
                 var new_size = self.cells.size;
-                new_size.rows = state.rows;
+                new_size.rows = paint_rows;
                 new_size.columns = state.cols;
                 try self.cells.resize(self.alloc, new_size);
 
@@ -2561,7 +2563,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             // the viewport is shorter than the cell contents buffer, we align
             // the top of the viewport with the top of the contents buffer.
             const row_len: usize = @min(
-                state.rows,
+                state.row_data.len,
                 self.cells.size.rows,
             );
 
@@ -2573,6 +2575,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 // don't show it.
                 const cursor_vp = state.cursor.viewport orelse
                     break :preedit null;
+                if (cursor_vp.y >= row_dirty.len) break :preedit null;
 
                 // If our preedit row isn't dirty then we don't need the
                 // preedit range. This also avoids an issue later where we
@@ -2642,6 +2645,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 // a cursor. Otherwise, get our cursor cell, because we may
                 // need it for styling.
                 const cursor_vp = state.cursor.viewport orelse break :cursor;
+                if (cursor_vp.y >= state.row_data.len) break :cursor;
                 const cursor_style: terminal.Style = cursor_style: {
                     const cells = state.row_data.items(.cells);
                     const cell = cells[cursor_vp.y].get(cursor_vp.x);

--- a/src/renderer/metal/shaders.zig
+++ b/src/renderer/metal/shaders.zig
@@ -199,6 +199,10 @@ pub const Uniforms = extern struct {
     /// Size of a single cell in pixels, unscaled.
     cell_size: [2]f32 align(8),
 
+    /// Pixel offset applied to the grid for fractional (smooth) scrolling.
+    /// Typically `(0, -frac * cell_height)`.
+    content_offset: [2]f32 align(8) = .{ 0, 0 },
+
     /// Size of the grid in columns and rows.
     grid_size: [2]u16 align(4),
 

--- a/src/renderer/opengl/shaders.zig
+++ b/src/renderer/opengl/shaders.zig
@@ -165,6 +165,10 @@ pub const Uniforms = extern struct {
     /// Size of a single cell in pixels, unscaled.
     cell_size: [2]f32 align(8),
 
+    /// Pixel offset applied to the grid for fractional (smooth) scrolling.
+    /// Typically `(0, -frac * cell_height)`.
+    content_offset: [2]f32 align(8) = .{ 0, 0 },
+
     /// Size of the grid in columns and rows.
     grid_size: [2]u16 align(4),
 

--- a/src/renderer/shaders/glsl/cell_bg.f.glsl
+++ b/src/renderer/shaders/glsl/cell_bg.f.glsl
@@ -12,7 +12,7 @@ layout(binding = 1, std430) readonly buffer bg_cells {
 
 vec4 cell_bg() {
     uvec2 grid_size = unpack2u16(grid_size_packed_2u16);
-    ivec2 grid_pos = ivec2(floor((gl_FragCoord.xy - grid_padding.wx) / cell_size));
+    ivec2 grid_pos = ivec2(floor((gl_FragCoord.xy - grid_padding.wx - content_offset) / cell_size));
     bool use_linear_blending = (bools & USE_LINEAR_BLENDING) != 0;
 
     vec4 bg = vec4(0.0);

--- a/src/renderer/shaders/glsl/cell_text.v.glsl
+++ b/src/renderer/shaders/glsl/cell_text.v.glsl
@@ -47,7 +47,7 @@ void main() {
     bool use_linear_blending = (bools & USE_LINEAR_BLENDING) != 0;
 
     // Convert the grid x, y into world space x, y by accounting for cell size
-    vec2 cell_pos = cell_size * vec2(grid_pos);
+    vec2 cell_pos = cell_size * vec2(grid_pos) + content_offset;
 
     int vid = gl_VertexID;
 

--- a/src/renderer/shaders/glsl/common.glsl
+++ b/src/renderer/shaders/glsl/common.glsl
@@ -15,6 +15,7 @@ layout(binding = 1, std140) uniform Globals {
     uniform mat4 projection_matrix;
     uniform vec2 screen_size;
     uniform vec2 cell_size;
+    uniform vec2 content_offset;
     uniform uint grid_size_packed_2u16;
     uniform vec4 grid_padding;
     uniform uint padding_extend;

--- a/src/renderer/shaders/glsl/image.v.glsl
+++ b/src/renderer/shaders/glsl/image.v.glsl
@@ -40,7 +40,7 @@ void main() {
 
     // The position of our image starts at the top-left of the grid cell and
     // adds the source rect width/height components.
-    vec2 image_pos = (cell_size * grid_pos) + cell_offset;
+    vec2 image_pos = (cell_size * grid_pos) + cell_offset + content_offset;
     image_pos += dest_size * corner;
 
     gl_Position = projection_matrix * vec4(image_pos.xy, 1.0, 1.0);

--- a/src/renderer/shaders/shaders.metal
+++ b/src/renderer/shaders/shaders.metal
@@ -13,6 +13,7 @@ struct Uniforms {
   float4x4 projection_matrix;
   float2 screen_size;
   float2 cell_size;
+  float2 content_offset;
   ushort2 grid_size;
   float4 grid_padding;
   uint8_t padding_extend;
@@ -453,7 +454,7 @@ fragment float4 cell_bg_fragment(
   constant Uniforms& uniforms [[buffer(1)]],
   constant uchar4 *cells [[buffer(2)]]
 ) {
-  int2 grid_pos = int2(floor((in.position.xy - uniforms.grid_padding.wx) / uniforms.cell_size));
+  int2 grid_pos = int2(floor((in.position.xy - uniforms.grid_padding.wx - uniforms.content_offset) / uniforms.cell_size));
 
   float4 bg = float4(0.0);
 
@@ -560,7 +561,7 @@ vertex CellTextVertexOut cell_text_vertex(
   constant uchar4 *bg_colors [[buffer(2)]]
 ) {
   // Convert the grid x, y into world space x, y by accounting for cell size
-  float2 cell_pos = uniforms.cell_size * float2(in.grid_pos);
+  float2 cell_pos = uniforms.cell_size * float2(in.grid_pos) + uniforms.content_offset;
 
   // We use a triangle strip with 4 vertices to render quads,
   // so we determine which corner of the cell this vertex is in
@@ -820,7 +821,7 @@ vertex ImageVertexOut image_vertex(
 
   // The position of our image starts at the top-left of the grid cell and
   // adds the source rect width/height components.
-  float2 image_pos = (uniforms.cell_size * in.grid_pos) + in.cell_offset;
+  float2 image_pos = (uniforms.cell_size * in.grid_pos) + in.cell_offset + uniforms.content_offset;
   image_pos += in.dest_size * corner;
 
   out.position =

--- a/src/terminal/render.zig
+++ b/src/terminal/render.zig
@@ -82,13 +82,20 @@ pub const RenderState = struct {
     rows: size.CellCountInt,
     cols: size.CellCountInt,
 
+    /// Extra document rows to collect below the viewport so fractional
+    /// scrolling can fill the gap at the bottom. `row_data` is
+    /// `rows` plus however many of these exist below the viewport.
+    /// Set by the caller before `beginUpdate`; this is a maximum.
+    paint_extra_rows: u8 = 0,
+
     /// The color state for the terminal.
     colors: Colors,
 
     /// Cursor state within the viewport.
     cursor: Cursor,
 
-    /// The rows (y=0 is top) of the viewport. Guaranteed to be `rows` length.
+    /// The rows (y=0 is top) of the viewport, plus `paint_extra_rows`
+    /// trailing document rows when they exist.
     ///
     /// This is a MultiArrayList because only the update cares about
     /// the allocators. Callers care about all the other properties, and
@@ -147,6 +154,7 @@ pub const RenderState = struct {
         .row_data = .empty,
         .dirty = .false,
         .screen = .primary,
+        .paint_extra_rows = 0,
     };
 
     /// The color state for the terminal.
@@ -377,6 +385,18 @@ pub const RenderState = struct {
     ) Allocator.Error!void {
         const s: *Screen = t.screens.active;
         const viewport_pin = s.pages.getTopLeft(.viewport);
+        const extra: usize = extra: {
+            if (self.paint_extra_rows == 0) break :extra 0;
+            const br = s.pages.getBottomRight(.viewport) orelse break :extra 0;
+            var n: usize = 0;
+            var pin = br;
+            while (n < self.paint_extra_rows) {
+                pin = pin.down(1) orelse break :extra n;
+                n += 1;
+            }
+            break :extra n;
+        };
+        const paint_rows: usize = @as(usize, s.pages.rows) + extra;
         const redraw = redraw: {
             // If our screen key changed, we need to do a full rebuild
             // because our render state is viewport-specific.
@@ -400,7 +420,8 @@ pub const RenderState = struct {
 
             // If our dimensions changed, we do a full rebuild.
             if (self.rows != s.pages.rows or
-                self.cols != s.pages.cols)
+                self.cols != s.pages.cols or
+                self.row_data.len != paint_rows)
             {
                 break :redraw true;
             }
@@ -456,22 +477,21 @@ pub const RenderState = struct {
             }
         }
 
-        // Ensure our row length is exactly our height, freeing or allocating
-        // data as necessary. In most cases we'll have a perfectly matching
-        // size.
-        if (self.row_data.len != self.rows) {
+        // Ensure our row length is the viewport plus any extra rows
+        // collected for fractional scrolling.
+        if (self.row_data.len != paint_rows) {
             @branchHint(.unlikely);
 
-            if (self.row_data.len < self.rows) {
+            if (self.row_data.len < paint_rows) {
                 // Resize our rows to the desired length, marking any added
                 // values undefined.
                 const old_len = self.row_data.len;
-                try self.row_data.resize(alloc, self.rows);
+                try self.row_data.resize(alloc, paint_rows);
 
                 // Initialize all our values. Its faster to use slice() + set()
                 // because appendAssumeCapacity does this multiple times.
                 var row_data = self.row_data.slice();
-                for (old_len..self.rows) |y| {
+                for (old_len..paint_rows) |y| {
                     row_data.set(y, .{
                         .arena = .{},
                         .pin = undefined,
@@ -487,16 +507,16 @@ pub const RenderState = struct {
             } else {
                 const row_data = self.row_data.slice();
                 for (
-                    row_data.items(.arena)[self.rows..],
-                    row_data.items(.cells)[self.rows..],
-                    row_data.items(.applied_styles)[self.rows..],
+                    row_data.items(.arena)[paint_rows..],
+                    row_data.items(.cells)[paint_rows..],
+                    row_data.items(.applied_styles)[paint_rows..],
                 ) |state, *cell, *applied| {
                     var arena: ArenaAllocator = state.promote(alloc);
                     arena.deinit();
                     cell.deinit(alloc);
                     applied.deinit(alloc);
                 }
-                self.row_data.shrinkRetainingCapacity(self.rows);
+                self.row_data.shrinkRetainingCapacity(paint_rows);
             }
         }
 
@@ -538,18 +558,19 @@ pub const RenderState = struct {
         var y: usize = 0;
         var any_dirty: bool = false;
         var page_it = viewport_pin.pageIterator(.right_down, null);
-        while (y < self.rows) {
+        while (y < paint_rows) {
             const chunk = page_it.next() orelse break;
             const node = chunk.node;
             const node_serial = node.serial;
             const p: *page.Page = node.page();
 
             // The number of rows we consume from this chunk. The chunk
-            // may extend beyond the viewport (the viewport is always
-            // exactly `rows` tall) so we clamp.
+            // may extend beyond the viewport (we collect up to
+            // `paint_extra_rows` past the viewport for fractional
+            // scrolling) so we clamp.
             const take: usize = @min(
                 @as(usize, chunk.end - chunk.start),
-                self.rows - y,
+                paint_rows - y,
             );
 
             // Find our cursor if we haven't found it yet. We do this even
@@ -650,7 +671,7 @@ pub const RenderState = struct {
 
             y += take;
         }
-        assert(y == self.rows);
+        assert(y == paint_rows);
 
         // If our screen has a selection, then mark the rows with the
         // selection. We do this outside of the loop above because its unlikely


### PR DESCRIPTION
I am opening this PR because native smooth scroll back with a trackpad feels and looks absolutely magical compared to the current chunky line based jumps.

I've been using it for a few days across both macOS and Linux in my DD Ghostty branch: https://github.com/j-c-m/ghostty/tree/j-c-m

This follows the pixel delta. Finger down, the grid moves with you. Lift, and the OS coast keeps going. You can rest between rows. Tap, and it stops. Same input path as Safari. The terminal finally uses it.

Default is smooth-scrollback = mouse, no-key, no-jump. Page keys, find, and jump-to-prompt stay discrete unless you turn key / jump on. Alternate screen, mouse reporting, and live PTY output stay discrete.

Depends on the fractional-row painting included in this PR.

It does merge conflict with https://github.com/ghostty-org/ghostty/pull/14053, but I have already resolved, if needed. It's easier to merge this commit first.

AI: Some Grok & Claude, but less than I would have liked.

