### PR TITLE
libghostty-vt: let the png decode hook report an allocation cap

### DIFF
--- a/example/c-vt-kitty-graphics/src/main.c
+++ b/example/c-vt-kitty-graphics/src/main.c
@@ -40,6 +40,8 @@ bool decode_png(void* userdata,
   out->height = 1;
   out->data = pixels;
   out->data_len = pixel_len;
+  /* The allocation is exactly the pixel data, so there is no surplus. */
+  out->data_extra = 0;
   return true;
 }
 //! [kitty-graphics-decode-png]

--- a/include/ghostty/vt/sys.h
+++ b/include/ghostty/vt/sys.h
@@ -49,6 +49,12 @@ extern "C" {
  * The `data` buffer must be allocated through the allocator provided to
  * the decode callback. The library takes ownership and will free it
  * with the same allocator.
+ *
+ * The allocator requires the allocation length to free, so a decoder that
+ * allocates more than it fills must report the surplus in `data_extra`.
+ * This lets a decoder over-allocate (round up to a block size, reuse a
+ * buffer sized for the largest image it expects, and so on) instead of
+ * sizing every allocation exactly.
  */
 typedef struct {
     /** Image width in pixels. */
@@ -62,6 +68,15 @@ typedef struct {
 
     /** Length of the pixel data in bytes. */
     size_t data_len;
+
+    /**
+     * Number of bytes allocated beyond `data_len`, when the decoder
+     * allocated more than it filled. The library frees the buffer with
+     * `data_len + data_extra` bytes.
+     *
+     * Leave this as 0 when the allocation is exactly `data_len` bytes.
+     */
+    size_t data_extra;
 } GhosttySysImage;
 
 /**
@@ -109,6 +124,9 @@ typedef void (*GhosttySysLogFn)(
  * Decodes raw PNG data into RGBA pixels. The output pixel data must be
  * allocated through the provided allocator. The library takes ownership
  * of the buffer and will free it with the same allocator.
+ *
+ * Set `out->data_extra` if the allocation is larger than the pixel data,
+ * otherwise leave it at 0. See GhosttySysImage.
  *
  * @param userdata  The userdata pointer set via GHOSTTY_SYS_OPT_USERDATA
  * @param allocator The allocator to use for the output pixel buffer

--- a/src/terminal/c/sys.zig
+++ b/src/terminal/c/sys.zig
@@ -12,6 +12,7 @@ pub const Image = extern struct {
     height: u32,
     data: ?[*]u8,
     data_len: usize,
+    data_extra: usize,
 };
 
 /// C: GhosttySysDecodePngFn
@@ -96,15 +97,33 @@ fn decodePngWrapper(
     const func = global.decode_png orelse return error.InvalidData;
 
     const c_alloc = CAllocator.fromZig(&alloc);
-    var out: Image = undefined;
+
+    // Zero-initialized so that a callback that doesn't know about `data_extra`
+    // leaves it at zero rather than reading back whatever was on the stack.
+    var out: Image = .{
+        .width = 0,
+        .height = 0,
+        .data = null,
+        .data_len = 0,
+        .data_extra = 0,
+    };
     if (!func(global.userdata, &c_alloc, data.ptr, data.len, &out)) return error.InvalidData;
 
     const result_data = out.data orelse return error.InvalidData;
+
+    // The callback may allocate more than it fills, so the allocation is the
+    // pixel data plus whatever surplus it reported. Checked because both
+    // lengths come from the callback: on overflow we have no idea how much
+    // was really allocated, so we reject the image rather than free a wrong
+    // length. That leaks the buffer, which beats corrupting the allocator.
+    const capacity = std.math.add(usize, out.data_len, out.data_extra) catch
+        return error.InvalidData;
 
     return .{
         .width = out.width,
         .height = out.height,
         .data = result_data[0..out.data_len],
+        .capacity = capacity,
     };
 }
 
@@ -298,7 +317,7 @@ test "set decode_png with null clears" {
 test "set decode_png installs wrapper" {
     const S = struct {
         fn decode(_: ?*anyopaque, _: *const CAllocator, _: [*]const u8, _: usize, out: *Image) callconv(lib.calling_conv) bool {
-            out.* = .{ .width = 1, .height = 1, .data = null, .data_len = 0 };
+            out.* = .{ .width = 1, .height = 1, .data = null, .data_len = 0, .data_extra = 0 };
             return true;
         }
     };
@@ -312,6 +331,123 @@ test "set decode_png installs wrapper" {
     // Clear it again.
     try std.testing.expectEqual(Result.success, set(.decode_png, null));
     try std.testing.expect(terminal_sys.decode_png == null);
+}
+
+test "decode_png over-allocates and reports the surplus" {
+    const testing = std.testing;
+
+    // Allocates twice the pixel data and reports the surplus.
+    // testing.allocator asserts the free length matches, so this only
+    // passes if we free data_len + data_extra and not data_len.
+    const S = struct {
+        const pixels = 4;
+        const allocated = pixels * 2;
+
+        fn decode(
+            _: ?*anyopaque,
+            alloc: *const CAllocator,
+            _: [*]const u8,
+            _: usize,
+            out: *Image,
+        ) callconv(lib.calling_conv) bool {
+            const buf = alloc.zig().alloc(u8, allocated) catch return false;
+            @memset(buf, 0);
+            out.* = .{
+                .width = 1,
+                .height = 1,
+                .data = buf.ptr,
+                .data_len = pixels,
+                .data_extra = allocated - pixels,
+            };
+            return true;
+        }
+    };
+
+    try testing.expectEqual(Result.success, set(.decode_png, @ptrCast(&S.decode)));
+    defer _ = set(.decode_png, null);
+
+    const func = terminal_sys.decode_png.?;
+    const image = try func(testing.allocator, "");
+
+    // The image is the pixel data, not the whole allocation.
+    try testing.expectEqual(@as(usize, S.pixels), image.data.len);
+    try testing.expectEqual(@as(usize, S.allocated), image.capacity);
+
+    image.deinit(testing.allocator);
+}
+
+test "decode_png with no surplus frees the pixel data" {
+    const testing = std.testing;
+
+    // A callback that doesn't set data_extra. The allocation is exactly the
+    // pixel data, which is the behavior before data_extra existed.
+    const S = struct {
+        const pixels = 4;
+
+        fn decode(
+            _: ?*anyopaque,
+            alloc: *const CAllocator,
+            _: [*]const u8,
+            _: usize,
+            out: *Image,
+        ) callconv(lib.calling_conv) bool {
+            const buf = alloc.zig().alloc(u8, pixels) catch return false;
+            @memset(buf, 0);
+            out.* = .{
+                .width = 1,
+                .height = 1,
+                .data = buf.ptr,
+                .data_len = pixels,
+                .data_extra = 0,
+            };
+            return true;
+        }
+    };
+
+    try testing.expectEqual(Result.success, set(.decode_png, @ptrCast(&S.decode)));
+    defer _ = set(.decode_png, null);
+
+    const func = terminal_sys.decode_png.?;
+    const image = try func(testing.allocator, "");
+
+    try testing.expectEqual(@as(usize, S.pixels), image.data.len);
+    try testing.expectEqual(@as(usize, S.pixels), image.capacity);
+
+    image.deinit(testing.allocator);
+}
+
+test "decode_png rejects lengths that overflow" {
+    const testing = std.testing;
+
+    // A surplus that overflows when added to the pixel length. We can't know
+    // the real allocation size, so the image is rejected. `data` points at
+    // static memory here so that rejecting it without freeing is not a leak.
+    const S = struct {
+        var buf: [4]u8 = @splat(0);
+
+        fn decode(
+            _: ?*anyopaque,
+            _: *const CAllocator,
+            _: [*]const u8,
+            _: usize,
+            out: *Image,
+        ) callconv(lib.calling_conv) bool {
+            out.* = .{
+                .width = 1,
+                .height = 1,
+                .data = &buf,
+                .data_len = std.math.maxInt(usize),
+                .data_extra = 1,
+            };
+            return true;
+        }
+    };
+
+    try testing.expectEqual(Result.success, set(.decode_png, @ptrCast(&S.decode)));
+    defer _ = set(.decode_png, null);
+
+    const func = terminal_sys.decode_png.?;
+    try testing.expectError(error.InvalidData, func(testing.allocator, ""));
 }
 
 test "set log with null clears" {

--- a/src/terminal/kitty/graphics_image.zig
+++ b/src/terminal/kitty/graphics_image.zig
@@ -637,7 +637,7 @@ pub const LoadingImage = struct {
             else
                 return error.OutOfMemory,
         };
-        defer decode_alloc.free(result.data);
+        defer result.deinit(decode_alloc);
 
         if (result.data.len > max_size) {
             log.warn("png image too large size={} max_size={}", .{ result.data.len, max_size });
@@ -1574,6 +1574,7 @@ test "image load: png rejects oversized decoder allocation" {
                 .width = 1,
                 .height = 1,
                 .data = data,
+                .capacity = data.len,
             };
         }
     }.decode;

--- a/src/terminal/sys.zig
+++ b/src/terminal/sys.zig
@@ -24,12 +24,24 @@ pub const DecodeError = Allocator.Error || error{InvalidData};
 pub const DecodePngFn = *const fn (Allocator, []const u8) DecodeError!Image;
 
 /// The result of decoding an image. The caller owns the returned data
-/// and must free it with the same allocator that was passed to the
-/// decode function.
+/// and must free it with `deinit` using the same allocator that was
+/// passed to the decode function.
 pub const Image = struct {
     width: u32,
     height: u32,
+
+    /// The decoded RGBA pixel data.
     data: []u8,
+
+    /// The number of bytes allocated for `data`. Decoders are allowed to
+    /// over-allocate, so this can be larger than `data.len`, and it is the
+    /// length the allocation must be freed with. Use `deinit` rather than
+    /// freeing `data` directly.
+    capacity: usize,
+
+    pub fn deinit(self: Image, alloc: Allocator) void {
+        alloc.free(self.data.ptr[0..self.capacity]);
+    }
 };
 
 fn decodePngWuffs(
@@ -50,6 +62,7 @@ fn decodePngWuffs(
         .width = result.width,
         .height = result.height,
         .data = result.data,
+        .capacity = result.data.len,
     };
 }
 


### PR DESCRIPTION
Fixes #12163

GhosttySysImage only carried data_len, and the library freed the pixel buffer
with that length. The allocator needs the real allocation length to free, so a
decode callback had to allocate exactly the pixel data. A buffer rounded up to
a block size, or one reused across images, had no way to be described.

Adds data_cap, the number of bytes allocated for data, which may be larger than
data_len. The library frees data_cap bytes and still reads data_len bytes of
pixels. Leaving it at 0 means the allocation is exactly data_len, so existing
callbacks keep working unchanged. A non-zero cap below data_len is a broken
callback, so the buffer is freed and the image rejected rather than leaked.

On the Zig side sys.Image gains a capacity field and a deinit that frees with
it, so the capacity-aware free lives in one place instead of at each call site.

Tested with the full zig build test and zig build test-lib-vt suites, plus new
tests in src/terminal/c/sys.zig covering the over-allocated, zero-cap, and
undersized-cap paths.
