### PR TITLE
cli/ssh: add opt-in ssh-mouse-cleanup shell integration feature

### DIFF
--- a/src/cli/ssh.zig
+++ b/src/cli/ssh.zig
@@ -19,6 +19,7 @@ const usage =
     \\  --forward-env[=bool]  Enable TERM / SendEnv forwarding. Default: true.
     \\  --terminfo[=bool]     Install Ghostty terminfo on first connect. Default: true.
     \\  --cache[=bool]        Use the terminfo install cache. Default: true.
+    \\  --mouse-cleanup[=bool]  Reset mouse modes after SSH exits. Default: false.
     \\  --ssh=<path>          Path to the ssh binary. Default: first `ssh` on PATH.
     \\  --verbose             Print +ssh status lines to stderr.
     \\  --help                Show full help.
@@ -39,6 +40,9 @@ pub const Options = struct {
 
     /// When false, both cache read and write are bypassed.
     cache: bool = true,
+
+    /// Reset mouse tracking modes after SSH exits if stdout is a TTY.
+    @"mouse-cleanup": bool = false,
 
     /// The wrapped `ssh` binary.
     /// `/`-containing values are treated as paths; otherwise resolved via PATH.
@@ -109,7 +113,8 @@ pub const Options = struct {
 /// nothing to collide.
 ///
 /// This is typically called via Ghostty's shell integration. When
-/// `shell-integration-features` includes `ssh-env` or `ssh-terminfo`,
+/// `shell-integration-features` includes `ssh-env`, `ssh-terminfo`, or
+/// `ssh-mouse-cleanup`,
 /// each shell defines an `ssh` function that runs:
 ///
 ///     ghostty +ssh <flags> -- "$@"
@@ -139,6 +144,12 @@ pub const Options = struct {
 /// remote, filesystem permissions), a warning is logged and the
 /// connection continues with `TERM=xterm-256color`.
 ///
+/// After `ssh` exits, `--mouse-cleanup` resets supported mouse tracking
+/// and encoding modes when standard output is a terminal. This is a
+/// best-effort recovery reset, not state restoration: intentionally active
+/// same-terminal mouse state will also be disabled. Cleanup does not change
+/// the `ssh` exit status.
+///
 /// Flags:
 ///
 ///   * `--forward-env=<bool>`: Enable `TERM` / `SendEnv` environment
@@ -153,6 +164,10 @@ pub const Options = struct {
 ///     connection performs the install. To one-shot reinstall a single
 ///     host while keeping the cache in use, prefer `ghostty +ssh-cache
 ///     --remove=<host>` followed by a normal connection.
+///
+///   * `--mouse-cleanup=<bool>`: Reset supported mouse tracking and encoding
+///     modes after SSH exits when standard output is a terminal. Default:
+///     `false`.
 ///
 ///   * `--ssh=<path>`: Path to the `ssh` binary to execute. Default: the
 ///     first `ssh` found on `PATH`.
@@ -314,6 +329,8 @@ fn runInner(
         return 1;
     };
     verbosePrint(opts, stderr, "exit: {d}", .{exit_code});
+
+    if (opts.@"mouse-cleanup") cleanupMouseReporting();
 
     // Attempt to cache (if needed) on a successful ssh execution.
     if (exit_code == 0) if (session.to_cache) |entry| {
@@ -562,6 +579,48 @@ fn childExec(argv: []const []const u8) !u8 {
     };
 }
 
+test "childExec returns conventional exit status" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
+    try std.testing.expectEqual(
+        @as(u8, 73),
+        try childExec(&.{ "/bin/sh", "-c", "exit 73" }),
+    );
+}
+
+test "childExec returns 128 plus signal" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
+    try std.testing.expectEqual(
+        @as(u8, 143),
+        try childExec(&.{ "/bin/sh", "-c", "kill -TERM $$" }),
+    );
+}
+
+const mouse_cleanup_sequence = "\x1b[?9;1000;1002;1003;1005;1006;1015;1016l";
+
+fn cleanupMouseReporting() void {
+    const stdout_file: std.Io.File = .stdout();
+    const is_tty = stdout_file.isTty(global.io()) catch |err| {
+        log.warn("unable to determine whether stdout is a TTY: {t}", .{err});
+        return;
+    };
+    var buffer: [mouse_cleanup_sequence.len]u8 = undefined;
+    var stdout_writer = stdout_file.writer(global.io(), &buffer);
+    writeMouseCleanup(&stdout_writer.interface, is_tty) catch |err| {
+        log.warn("unable to reset mouse tracking after SSH exit: {t}", .{err});
+    };
+}
+
+fn writeMouseCleanup(
+    writer: *std.Io.Writer,
+    is_tty: bool,
+) std.Io.Writer.Error!void {
+    if (!is_tty) return;
+    try writer.writeAll(mouse_cleanup_sequence);
+    try writer.flush();
+}
+
 fn parseTestArgs(alloc: Allocator, opts: *Options, line: []const u8) !void {
     var iter = try std.process.Args.IteratorGeneral(.{}).init(alloc, line);
     defer iter.deinit();
@@ -603,6 +662,34 @@ test "parseManuallyHook: explicit -- separator" {
     try testing.expectEqual(@as(usize, 2), opts._ssh_args.items.len);
     try testing.expectEqualStrings("--some-rare-ssh-arg", opts._ssh_args.items[0]);
     try testing.expectEqualStrings("user@example.com", opts._ssh_args.items[1]);
+}
+
+test "mouse cleanup flag" {
+    const testing = std.testing;
+    var opts: Options = .{};
+    defer opts.deinit();
+    try parseTestArgs(testing.allocator, &opts, "--mouse-cleanup user@example.com");
+    try testing.expect(opts.@"mouse-cleanup");
+    try testing.expectEqual(@as(usize, 1), opts._ssh_args.items.len);
+    try testing.expectEqualStrings("user@example.com", opts._ssh_args.items[0]);
+}
+
+test "mouse cleanup emission requires a TTY" {
+    const testing = std.testing;
+
+    {
+        var buffer: [mouse_cleanup_sequence.len]u8 = undefined;
+        var writer: std.Io.Writer = .fixed(&buffer);
+        try writeMouseCleanup(&writer, true);
+        try testing.expectEqualStrings(mouse_cleanup_sequence, writer.buffered());
+    }
+
+    {
+        var buffer: [mouse_cleanup_sequence.len]u8 = undefined;
+        var writer: std.Io.Writer = .fixed(&buffer);
+        try writeMouseCleanup(&writer, false);
+        try testing.expectEqualStrings("", writer.buffered());
+    }
 }
 
 test "parseDestination: typical ssh -G output" {

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -2959,6 +2959,13 @@ keybind: Keybinds = .{},
 ///
 ///   * `title` - Set the window title via shell integration.
 ///
+///   * `ssh-mouse-cleanup` - Reset supported mouse tracking and encoding modes
+///     after integrated SSH exits when standard output is a terminal. This is a
+///     recovery reset, not state restoration: intentionally active same-terminal
+///     mouse state will also be disabled.
+///
+///     Example: `shell-integration-features = ssh-mouse-cleanup`
+///
 ///   * `ssh-env` - Enable SSH environment variable compatibility. Automatically
 ///     converts TERM from `xterm-ghostty` to `xterm-256color` when connecting to
 ///     remote hosts and propagates COLORTERM, TERM_PROGRAM, and TERM_PROGRAM_VERSION.
@@ -8825,6 +8832,7 @@ pub const ShellIntegrationFeatures = packed struct {
     cursor: bool = true,
     sudo: bool = false,
     title: bool = true,
+    @"ssh-mouse-cleanup": bool = false,
     @"ssh-env": bool = false,
     @"ssh-terminfo": bool = false,
     path: bool = true,
@@ -10549,6 +10557,21 @@ const TestIterator = struct {
         return result;
     }
 };
+
+test "parse shell integration feature: ssh-mouse-cleanup" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var cfg = try Config.default(alloc);
+    defer cfg.deinit();
+    try testing.expect(!cfg.@"shell-integration-features".@"ssh-mouse-cleanup");
+
+    var it: TestIterator = .{
+        .data = &.{"--shell-integration-features=ssh-mouse-cleanup"},
+    };
+    try cfg.loadIter(alloc, &it);
+    try testing.expect(cfg.@"shell-integration-features".@"ssh-mouse-cleanup");
+}
 
 test "parse hook: invalid command" {
     const testing = std.testing;

--- a/src/shell-integration/README.md
+++ b/src/shell-integration/README.md
@@ -79,7 +79,7 @@ the module using the `-e "use ghostty *"` flag when starting Nushell.
 
 Nushell provides many shell features itself, such as `title` and `cursor`,
 so our integration focuses on Ghostty-specific features like `sudo`,
-`ssh-env`, and `ssh-terminfo`.
+`ssh-env`, `ssh-mouse-cleanup`, and `ssh-terminfo`.
 
 The shell integration is automatically enabled when running Nushell in Ghostty,
 but you can also load it manually is shell integration is disabled:

--- a/src/shell-integration/bash/ghostty.bash
+++ b/src/shell-integration/bash/ghostty.bash
@@ -124,6 +124,7 @@ if [[ "$GHOSTTY_SHELL_FEATURES" == *ssh-* ]]; then
     flags=()
     [[ "$GHOSTTY_SHELL_FEATURES" != *ssh-env* ]] && flags+=(--forward-env=false)
     [[ "$GHOSTTY_SHELL_FEATURES" != *ssh-terminfo* ]] && flags+=(--terminfo=false)
+    [[ "$GHOSTTY_SHELL_FEATURES" == *ssh-mouse-cleanup* ]] && flags+=(--mouse-cleanup)
     "$GHOSTTY_BIN_DIR/ghostty" +ssh "${flags[@]}" -- "$@"
   }
 fi

--- a/src/shell-integration/elvish/lib/ghostty-integration.elv
+++ b/src/shell-integration/elvish/lib/ghostty-integration.elv
@@ -89,6 +89,9 @@
     if (not (has-value $features ssh-terminfo)) {
       set flags = (conj $flags --terminfo=false)
     }
+    if (has-value $features ssh-mouse-cleanup) {
+      set flags = (conj $flags --mouse-cleanup)
+    }
     $ghostty +ssh $@flags -- $@args
   }
 

--- a/src/shell-integration/fish/vendor_conf.d/ghostty-shell-integration.fish
+++ b/src/shell-integration/fish/vendor_conf.d/ghostty-shell-integration.fish
@@ -124,12 +124,13 @@ function __ghostty_setup --on-event fish_prompt -d "Setup ghostty integration"
     # Wrap `ssh` with `ghostty +ssh` and translate the shell-integration
     # feature flags into command options.
     set -l features (string split ',' -- "$GHOSTTY_SHELL_FEATURES")
-    if contains ssh-env $features; or contains ssh-terminfo $features
+    if contains ssh-env $features; or contains ssh-terminfo $features; or contains ssh-mouse-cleanup $features
         function ssh --wraps=ssh --description "SSH wrapper with Ghostty integration"
             set -l features (string split ',' -- "$GHOSTTY_SHELL_FEATURES")
             set -l flags
             contains ssh-env $features; or set -a flags --forward-env=false
             contains ssh-terminfo $features; or set -a flags --terminfo=false
+            contains ssh-mouse-cleanup $features; and set -a flags --mouse-cleanup
             "$GHOSTTY_BIN_DIR/ghostty" +ssh $flags -- $argv
         end
     end

--- a/src/shell-integration/nushell/vendor/autoload/ghostty.nu
+++ b/src/shell-integration/nushell/vendor/autoload/ghostty.nu
@@ -8,7 +8,7 @@ export module ghostty {
   # feature flags into command options.
   @complete external
   export def --wrapped ssh [...args] {
-    if not ((has_feature "ssh-env") or (has_feature "ssh-terminfo")) {
+    if not ((has_feature "ssh-env") or (has_feature "ssh-terminfo") or (has_feature "ssh-mouse-cleanup")) {
       ^ssh ...$args
       return
     }
@@ -20,6 +20,9 @@ export module ghostty {
     }
     if not (has_feature "ssh-terminfo") {
       $flags = ($flags ++ ["--terminfo=false"])
+    }
+    if (has_feature "ssh-mouse-cleanup") {
+      $flags = ($flags ++ ["--mouse-cleanup"])
     }
     ^$ghostty "+ssh" ...$flags "--" ...$args
   }

--- a/src/shell-integration/zsh/ghostty-integration
+++ b/src/shell-integration/zsh/ghostty-integration
@@ -319,6 +319,7 @@ _ghostty_deferred_init() {
         local flags=()
         [[ "$GHOSTTY_SHELL_FEATURES" != *ssh-env* ]] && flags+=(--forward-env=false)
         [[ "$GHOSTTY_SHELL_FEATURES" != *ssh-terminfo* ]] && flags+=(--terminfo=false)
+        [[ "$GHOSTTY_SHELL_FEATURES" == *ssh-mouse-cleanup* ]] && flags+=(--mouse-cleanup)
         "$GHOSTTY_BIN_DIR/ghostty" +ssh $flags -- "$@"
       }
     fi

--- a/src/terminal/stream_terminal.zig
+++ b/src/terminal/stream_terminal.zig
@@ -2277,6 +2277,35 @@ test "modes" {
     try testing.expect(t.modes.get(.wraparound));
 }
 
+test "mouse cleanup sequence resets supported modes" {
+    var t: Terminal = try .init(testing.io, testing.allocator, .{ .cols = 80, .rows = 24 });
+    defer t.deinit(testing.allocator);
+
+    var s: Stream = .init(.{ .allocator = testing.allocator, .handler = .init(&t) });
+    defer s.deinit();
+
+    const mouse_modes = [_]modes.Mode{
+        .mouse_event_x10,
+        .mouse_event_normal,
+        .mouse_event_button,
+        .mouse_event_any,
+        .mouse_format_utf8,
+        .mouse_format_sgr,
+        .mouse_format_urxvt,
+        .mouse_format_sgr_pixels,
+    };
+
+    s.nextSlice("\x1b[?9;1000;1002;1003;1005;1006;1015;1016h");
+    for (mouse_modes) |mode| try testing.expect(t.modes.get(mode));
+    try testing.expectEqual(.any, t.flags.mouse_event);
+    try testing.expectEqual(.sgr_pixels, t.flags.mouse_format);
+
+    s.nextSlice("\x1b[?9;1000;1002;1003;1005;1006;1015;1016l");
+    for (mouse_modes) |mode| try testing.expect(!t.modes.get(mode));
+    try testing.expectEqual(.none, t.flags.mouse_event);
+    try testing.expectEqual(.x10, t.flags.mouse_format);
+}
+
 test "scrolling regions" {
     var t: Terminal = try .init(testing.io, testing.allocator, .{ .cols = 80, .rows = 24 });
     defer t.deinit(testing.allocator);

--- a/src/termio/shell_integration.zig
+++ b/src/termio/shell_integration.zig
@@ -248,8 +248,20 @@ test "setup features" {
         var env = EnvMap.init(alloc);
         defer env.deinit();
 
-        try setupFeatures(&env, .{ .cursor = true, .sudo = true, .title = true, .@"ssh-env" = true, .@"ssh-terminfo" = true, .path = true }, true);
-        try testing.expectEqualStrings("cursor:blink,path,ssh-env,ssh-terminfo,sudo,title", env.get("GHOSTTY_SHELL_FEATURES").?);
+        try setupFeatures(
+            &env,
+            .{
+                .cursor = true,
+                .sudo = true,
+                .title = true,
+                .@"ssh-mouse-cleanup" = true,
+                .@"ssh-env" = true,
+                .@"ssh-terminfo" = true,
+                .path = true,
+            },
+            true,
+        );
+        try testing.expectEqualStrings("cursor:blink,path,ssh-env,ssh-mouse-cleanup,ssh-terminfo,sudo,title", env.get("GHOSTTY_SHELL_FEATURES").?);
     }
 
     // Test: all features disabled
@@ -268,6 +280,15 @@ test "setup features" {
 
         try setupFeatures(&env, .{ .cursor = false, .sudo = true, .title = false, .@"ssh-env" = true, .@"ssh-terminfo" = false, .path = false }, true);
         try testing.expectEqualStrings("ssh-env,sudo", env.get("GHOSTTY_SHELL_FEATURES").?);
+    }
+
+    // Test: SSH cleanup with default features
+    {
+        var env = EnvMap.init(alloc);
+        defer env.deinit();
+
+        try setupFeatures(&env, .{ .@"ssh-mouse-cleanup" = true }, true);
+        try testing.expectEqualStrings("cursor:blink,path,ssh-mouse-cleanup,title", env.get("GHOSTTY_SHELL_FEATURES").?);
     }
 
     // Test: blinking cursor


### PR DESCRIPTION
Fixes #12358
Vouch: https://github.com/ghostty-org/ghostty/discussions/13812#discussioncomment-18018163

## Problem

If an SSH session dies while a remote program has mouse reporting on, the disable sequence never arrives. Ghostty keeps sending mouse escape codes to the local shell until you run `reset`.

## Change

New opt-in shell integration feature:

```
shell-integration-features = ssh-mouse-cleanup
```

The shell `ssh` wrapper passes `--mouse-cleanup` to `ghostty +ssh`. After `ssh` exits, it writes `CSI ? 9;1000;1002;1003;1005;1006;1015;1016 l` to stdout, turning off every mouse mode Ghostty supports.

- Only emitted when stdout is a TTY.
- `ssh` exit status is unchanged.
- Off by default.
- Wired into bash, zsh, fish, elvish, and nushell.

## Why not #11833

That PR reset mouse state on OSC 133 prompt markers and was declined for inventing semantics and misfiring in nested prompts. This ties the reset to one concrete event: the `ssh` process exiting. It's a recovery reset, not state restoration, so it can also clear a mouse mode the user set on purpose before running `ssh`. That's why it's opt-in.

## Testing

New unit tests: flag parsing, TTY guard, child exit status (normal and signal), config parsing, features string, and terminal mode clearing.

On Ubuntu 24.04 aarch64 against a real local `sshd`:

- Full `zig build test`: 3760 pass, 35 skip, 0 fail (on main at 492300cad).
- Remote enables mouse mode then is killed with SIGKILL: reset sequence emitted in all five shells with the feature on, absent with it off. Exit status 255 either way.
- Local `ssh` killed with SIGTERM (bash): same result.

## AI disclosure

Implementation and unit tests were written with OpenAI Codex. Claude Code was used to verify: run the suite, build the binary, and run the end-to-end shell tests above. I have read and understand every changed line and edited this description.
