### PR TITLE
terminal/parser: preserve CSI subparameter separators

### DIFF
--- a/src/terminal/Parser.zig
+++ b/src/terminal/Parser.zig
@@ -123,6 +123,39 @@ pub const Action = union(enum) {
             };
         }
 
+        /// Iterates the parameters as semicolon-separated groups, where
+        /// a group is the maximal run of parameters joined by colons.
+        /// `1;2:3:4;5` yields `{1}`, `{2,3,4}`, and `{5}`.
+        ///
+        /// This saves protocols that structure their parameters with
+        /// colons, such as the kitty multiple cursors protocol, from
+        /// walking the separator bits themselves.
+        pub const GroupIterator = struct {
+            params: []const u16,
+            params_sep: *const SepList,
+
+            /// The parameter the next group starts at. Set this past a
+            /// leading parameter you have already consumed, such as an
+            /// operation code.
+            index: usize = 0,
+
+            pub fn next(self: *GroupIterator) ?[]const u16 {
+                if (self.index >= self.params.len) return null;
+
+                // A set bit at i means parameter i is followed by ':',
+                // so the group continues past it. The bound keeps a
+                // trailing bit from running off the end.
+                const start = self.index;
+                var end = start;
+                while (end + 1 < self.params.len and
+                    self.params_sep.isSet(end)) : (end += 1)
+                {}
+
+                self.index = end + 1;
+                return self.params[start .. end + 1];
+            }
+        };
+
         // Implement formatter for logging
         pub fn format(
             self: CSI,

--- a/src/terminal/Parser.zig
+++ b/src/terminal/Parser.zig
@@ -454,6 +454,46 @@ pub const Params = struct {
     }
 };
 
+test "Params: spills only after inline capacity" {
+    var params: Params = .empty;
+    params.alloc = testing.allocator;
+    defer params.deinit();
+
+    // Exactly `INLINE_PARAMS` still fits inline.
+    for (0..INLINE_PARAMS) |i| params.push(@intCast(i), false);
+    try testing.expectEqual(0, params.spill.items.len);
+
+    // One more moves the whole sequence to the heap, separators and all.
+    // `take` still hands back a single contiguous slice.
+    params.push(INLINE_PARAMS, true);
+    const values = params.take().?;
+    try testing.expectEqual(INLINE_PARAMS + 1, values.len);
+    for (values, 0..) |value, i| try testing.expectEqual(i, value);
+    try testing.expect(params.seps.isSet(INLINE_PARAMS));
+
+    // A reset keeps the spill capacity but not its contents. The next
+    // short sequence is served inline again.
+    params.reset();
+    params.push(1, false);
+    try testing.expectEqualSlices(u16, &.{1}, params.take().?);
+    try testing.expectEqual(0, params.spill.items.len);
+}
+
+test "Params: allocation failure drops the sequence" {
+    var failing: testing.FailingAllocator = .init(testing.allocator, .{
+        .fail_index = 0,
+    });
+    var params: Params = .empty;
+    params.alloc = failing.allocator();
+    defer params.deinit();
+
+    // A failed spill discards everything. Half a sequence is worse than
+    // none of it.
+    for (0..INLINE_PARAMS + 1) |i| params.push(@intCast(i), false);
+    try testing.expect(params.take() == null);
+    try testing.expect(failing.has_induced_failure);
+}
+
 pub fn init() Parser {
     var result: Parser = .{
         .state = .ground,
@@ -1008,6 +1048,16 @@ test "csi: SGR mixed colon and semicolon setting underline, bg, fg" {
     }
 }
 
+test "csi: colon for a final that defines no subparameters" {
+    // Read positionally, "38:2" would make this a set-mode for mode 2.
+    // The whole sequence is dropped instead.
+    var p = init();
+    _ = p.next(0x1B);
+    for ("[38:2") |c| _ = p.next(c);
+    try testing.expect(p.next('h')[1] == null);
+    try testing.expect(p.state == .ground);
+}
+
 test "csi: request mode decrqm" {
     var p = init();
     _ = p.next(0x1B);
@@ -1059,6 +1109,132 @@ test "csi: change cursor" {
         try testing.expectEqual(@as(u16, ' '), d.intermediates[0]);
         try testing.expectEqual(@as(u16, 3), d.params[0]);
     }
+}
+
+test "csi: kitty multiple cursors keeps colon separators" {
+    var p = init();
+    _ = p.next(0x1B);
+    for ("[>29;2:4:5 ") |c| _ = p.next(c);
+
+    const d = p.next('q')[1].?.csi_dispatch;
+    try testing.expect(p.state == .ground);
+    try testing.expectEqual(@as(u8, 'q'), d.final);
+    try testing.expectEqualSlices(u8, "> ", d.intermediates);
+    try testing.expectEqualSlices(u16, &.{ 29, 2, 4, 5 }, d.params);
+
+    // A bit is set for each parameter followed by ':', so the ';' after
+    // the operation is the only one clear.
+    try testing.expectEqual(@as(usize, 2), d.params_sep.count());
+    try testing.expect(!d.params_sep.isSet(0));
+    try testing.expect(d.params_sep.isSet(1));
+    try testing.expect(d.params_sep.isSet(2));
+}
+
+test "csi: subparameters only reach the finals that define them" {
+    // SGR and the kitty multiple cursors protocol define subparameters.
+    // DECSCUSR shares the 'q' final but not the '>' marker, and CUP
+    // defines none at all. Both of those get dropped.
+    const cases = .{
+        .{ "[38:2:1:2:3", 'm', true },
+        .{ "[>29;2:4:5 ", 'q', true },
+        .{ "[2:3 ", 'q', false },
+        .{ "[1;2:3", 'H', false },
+    };
+
+    inline for (cases) |case| {
+        var p = init();
+        _ = p.next(0x1B);
+        for (case[0]) |c| _ = p.next(c);
+        const action = p.next(case[1])[1];
+        if (comptime case[2]) {
+            try testing.expect(action.?.csi_dispatch.params_sep.count() > 0);
+        } else {
+            try testing.expect(action == null);
+        }
+    }
+}
+
+test "csi: a colon after the last parameter is not a separator" {
+    // Nothing follows the final parameter, so its separator bit is
+    // meaningless. Consumers that walk the bits must stop at the last
+    // parameter rather than reading off the end of the set.
+    var p = init();
+    p.setAllocator(testing.allocator);
+    defer p.deinit();
+    _ = p.next(0x1B);
+    _ = p.next('[');
+    for (0..MAX_PARAMS) |_| {
+        _ = p.next('1');
+        _ = p.next(':');
+    }
+
+    const csi = p.next('m')[1].?.csi_dispatch;
+    try testing.expectEqual(@as(usize, MAX_PARAMS), csi.params.len);
+
+    var sgr_parser: sgr.Parser = .{
+        .params = csi.params,
+        .params_sep = csi.params_sep,
+    };
+    while (sgr_parser.next()) |_| {}
+}
+
+test "csi: one parameter too many drops the sequence" {
+    // Both the state machine and the stream's own CSI loop must drop an
+    // overflowing sequence whole rather than act on a truncated one.
+    var p = init();
+    p.setAllocator(testing.allocator);
+    defer p.deinit();
+    _ = p.next(0x1B);
+    _ = p.next('[');
+    for (0..MAX_PARAMS) |_| {
+        _ = p.next('1');
+        _ = p.next(';');
+    }
+    _ = p.next('1');
+    try testing.expect(p.next('m')[1] == null);
+}
+
+test "csi: kitty multiple cursors accepts a full parameter batch" {
+    // One operation plus three parameters per point, filling the limit
+    // that kitty's own parser imposes on a single sequence.
+    var p = init();
+    p.setAllocator(testing.allocator);
+    defer p.deinit();
+    _ = p.next(0x1B);
+    _ = p.next('[');
+
+    const points = (MAX_PARAMS - 1) / 3;
+    var buf: [MAX_PARAMS * 8]u8 = undefined;
+    var writer: std.Io.Writer = .fixed(&buf);
+    try writer.writeAll(">1");
+    for (1..points + 1) |col| try writer.print(";2:1:{d}", .{col});
+    try writer.writeByte(' ');
+    for (writer.buffered()) |byte| _ = p.next(byte);
+
+    const csi = p.next('q')[1].?.csi_dispatch;
+    try testing.expectEqual(@as(usize, 1 + points * 3), csi.params.len);
+    try testing.expectEqual(@as(usize, points * 2), csi.params_sep.count());
+    try testing.expectEqualSlices(u16, &.{ 1, 2, 1, 1 }, csi.params[0..4]);
+    try testing.expectEqualSlices(
+        u16,
+        &.{ 2, 1, points },
+        csi.params[csi.params.len - 3 ..],
+    );
+}
+
+test "csi: separators do not leak into the next sequence" {
+    // `reset` only clears the separator bits below `len`, so a sequence
+    // that used colons must not leave them set for the next one, which
+    // would get dropped as a subparameter mismatch.
+    var p = init();
+    _ = p.next(0x1B);
+    for ("[38:2:1:2:3") |c| _ = p.next(c);
+    try testing.expect(p.next('m')[1] != null);
+
+    _ = p.next(0x1B);
+    for ("[1;2") |c| _ = p.next(c);
+    const csi = p.next('m')[1].?.csi_dispatch;
+    try testing.expectEqual(@as(usize, 0), csi.params_sep.count());
 }
 
 test "osc: change window title" {

--- a/src/terminal/Parser.zig
+++ b/src/terminal/Parser.zig
@@ -6,6 +6,7 @@ const Parser = @This();
 
 const std = @import("std");
 const testing = std.testing;
+const sgr = @import("sgr.zig");
 const table = @import("parse_table.zig").table;
 const osc = @import("osc.zig");
 
@@ -78,16 +79,26 @@ pub const Action = union(enum) {
     apc_end: void,
 
     pub const CSI = struct {
-        intermediates: []u8,
-        params: []u16,
-        params_sep: SepList,
+        intermediates: []const u8,
+        params: []const u16,
+
+        /// The separator that follows each parameter.
+        ///
+        /// Borrowed from the parser like `params` and `intermediates`,
+        /// so it dies on the next byte fed to the parser. It is a
+        /// pointer because the bit set covers every possible parameter
+        /// and copying it into a hot dispatch costs more than it saves.
+        /// Only bits below `params.len` mean anything; the last
+        /// parameter has nothing after it.
+        params_sep: *const SepList,
+
         final: u8,
 
         /// The list of separators used for CSI params. The value of the
         /// bit can be mapped to Sep. The index of this bit set specifies
         /// the separator AFTER that param. For example: 0;4:3 would have
         /// index 1 set.
-        pub const SepList = std.StaticBitSet(MAX_PARAMS);
+        pub const SepList = Params.SepList;
 
         /// The separator used for CSI params.
         pub const Sep = enum(u1) { semicolon = 0, colon = 1 };
@@ -195,18 +206,25 @@ pub const Action = union(enum) {
 /// can be at most 4 bytes.
 pub const MAX_INTERMEDIATE = 4;
 
-/// Maximum number of CSI parameters. This is arbitrary. Practically, the
-/// only CSI command that uses more than 3 parameters is the SGR command
-/// which can be infinitely long. 24 is a reasonable limit based on empirical
-/// data. This used to be 16 but Kakoune has a SGR command that uses 17
-/// parameters.
+/// Maximum number of CSI parameters.
 ///
-/// We could in the future make this the static limit and then allocate after
-/// but that's a lot more work and practically its so rare to exceed this
-/// number. I implore TUI authors to not use more than this number of CSI
-/// params, but I suspect we'll introduce a slow path with heap allocation
-/// one day.
-pub const MAX_PARAMS = 24;
+/// Only two CSI commands use more than three parameters: SGR, which has
+/// no bound at all, and the kitty multiple cursors protocol, which packs
+/// a batch of cursor coordinates into one sequence. This was 16 until
+/// Kakoune turned up with an SGR command that uses 17, then 24 on
+/// empirical data, and is now 256 to match kitty's own limit, which the
+/// cursors protocol is written against.
+///
+/// A longer sequence is dropped whole. Acting on one with parameters
+/// silently missing from the middle is worse than not acting at all.
+pub const MAX_PARAMS = 256;
+
+/// Parameters retained without allocating.
+///
+/// Nearly every sequence fits here; longer ones spill to the heap. On a
+/// parser with no allocator, which a freestanding target may well be,
+/// this is the hard limit.
+pub const INLINE_PARAMS = 24;
 
 /// Current state of the state machine
 state: State,
@@ -215,40 +233,216 @@ state: State,
 intermediates: [MAX_INTERMEDIATE]u8,
 intermediates_idx: u8,
 
-/// Param tracking, building
-params: [MAX_PARAMS]u16,
-params_sep: Action.CSI.SepList,
-params_idx: u8,
-param_acc: u16,
-param_acc_idx: u8,
+/// The parameters of the CSI or DCS sequence being parsed.
+params: Params,
 
 /// Parser for OSC sequences
 osc_parser: osc.Parser,
+
+/// The parameters of one control sequence, under construction.
+///
+/// Parameters arrive from the state machine one digit and one separator
+/// at a time, and are consumed all at once at dispatch. This type owns
+/// that whole lifecycle, so the byte-at-a-time state machine in `next`
+/// and the bulk loop in `Stream` share one copy of the limit and
+/// separator policy.
+pub const Params = struct {
+    /// The first `INLINE_PARAMS` completed parameters. Past that
+    /// everything moves to `spill`, so the two are never read together.
+    values: [INLINE_PARAMS]u16,
+
+    /// Parameters past `INLINE_PARAMS`, preceded by a copy of `values`
+    /// so `take` can return one contiguous slice. Empty until a sequence
+    /// outgrows the inline storage.
+    spill: std.ArrayListUnmanaged(u16),
+
+    /// The separator that follows each parameter. See `SepList`.
+    seps: SepList,
+
+    /// Set by `Parser.setAllocator`. Null on a parser that cannot
+    /// allocate, which caps a sequence at `INLINE_PARAMS`.
+    alloc: ?std.mem.Allocator,
+
+    /// The number of completed parameters.
+    len: u16,
+
+    /// Set once a parameter has been dropped, either past `MAX_PARAMS`
+    /// or on a failed spill. Dispatch then discards the whole sequence.
+    failed: bool,
+
+    /// Whether any parameter is colon-joined to the next. Colons are
+    /// rare, and this lets `reset` and the subparameter policy check
+    /// skip `seps` for almost every sequence the parser sees.
+    colons: bool,
+
+    /// The parameter currently being accumulated, and whether any digit
+    /// has fed it. The flag separates a trailing separator (`1;`, one
+    /// parameter) from a trailing value (`1;2`, two).
+    acc: u16,
+    acc_set: bool,
+
+    /// One bit per parameter, set when a ':' follows that parameter
+    /// instead of a ';'. See `Action.CSI.SepList`.
+    pub const SepList = std.StaticBitSet(MAX_PARAMS);
+
+    pub const empty: Params = .{
+        .values = undefined,
+        .spill = .empty,
+        .seps = .initEmpty(),
+        .alloc = null,
+        .len = 0,
+        .failed = false,
+        .colons = false,
+        .acc = 0,
+        .acc_set = false,
+    };
+
+    pub fn deinit(self: *Params) void {
+        if (self.alloc) |alloc| self.spill.deinit(alloc);
+        self.* = undefined;
+    }
+
+    /// Discard the sequence under construction, keeping any spill
+    /// capacity for the next one.
+    pub inline fn reset(self: *Params) void {
+        // Only bits below `len` can ever be set, and only if a colon
+        // was seen at all. `initEmpty` would zero the whole 32-byte mask
+        // on every escape sequence, and this is the parser's hot path.
+        if (self.colons) {
+            @branchHint(.unlikely);
+            self.seps.setRangeValue(.{ .start = 0, .end = self.len }, false);
+            self.colons = false;
+        }
+
+        self.spill.clearRetainingCapacity();
+        self.len = 0;
+        self.failed = false;
+        self.acc = 0;
+        self.acc_set = false;
+    }
+
+    /// Accumulate one digit into the parameter being built. Values
+    /// saturate: a parameter that large is nonsense already, and every
+    /// consumer clamps it.
+    ///
+    /// There is no limit check here. A digit past the limit only feeds a
+    /// parameter `push` refuses anyway, and this is the hottest step in
+    /// CSI parsing.
+    pub inline fn digit(self: *Params, value: u8) void {
+        self.acc = (self.acc *| 10) +| value;
+        self.acc_set = true;
+    }
+
+    /// Finish the parameter being built because a separator was reached.
+    pub fn separator(self: *Params, colon: bool) void {
+        self.push(self.acc, colon);
+        self.acc = 0;
+        self.acc_set = false;
+    }
+
+    /// Append a completed parameter and the separator that follows it.
+    /// Once the inline storage is full this moves the whole sequence to
+    /// the heap, and sets `failed` if it cannot.
+    pub fn push(self: *Params, value: u16, colon: bool) void {
+        if (self.failed) return;
+        if (self.len >= MAX_PARAMS) {
+            @branchHint(.cold);
+            self.failed = true;
+            return;
+        }
+
+        if (self.len < INLINE_PARAMS) {
+            self.values[self.len] = value;
+        } else {
+            const alloc = self.alloc orelse {
+                self.failed = true;
+                return;
+            };
+            if (self.spill.items.len == 0) {
+                self.spill.ensureTotalCapacity(
+                    alloc,
+                    @as(usize, self.len) + 1,
+                ) catch {
+                    self.failed = true;
+                    return;
+                };
+                self.spill.appendSliceAssumeCapacity(
+                    self.values[0..INLINE_PARAMS],
+                );
+            } else self.spill.ensureUnusedCapacity(alloc, 1) catch {
+                self.failed = true;
+                return;
+            };
+            self.spill.appendAssumeCapacity(value);
+        }
+
+        if (colon) {
+            self.seps.set(self.len);
+            self.colons = true;
+        }
+        self.len += 1;
+    }
+
+    /// Consume the pending parameter and return the whole sequence, or
+    /// null if it overflowed and must be dropped.
+    pub fn take(self: *Params) ?[]const u16 {
+        if (self.acc_set) {
+            self.push(self.acc, false);
+            self.acc_set = false;
+        }
+        if (self.failed) {
+            @branchHint(.cold);
+            return null;
+        }
+        return if (self.spill.items.len > 0)
+            self.spill.items
+        else
+            self.values[0..self.len];
+    }
+};
 
 pub fn init() Parser {
     var result: Parser = .{
         .state = .ground,
         .intermediates_idx = 0,
-        .params_sep = .initEmpty(),
-        .params_idx = 0,
-        .param_acc = 0,
-        .param_acc_idx = 0,
+        .params = .empty,
         .osc_parser = .init(null),
 
         .intermediates = undefined,
-        .params = undefined,
     };
     if (std.valgrind.runningOnValgrind() > 0) {
         // Initialize our undefined fields so Valgrind can catch it.
         // https://github.com/ziglang/zig/issues/19148
         result.intermediates = undefined;
-        result.params = undefined;
+        result.params.values = undefined;
     }
     return result;
 }
 
+/// Let the parser allocate for the two features a sequence can outgrow
+/// the inline storage of: CSI parameters and OSC strings. A parser with
+/// no allocator still works and drops those sequences instead.
+pub fn setAllocator(self: *Parser, alloc: std.mem.Allocator) void {
+    std.debug.assert(self.params.alloc == null);
+    self.params.alloc = alloc;
+    self.osc_parser.alloc = alloc;
+}
+
 pub fn deinit(self: *Parser) void {
+    self.params.deinit();
     self.osc_parser.deinit();
+}
+
+/// Log a CSI dispatch dropped for parameters we could not keep: past
+/// `MAX_PARAMS`, or a failed spill allocation.
+///
+/// This is noinline on purpose. It is cold, and inlining it into the hot
+/// dispatch path has been measured to cost binary size and performance
+/// through icache pressure. It is public so the stream's own CSI fast
+/// path, which bypasses the state machine, reports drops identically.
+pub noinline fn warnCsiParams() void {
+    @branchHint(.cold);
+    log.warn("unable to retain CSI parameters, dropping sequence", .{});
 }
 
 /// Next consumes the next character c and returns the actions to execute.
@@ -295,17 +489,11 @@ pub fn next(self: *Parser, c: u8) [3]?Action {
                 break :osc_string null;
             },
             .dcs_passthrough => dcs_hook: {
-                // Ignore too many parameters
-                if (self.params_idx >= MAX_PARAMS) break :dcs_hook null;
-                // Finalize parameters
-                if (self.param_acc_idx > 0) {
-                    self.params[self.params_idx] = self.param_acc;
-                    self.params_idx += 1;
-                }
+                const params = self.params.take() orelse break :dcs_hook null;
                 break :dcs_hook .{
                     .dcs_hook = .{
                         .intermediates = self.intermediates[0..self.intermediates_idx],
-                        .params = self.params[0..self.params_idx],
+                        .params = params,
                         .final = c,
                     },
                 };
@@ -340,28 +528,12 @@ inline fn doAction(self: *Parser, action: TransitionAction, c: u8) ?Action {
             // Semicolon separates parameters. If we encounter a semicolon
             // we need to store and move on to the next parameter.
             if (c == ';' or c == ':') {
-                // Ignore too many parameters
-                if (self.params_idx >= MAX_PARAMS) break :param null;
-
-                // Set param final value
-                self.params[self.params_idx] = self.param_acc;
-                if (c == ':') self.params_sep.set(self.params_idx);
-                self.params_idx += 1;
-
-                // Reset current param value to 0
-                self.param_acc = 0;
-                self.param_acc_idx = 0;
+                self.params.separator(c == ':');
                 break :param null;
             }
 
             // A numeric value. Add it to our accumulator.
-            self.param_acc *|= 10;
-            self.param_acc +|= c - '0';
-
-            // Increment our accumulator index. If we overflow then
-            // we're out of bounds and we exit immediately.
-            self.param_acc_idx, const overflow = @addWithOverflow(self.param_acc_idx, 1);
-            if (overflow > 0) break :param null;
+            self.params.digit(c - '0');
 
             // The client is expected to perform no action.
             break :param null;
@@ -371,28 +543,29 @@ inline fn doAction(self: *Parser, action: TransitionAction, c: u8) ?Action {
             break :osc_put null;
         },
         .csi_dispatch => csi_dispatch: {
-            // Ignore too many parameters
-            if (self.params_idx >= MAX_PARAMS) break :csi_dispatch null;
-
-            // Finalize parameters if we have one
-            if (self.param_acc_idx > 0) {
-                self.params[self.params_idx] = self.param_acc;
-                self.params_idx += 1;
-            }
+            const params = self.params.take() orelse {
+                warnCsiParams();
+                break :csi_dispatch null;
+            };
 
             const result: Action = .{
                 .csi_dispatch = .{
                     .intermediates = self.intermediates[0..self.intermediates_idx],
-                    .params = self.params[0..self.params_idx],
-                    .params_sep = self.params_sep,
+                    .params = params,
+                    .params_sep = &self.params.seps,
                     .final = c,
                 },
             };
 
-            // We only allow colon or mixed separators for the 'm' command.
-            if (c != 'm' and self.params_sep.count() > 0) {
+            // Only SGR defines colon-joined subparameters. Reading them
+            // positionally elsewhere would turn `CSI 1:2 H` into a
+            // cursor move to (1, 2), so the sequence is dropped.
+            if (self.params.colons and c != 'm') {
                 @branchHint(.cold);
-                warnCsiSepMismatch(result.csi_dispatch);
+                log.warn(
+                    "CSI colon or mixed separators only allowed for 'm' command, got: {f}",
+                    .{result.csi_dispatch},
+                );
                 break :csi_dispatch null;
             }
 
@@ -409,26 +582,9 @@ inline fn doAction(self: *Parser, action: TransitionAction, c: u8) ?Action {
     };
 }
 
-/// Log a warning for a CSI dispatch with colon/mixed separators on a
-/// non-'m' command.
-///
-/// This is noinline on purpose so that this unlikely (cold) behavior
-/// doesn't bloat the hot dispatch path which has been measured to actually
-/// affect both binary size and performance due to icache busts.
-noinline fn warnCsiSepMismatch(csi: Action.CSI) void {
-    @branchHint(.cold);
-    log.warn(
-        "CSI colon or mixed separators only allowed for 'm' command, got: {f}",
-        .{csi},
-    );
-}
-
 pub inline fn clear(self: *Parser) void {
     self.intermediates_idx = 0;
-    self.params_idx = 0;
-    self.params_sep = .initEmpty();
-    self.param_acc = 0;
-    self.param_acc_idx = 0;
+    self.params.reset();
 }
 
 test {
@@ -792,19 +948,6 @@ test "csi: SGR mixed colon and semicolon setting underline, bg, fg" {
     }
 }
 
-test "csi: colon for non-m final" {
-    var p = init();
-    _ = p.next(0x1B);
-    for ("[38:2h") |c| {
-        const a = p.next(c);
-        try testing.expect(a[0] == null);
-        try testing.expect(a[1] == null);
-        try testing.expect(a[2] == null);
-    }
-
-    try testing.expect(p.state == .ground);
-}
-
 test "csi: request mode decrqm" {
     var p = init();
     _ = p.next(0x1B);
@@ -910,7 +1053,7 @@ test "osc: change window title (end in esc)" {
 test "osc: 112 incomplete sequence" {
     var p: Parser = init();
     defer p.deinit();
-    p.osc_parser.alloc = std.testing.allocator;
+    p.setAllocator(std.testing.allocator);
 
     _ = p.next(0x1B);
     _ = p.next(']');
@@ -946,7 +1089,7 @@ test "osc: 112 incomplete sequence" {
 test "osc: 104 empty" {
     var p: Parser = init();
     defer p.deinit();
-    p.osc_parser.alloc = std.testing.allocator;
+    p.setAllocator(std.testing.allocator);
 
     _ = p.next(0x1B);
     _ = p.next(']');
@@ -977,9 +1120,11 @@ test "osc: 104 empty" {
 
 test "csi: too many params" {
     var p = init();
+    p.setAllocator(testing.allocator);
+    defer p.deinit();
     _ = p.next(0x1B);
     _ = p.next('[');
-    for (0..100) |_| {
+    for (0..MAX_PARAMS) |_| {
         _ = p.next('1');
         _ = p.next(';');
     }
@@ -997,6 +1142,8 @@ test "csi: too many params" {
 test "csi: sgr with up to our max parameters" {
     for (1..MAX_PARAMS + 1) |max| {
         var p = init();
+        p.setAllocator(testing.allocator);
+        defer p.deinit();
         _ = p.next(0x1B);
         _ = p.next('[');
 
@@ -1025,6 +1172,8 @@ test "csi: sgr beyond our max drops it" {
     const max = MAX_PARAMS + 2;
 
     var p = init();
+    p.setAllocator(testing.allocator);
+    defer p.deinit();
     _ = p.next(0x1B);
     _ = p.next('[');
 
@@ -1092,10 +1241,12 @@ test "dcs: params" {
 
 test "dcs: too many params" {
     // Regression test for a crash found by fuzzing (afl). When a DCS
-    // sequence has more than MAX_PARAMS parameters and param_acc_idx > 0,
-    // entering dcs_passthrough wrote to params[params_idx] without a
+    // sequence has more than MAX_PARAMS parameters and param_acc_set is
+    // true, entering dcs_passthrough wrote to params[len] without a
     // bounds check, causing an out-of-bounds access.
     var p = init();
+    p.setAllocator(testing.allocator);
+    defer p.deinit();
     _ = p.next(0x1B); // ESC
     _ = p.next('P'); // DCS entry
 
@@ -1104,7 +1255,7 @@ test "dcs: too many params" {
     for (0..MAX_PARAMS) |_| {
         _ = p.next(';');
     }
-    // Feed another digit so param_acc_idx > 0 while params_idx == MAX_PARAMS.
+    // Feed another digit so param_acc_set is true while len == MAX_PARAMS.
     _ = p.next('7');
 
     // A final byte triggers entry to dcs_passthrough. The DCS should

--- a/src/terminal/Parser.zig
+++ b/src/terminal/Parser.zig
@@ -103,6 +103,26 @@ pub const Action = union(enum) {
         /// The separator used for CSI params.
         pub const Sep = enum(u1) { semicolon = 0, colon = 1 };
 
+        /// Whether this command defines colon-joined subparameters.
+        ///
+        /// A colon introduces a subparameter (ECMA-48 5.4.2). Only the
+        /// commands that define one can read it. The rest have to drop
+        /// the whole sequence: reading the subparameters positionally
+        /// would turn `CSI 1:2 H` into a cursor move to (1, 2).
+        pub fn allowsSubparams(self: CSI) bool {
+            return switch (self.final) {
+                // SGR: direct colors and underline styles.
+                'm' => true,
+
+                // Kitty multiple cursors: coordinate and color groups.
+                // DECSCUSR shares the 'q' final but has no '>', so it
+                // falls through to false.
+                'q' => std.mem.eql(u8, self.intermediates, "> "),
+
+                else => false,
+            };
+        }
+
         // Implement formatter for logging
         pub fn format(
             self: CSI,
@@ -436,13 +456,24 @@ pub fn deinit(self: *Parser) void {
 /// Log a CSI dispatch dropped for parameters we could not keep: past
 /// `MAX_PARAMS`, or a failed spill allocation.
 ///
-/// This is noinline on purpose. It is cold, and inlining it into the hot
-/// dispatch path has been measured to cost binary size and performance
-/// through icache pressure. It is public so the stream's own CSI fast
-/// path, which bypasses the state machine, reports drops identically.
+/// This and `warnCsiSepMismatch` are noinline on purpose. Both are cold,
+/// and inlining them into the hot dispatch path has been measured to
+/// cost binary size and performance through icache pressure. Both are
+/// public so the stream's own CSI fast path, which bypasses the state
+/// machine, reports drops identically.
 pub noinline fn warnCsiParams() void {
     @branchHint(.cold);
     log.warn("unable to retain CSI parameters, dropping sequence", .{});
+}
+
+/// Log a CSI dispatch dropped for using subparameters its final byte
+/// does not define. See `Action.CSI.allowsSubparams`.
+pub noinline fn warnCsiSepMismatch(csi: Action.CSI) void {
+    @branchHint(.cold);
+    log.warn(
+        "CSI subparameters are not defined for this command, got: {f}",
+        .{csi},
+    );
 }
 
 /// Next consumes the next character c and returns the actions to execute.
@@ -557,15 +588,11 @@ inline fn doAction(self: *Parser, action: TransitionAction, c: u8) ?Action {
                 },
             };
 
-            // Only SGR defines colon-joined subparameters. Reading them
-            // positionally elsewhere would turn `CSI 1:2 H` into a
-            // cursor move to (1, 2), so the sequence is dropped.
-            if (self.params.colons and c != 'm') {
+            if (self.params.colons and
+                !result.csi_dispatch.allowsSubparams())
+            {
                 @branchHint(.cold);
-                log.warn(
-                    "CSI colon or mixed separators only allowed for 'm' command, got: {f}",
-                    .{result.csi_dispatch},
-                );
+                warnCsiSepMismatch(result.csi_dispatch);
                 break :csi_dispatch null;
             }
 

--- a/src/terminal/c/sgr.zig
+++ b/src/terminal/c/sgr.zig
@@ -11,6 +11,12 @@ const log = std.log.scoped(.sgr);
 /// Wrapper around parser that tracks the allocator for C API usage.
 const ParserWrapper = struct {
     parser: sgr.Parser,
+
+    /// Backing store for `parser.params_sep`, which the parser only
+    /// borrows. The wrapper owns it because it has to outlive any one
+    /// `setParams` call, and a C caller keeps a parser across many.
+    seps: sgr.SepList,
+
     alloc: Allocator,
 };
 
@@ -26,8 +32,10 @@ pub fn new(
         return .out_of_memory;
     ptr.* = .{
         .parser = .empty,
+        .seps = .initEmpty(),
         .alloc = alloc,
     };
+    ptr.parser.params_sep = &ptr.seps;
     result.* = ptr;
     return .success;
 }
@@ -62,19 +70,20 @@ pub fn setParams(
     if (parser.params.len > 0) alloc.free(parser.params);
     parser.params = params_slice;
 
-    // If we have separators, set that state too.
-    parser.params_sep = .initEmpty();
+    // The parser only borrows the separators, so the wrapper's own bit
+    // set is what gets rewritten here.
+    wrapper.seps = .initEmpty();
     if (seps_) |seps| {
-        if (len > @TypeOf(parser.params_sep).bit_length) {
+        if (len > sgr.SepList.bit_length) {
             log.warn("ghostty_sgr_set_params: separators length {} exceeds max supported length {}", .{
                 len,
-                @TypeOf(parser.params_sep).bit_length,
+                sgr.SepList.bit_length,
             });
             return .invalid_value;
         }
 
         for (seps[0..len], 0..) |sep, i| {
-            if (sep == ':') parser.params_sep.set(i);
+            if (sep == ':') wrapper.seps.set(i);
         }
     }
 

--- a/src/terminal/sgr.zig
+++ b/src/terminal/sgr.zig
@@ -5,7 +5,12 @@ const assert = @import("../quirks.zig").inlineAssert;
 const testing = std.testing;
 const lib = @import("lib.zig");
 const color = @import("color.zig");
-const SepList = @import("Parser.zig").Action.CSI.SepList;
+pub const SepList = @import("Parser.zig").Action.CSI.SepList;
+
+/// The separator list of a sequence that used no colons at all. Almost
+/// every SGR sequence is one of those, and they all share this one bit
+/// set instead of each carrying a copy.
+const no_seps: SepList = .initEmpty();
 
 /// Attribute type for SGR
 pub const Attribute = union(Tag) {
@@ -183,7 +188,13 @@ pub const Attribute = union(Tag) {
 /// Parser parses the attributes from a list of SGR parameters.
 pub const Parser = struct {
     params: []const u16 = &.{},
-    params_sep: SepList = .initEmpty(),
+
+    /// Colon separators by parameter index, borrowed alongside `params`
+    /// the same way `Parser.Action.CSI.params_sep` is. A pointer,
+    /// because the bit set is `MAX_PARAMS` wide and copying 32 bytes
+    /// into every SGR dispatch buys nothing.
+    params_sep: *const SepList = &no_seps,
+
     idx: usize = 0,
 
     /// Empty state parser.
@@ -209,7 +220,7 @@ pub const Parser = struct {
         const colon = @call(
             .always_inline,
             SepList.isSet,
-            .{ self.params_sep, self.idx },
+            .{ self.params_sep.*, self.idx },
         );
         self.idx += 1;
 
@@ -233,7 +244,11 @@ pub const Parser = struct {
                     // Consume all the colon separated
                     // values and return them as unknown.
                     const start = self.idx;
-                    while (self.params_sep.isSet(self.idx)) self.idx += 1;
+                    // Bounded like countColon: the last parameter has no
+                    // separator after it, so a set bit there is stale and
+                    // walking past it would read off the end of the set.
+                    while (self.idx + 1 < self.params.len and
+                        self.params_sep.isSet(self.idx)) self.idx += 1;
                     self.idx += 1;
                     return .{ .unknown = .{
                         .full = self.params,
@@ -512,7 +527,7 @@ pub const Parser = struct {
         return @call(
             .always_inline,
             SepList.isSet,
-            .{ self.params_sep, self.idx },
+            .{ self.params_sep.*, self.idx },
         );
     }
 
@@ -538,10 +553,38 @@ fn testParse(params: []const u16) Attribute {
     return p.next().?;
 }
 
-fn testParseColon(params: []const u16) Attribute {
-    var p: Parser = .{ .params = params };
-    // Mark all parameters except the last as having a colon after.
-    for (0..params.len - 1) |i| p.params_sep.set(i);
+/// A separator list with a colon after each parameter index in
+/// `colons`. The bit set is materialized at comptime, so the returned
+/// pointer is static and a `Parser` literal can borrow it the way a real
+/// dispatch borrows the parser's own.
+fn testSeps(comptime colons: []const usize) *const SepList {
+    return &struct {
+        const value: SepList = value: {
+            var list: SepList = .initEmpty();
+            for (colons) |i| list.set(i);
+            break :value list;
+        };
+    }.value;
+}
+
+/// A separator list joining every parameter to the next. The last
+/// parameter has nothing after it, so its bit stays clear.
+fn testSepsAll(comptime len: usize) *const SepList {
+    return testSeps(comptime colons: {
+        var idx: [len - 1]usize = undefined;
+        for (&idx, 0..) |*v, i| v.* = i;
+        const final = idx;
+        break :colons &final;
+    });
+}
+
+/// Parse the first attribute of a sequence whose parameters are all
+/// colon-joined, which is how SGR spells a subparameter group.
+fn testParseColon(comptime params: []const u16) Attribute {
+    var p: Parser = .{
+        .params = params,
+        .params_sep = testSepsAll(params.len),
+    };
     return p.next().?;
 }
 
@@ -585,11 +628,7 @@ test "sgr: Parser multiple" {
 test "sgr: unsupported with colon" {
     var p: Parser = .{
         .params = &[_]u16{ 0, 4, 1 },
-        .params_sep = sep: {
-            var list = SepList.initEmpty();
-            list.set(0);
-            break :sep list;
-        },
+        .params_sep = testSeps(&.{0}),
     };
     try testing.expect(p.next().? == .unknown);
     try testing.expect(p.next().? == .bold);
@@ -599,12 +638,7 @@ test "sgr: unsupported with colon" {
 test "sgr: unsupported with multiple colon" {
     var p: Parser = .{
         .params = &[_]u16{ 0, 4, 2, 1 },
-        .params_sep = sep: {
-            var list = SepList.initEmpty();
-            list.set(0);
-            list.set(1);
-            break :sep list;
-        },
+        .params_sep = testSeps(&.{ 0, 1 }),
     };
     try testing.expect(p.next().? == .unknown);
     try testing.expect(p.next().? == .bold);
@@ -689,11 +723,7 @@ test "sgr: underline styles" {
 test "sgr: underline style with more" {
     var p: Parser = .{
         .params = &[_]u16{ 4, 2, 1 },
-        .params_sep = sep: {
-            var list = SepList.initEmpty();
-            list.set(0);
-            break :sep list;
-        },
+        .params_sep = testSeps(&.{0}),
     };
 
     try testing.expect(p.next().? == .underline);
@@ -704,12 +734,7 @@ test "sgr: underline style with more" {
 test "sgr: underline style with too many colons" {
     var p: Parser = .{
         .params = &[_]u16{ 4, 2, 3, 1 },
-        .params_sep = sep: {
-            var list = SepList.initEmpty();
-            list.set(0);
-            list.set(1);
-            break :sep list;
-        },
+        .params_sep = testSeps(&.{ 0, 1 }),
     };
 
     try testing.expect(p.next().? == .unknown);
@@ -939,11 +964,7 @@ test "sgr: direct fg/bg/underline ignore optional color space" {
 test "sgr: direct fg colon with too many colons" {
     var p: Parser = .{
         .params = &[_]u16{ 38, 2, 0, 1, 2, 3, 4, 1 },
-        .params_sep = sep: {
-            var list = SepList.initEmpty();
-            for (0..6) |idx| list.set(idx);
-            break :sep list;
-        },
+        .params_sep = testSeps(&.{ 0, 1, 2, 3, 4, 5 }),
     };
 
     try testing.expect(p.next().? == .unknown);
@@ -954,11 +975,7 @@ test "sgr: direct fg colon with too many colons" {
 test "sgr: direct fg colon with colorspace and extra param" {
     var p: Parser = .{
         .params = &[_]u16{ 38, 2, 0, 1, 2, 3, 1 },
-        .params_sep = sep: {
-            var list = SepList.initEmpty();
-            for (0..5) |idx| list.set(idx);
-            break :sep list;
-        },
+        .params_sep = testSeps(&.{ 0, 1, 2, 3, 4 }),
     };
 
     {
@@ -976,11 +993,7 @@ test "sgr: direct fg colon with colorspace and extra param" {
 test "sgr: direct fg colon no colorspace and extra param" {
     var p: Parser = .{
         .params = &[_]u16{ 38, 2, 1, 2, 3, 1 },
-        .params_sep = sep: {
-            var list = SepList.initEmpty();
-            for (0..4) |idx| list.set(idx);
-            break :sep list;
-        },
+        .params_sep = testSeps(&.{ 0, 1, 2, 3 }),
     };
 
     {
@@ -1000,16 +1013,7 @@ test "sgr: kakoune input" {
     // This used to crash
     var p: Parser = .{
         .params = &[_]u16{ 0, 4, 3, 38, 2, 175, 175, 215, 58, 2, 0, 190, 80, 70 },
-        .params_sep = sep: {
-            var list = SepList.initEmpty();
-            list.set(1);
-            list.set(8);
-            list.set(9);
-            list.set(10);
-            list.set(11);
-            list.set(12);
-            break :sep list;
-        },
+        .params_sep = testSeps(&.{ 1, 8, 9, 10, 11, 12 }),
     };
 
     {
@@ -1046,11 +1050,7 @@ test "sgr: kakoune input issue underline, fg, and bg" {
     // This used to crash
     var p: Parser = .{
         .params = &[_]u16{ 4, 3, 38, 2, 51, 51, 51, 48, 2, 170, 170, 170, 58, 2, 255, 97, 136 },
-        .params_sep = sep: {
-            var list = SepList.initEmpty();
-            list.set(0);
-            break :sep list;
-        },
+        .params_sep = testSeps(&.{0}),
     };
 
     {
@@ -1094,12 +1094,7 @@ test "sgr: kakoune input issue underline, fg, and bg" {
 test "sgr: underline colon with trailing separator and short slice" {
     var p: Parser = .{
         .params = &[_]u16{ 58, 4 },
-        .params_sep = sep: {
-            var list = SepList.initEmpty();
-            list.set(0);
-            list.set(1);
-            break :sep list;
-        },
+        .params_sep = testSeps(&.{ 0, 1 }),
     };
 
     // 58:4 is not a valid underline color (sub-param 4 is not 2 or 5),

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -2269,7 +2269,7 @@ pub fn Stream(comptime H: type) type {
                     },
 
                     else => log.warn(
-                        "ignoring unimplemented CSI p with intermediates: {s}",
+                        "ignoring unimplemented CSI q with intermediates: {s}",
                         .{input.intermediates},
                     ),
                 },

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -525,7 +525,7 @@ pub fn Stream(comptime H: type) type {
         pub fn init(options: Options) Self {
             // Initialize the parser
             var parser: Parser = .init();
-            if (options.allocator) |alloc| parser.osc_parser.alloc = alloc;
+            if (options.allocator) |alloc| parser.setAllocator(alloc);
 
             // Initialize the continuation tracker if one is requested.
             var tracker: ?continuationpkg.Tracker = null;
@@ -942,16 +942,12 @@ pub fn Stream(comptime H: type) type {
                 // First parameter digit.
                 '0'...'9' => {
                     self.parser.state = .csi_param;
-                    // param_acc is zero (cleared on escape entry)
-                    // so accumulating is just the digit value.
-                    self.parser.param_acc = c - '0';
-                    self.parser.param_acc_idx = 1;
+                    self.parser.params.digit(c - '0');
                 },
                 // An empty first parameter.
                 ';' => {
                     self.parser.state = .csi_param;
-                    self.parser.params[0] = 0;
-                    self.parser.params_idx = 1;
+                    self.parser.params.push(0, false);
                 },
                 // Private marker (e.g. '?' in "ESC [ ? 2004 h").
                 0x3C...0x3F => {
@@ -976,42 +972,36 @@ pub fn Stream(comptime H: type) type {
             const p = &self.parser;
             assert(p.state == .csi_param);
 
-            // Accumulate parser state in locals for the hot loop.
-            var acc = p.param_acc;
-            var acc_idx = p.param_acc_idx;
-            var idx = p.params_idx;
-
+            // Accumulate the in-progress parameter in locals and write
+            // it back when the loop exits.
+            const params = &p.params;
+            var acc = params.acc;
+            var acc_set = params.acc_set;
             var offset: usize = 0;
             while (offset < input.len) {
                 const c = input[offset];
                 switch (c) {
-                    // A parameter digit.
+                    // A parameter digit. Inlined here, not routed through
+                    // `Params.digit`, so the accumulator stays in
+                    // registers across the whole run of digits.
                     '0'...'9' => {
-                        if (idx < Parser.MAX_PARAMS) {
-                            acc *|= 10;
-                            acc +|= c - '0';
-                            acc_idx |= 1;
-                        }
+                        acc = (acc *| 10) +| (c - '0');
+                        acc_set = true;
                         offset += 1;
                     },
 
                     // A parameter separator.
                     ':', ';' => {
-                        if (idx < Parser.MAX_PARAMS) {
-                            p.params[idx] = acc;
-                            if (c == ':') p.params_sep.set(idx);
-                            idx += 1;
-                            acc = 0;
-                            acc_idx = 0;
-                        }
+                        params.push(acc, c == ':');
+                        acc = 0;
+                        acc_set = false;
                         offset += 1;
                     },
 
                     // A final byte: dispatch the CSI.
                     0x40...0x7E => {
-                        p.param_acc = acc;
-                        p.param_acc_idx = acc_idx;
-                        p.params_idx = idx;
+                        params.acc = acc;
+                        params.acc_set = acc_set;
                         self.csiDispatchFinal(c);
                         return offset + 1;
                     },
@@ -1022,9 +1012,8 @@ pub fn Stream(comptime H: type) type {
                 }
             }
 
-            p.param_acc = acc;
-            p.param_acc_idx = acc_idx;
-            p.params_idx = idx;
+            params.acc = acc;
+            params.acc_set = acc_set;
             return offset;
         }
 
@@ -1233,24 +1222,9 @@ pub fn Stream(comptime H: type) type {
                     // the parser state to ground.
                     0x18, 0x1A => self.parser.state = .ground,
                     // A parameter digit:
-                    '0'...'9' => if (self.parser.params_idx < Parser.MAX_PARAMS) {
-                        self.parser.param_acc *|= 10;
-                        self.parser.param_acc +|= c - '0';
-                        // The parser's CSI param action uses param_acc_idx
-                        // to decide if there's a final param that needs to
-                        // be consumed or not, but it doesn't matter really
-                        // what it is as long as it's not 0.
-                        self.parser.param_acc_idx |= 1;
-                    },
+                    '0'...'9' => self.parser.params.digit(c - '0'),
                     // A parameter separator:
-                    ':', ';' => if (self.parser.params_idx < Parser.MAX_PARAMS) {
-                        self.parser.params[self.parser.params_idx] = self.parser.param_acc;
-                        if (c == ':') self.parser.params_sep.set(self.parser.params_idx);
-                        self.parser.params_idx += 1;
-
-                        self.parser.param_acc = 0;
-                        self.parser.param_acc_idx = 0;
-                    },
+                    ':', ';' => self.parser.params.separator(c == ':'),
                     // A final byte: dispatch the CSI directly.
                     0x40...0x7E => if (comptime !has_vt_raw) {
                         self.csiDispatchFinal(c);
@@ -1326,28 +1300,22 @@ pub fn Stream(comptime H: type) type {
             const p = &self.parser;
             p.state = .ground;
 
-            // Ignore sequences with too many parameters, matching the
-            // parser's behavior of dropping the dispatch entirely.
-            if (p.params_idx >= Parser.MAX_PARAMS) {
-                @branchHint(.unlikely);
+            const params = p.params.take() orelse {
+                Parser.warnCsiParams();
                 return;
-            }
-
-            // Finalize the last parameter if we have one.
-            if (p.param_acc_idx > 0) {
-                p.params[p.params_idx] = p.param_acc;
-                p.params_idx += 1;
-            }
+            };
 
             const action: Parser.Action.CSI = .{
                 .intermediates = p.intermediates[0..p.intermediates_idx],
-                .params = p.params[0..p.params_idx],
-                .params_sep = p.params_sep,
+                .params = params,
+                .params_sep = &p.params.seps,
                 .final = c,
             };
 
-            // We only allow colon or mixed separators for the 'm' command.
-            if (c != 'm' and p.params_sep.count() > 0) {
+            // Only SGR defines colon-joined subparameters. Reading them
+            // positionally elsewhere would turn `CSI 1:2 H` into a
+            // cursor move to (1, 2), so the sequence is dropped.
+            if (p.params.colons and c != 'm') {
                 @branchHint(.cold);
                 log.warn(
                     "CSI colon or mixed separators only allowed for 'm' command, got: {f}",
@@ -4091,6 +4059,10 @@ test "stream: SCORC" {
 
 test "stream: too many csi params" {
     const H = struct {
+        pub fn deinit(self: *@This()) void {
+            _ = self;
+        }
+
         pub fn vt(
             self: *@This(),
             comptime action: anytype,
@@ -4105,8 +4077,14 @@ test "stream: too many csi params" {
         }
     };
 
-    var s: Stream(H) = .init(.{ .handler = .{} });
-    s.nextSlice("\x1B[1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1;1C");
+    var s: Stream(H) = .init(.{
+        .handler = .{},
+        .allocator = testing.allocator,
+    });
+    defer s.deinit();
+    s.nextSlice("\x1B[");
+    for (0..Parser.MAX_PARAMS) |_| s.nextSlice("1;");
+    s.nextSlice("1C");
 }
 
 test "stream: csi param too long" {

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -4081,6 +4081,29 @@ test "stream: too many csi params" {
     s.nextSlice("1C");
 }
 
+test "stream: CSI subparameters only reach the finals that define them" {
+    const H = struct {
+        pos: ?Action.CursorPos = null,
+
+        pub fn vt(
+            self: *@This(),
+            comptime action: anytype,
+            value: anytype,
+        ) void {
+            switch (action) {
+                .cursor_pos => self.pos = value,
+                else => {},
+            }
+        }
+    };
+
+    // CUP defines no subparameters. The colon drops the sequence; it
+    // does not move the cursor to (1, 2).
+    var s: Stream(H) = .init(.{ .handler = .{} });
+    s.nextSlice("\x1B[1:2H");
+    try testing.expect(s.handler.pos == null);
+}
+
 test "stream: csi param too long" {
     const H = struct {
         pub fn vt(

--- a/src/terminal/stream.zig
+++ b/src/terminal/stream.zig
@@ -1312,15 +1312,9 @@ pub fn Stream(comptime H: type) type {
                 .final = c,
             };
 
-            // Only SGR defines colon-joined subparameters. Reading them
-            // positionally elsewhere would turn `CSI 1:2 H` into a
-            // cursor move to (1, 2), so the sequence is dropped.
-            if (p.params.colons and c != 'm') {
+            if (p.params.colons and !action.allowsSubparams()) {
                 @branchHint(.cold);
-                log.warn(
-                    "CSI colon or mixed separators only allowed for 'm' command, got: {f}",
-                    .{action},
-                );
+                Parser.warnCsiSepMismatch(action);
                 return;
             }
 


### PR DESCRIPTION
CSI allows for BOTH `;` params AND `:` subparams. Prior to this, the parser
would discard sequences containing colons unless the last byte was `m`.
That mixed command policy into syntax parsing, and caused a little issue for my
later work on the multi-cursor protocol, which makes great use of subparams.

In this change:
- I introuce a `Parser.Params` so the bytewise parser and the stream *fast path*
  share accumulation, overflow, and separator handling;
- Preserve separator bits on every CSI dispatch rather than treating colons as
  a parser error;
- Keep 24 parameters inline and (addressing an earlier comment) growing allocator-backed streams only for larger
  batches. I borrow from Kitty's internal limit of 256, but I can't say there's a good reason to bound it, other than it's
  super bad terminal behavior.
  For now over-limit sequences as a unit in comparison to sendin a dispatch on a truncation.

A colon is only *meaningful* to a command that defines a subparameter (ECMA-48
5.4.2). One predicate, `Action.CSI.allowsSubparams`, says which finals those
are: `m` (SGR) and `CSI > ... SP q` (this protocol). Anything else carrying a
colon gets dropped whole with a cold warning. Read positionally, `CSI 1:2 H`
would be a cursor move to (1, 2). The bytewise state machine and the stream fast
path both call that one predicate, so they can't drift apart.

Separator bits live in a `StaticBitSet` next to the parameters. Two things keep
that off the hot path. `Params` remembers whether it saw a colon *at all*, so
`reset` skips clearing the 32-byte mask on nearly every sequence. And consumers
borrow the bit set by pointer instead of copying it into each dispatch.

SGR behavior is otherwise unchanged. Other CSI commands still get their param
values with no allowlist in the way; the consumers that actually need
subparameter structure read the separator bits.

Added tests that work on bytewise and stream parsing, mixed separators, separator
reset, inline and spilled storage, allocation failure, the 256-parameter
boundary, and that subparameters only reach the finals that define them.

AI DISCLOSURE: I used $llm(s) for research/hardening of implementation and differential testing against Kitty. I wrote the initial Zig code and then got cross-references and reviewed improved style/structure to match idioms (I'm a rust dev). All work is double + triple checked, but let me know if anything feels weird, want to get good at Zig and ideally write more of any future PRs by hand (to become a not ai driver with real skillz!!)
