### PR TITLE
nix: update zon2nix to 0.7.0

### DIFF
--- a/build.zig.zon.nix
+++ b/build.zig.zon.nix
@@ -130,7 +130,7 @@
     }
     ''
       mkdir -p "$out"
-      cp --recursive --symbolic-link --dereference --no-preserve=mode \
+      cp --recursive --link --dereference --no-preserve=mode \
         ${linkFarm farm entries}/. "$out/"
     '';
 in

--- a/build.zig.zon.nix
+++ b/build.zig.zon.nix
@@ -111,11 +111,24 @@
   # puts it when the sandbox is off. Real directories make the two depths
   # agree, so it works either way.
   #
-  # Only the directories have to be real. `--symbolic-link` leaves the files
-  # pointing into each dependency's own store path, so the farm is a few
-  # megabytes of symlinks rather than a second copy of every dependency, two
-  # projects sharing a dependency share it in the store, and a file keeps the
-  # mode it was fetched with.
+  # The files have to be real as well, which is the expensive part and cannot
+  # be avoided. `--symbolic-link` would leave them pointing into each
+  # dependency's own store path, so that the farm is a few megabytes rather
+  # than a second copy of every dependency -- but Zig's
+  # `installHeadersDirectory` walks the directory and copies only the entries
+  # whose kind is `.file`. Symlinked headers are skipped without a word, and
+  # the first thing to include one fails with `'dcimgui.h' not found`.
+  #
+  # `--link` is not the way out. A hard link into a Nix output is a file the
+  # builder did not create: inside the Linux sandbox the store is a separate
+  # mount and `link` fails with `Invalid cross-device link`, while on Darwin it
+  # succeeds and leaves root-owned files in the output, which Nix refuses while
+  # canonicalising with `invalid ownership on file`.
+  #
+  # So it is a real copy, with `--reflink=auto` to share the blocks on a
+  # filesystem that can. `nix store optimise` recovers the duplication after
+  # the fact, hard-linking identical files across the store, which is the
+  # store's own business to do and not a build's.
   copyFarm = farm: entries: pathDependencyPackages:
     runCommandLocal farm
     {
@@ -130,7 +143,7 @@
     }
     ''
       mkdir -p "$out"
-      cp --recursive --link --dereference --no-preserve=mode \
+      cp --recursive --reflink=auto --dereference --no-preserve=mode \
         ${linkFarm farm entries}/. "$out/"
     '';
 in

--- a/build.zig.zon.nix
+++ b/build.zig.zon.nix
@@ -21,7 +21,7 @@
     ''
       # workaround https://codeberg.org/ziglang/zig/issues/31866
       # https://github.com/Cloudef/zig2nix/issues/54
-      mkdir "$TMPDIR/src" "$TMPDIR/cache"
+      mkdir "$TMPDIR/src" "$TMPDIR/cache" "$TMPDIR/cache/tmp"
       touch "$TMPDIR/src/build.zig"
       hash="$(cd "$TMPDIR/src" && zig fetch --global-cache-dir "$TMPDIR/cache" ${artifact})"
       mkdir "$out"
@@ -95,8 +95,47 @@
     };
   in
     fetcher.${proto};
+  # The packages, as real directories holding symlinked files, rather than as
+  # a farm of symlinked directories.
+  #
+  # Zig runs a dependency's own build steps with the working directory set to
+  # that dependency, and points at the program to run with a path counted in
+  # directories up from there. Through a symlink the two disagree: Zig counts
+  # from `<farm>/<package>/`, four directories below the root, while the kernel
+  # resolves the working directory to `/nix/store/<hash>`, which is three, so
+  # the path lands one short of where the program is.
+  #
+  # It works anyway when the build directory is `/build`, because the sum then
+  # overshoots into the root and going above the root stays there. It fails
+  # when the build directory is under `/nix/var/nix/builds`, which is where Nix
+  # puts it when the sandbox is off. Real directories make the two depths
+  # agree, so it works either way.
+  #
+  # Only the directories have to be real. `--symbolic-link` leaves the files
+  # pointing into each dependency's own store path, so the farm is a few
+  # megabytes of symlinks rather than a second copy of every dependency, two
+  # projects sharing a dependency share it in the store, and a file keeps the
+  # mode it was fetched with.
+  copyFarm = farm: entries: pathDependencyPackages:
+    runCommandLocal farm
+    {
+      # The packages whose own manifest declares a dependency by `.path`.
+      # Zig 0.16.0 cannot build these through `zig build --system`: it spins
+      # in userspace forever, because a `.path` dependency's hash is computed
+      # against the system package directory during the fetch and against the
+      # real global cache afterwards, and in that mode the two disagree. A
+      # package that wants `--system` copies each of these into its build
+      # root and passes `--fork=`; see the README.
+      passthru = {inherit pathDependencyPackages;};
+    }
+    ''
+      mkdir -p "$out"
+      cp --recursive --symbolic-link --dereference --no-preserve=mode \
+        ${linkFarm farm entries}/. "$out/"
+    '';
 in
-  linkFarm name [
+  copyFarm name
+  [
     {
       name = "aro-0.0.0-JSD1Qk6lNgDdcDV4Vh7Sfy-34m2TluIVOdPzMmj_0BjX";
       path = fetchZigArtifact {
@@ -439,4 +478,6 @@ in
         unpack = false;
       };
     }
+  ]
+  [
   ]

--- a/flake.lock
+++ b/flake.lock
@@ -108,11 +108,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788972981,
-        "narHash": "sha256-MxVNwu1U7XWL/8HYzDDiaHjfIFE2yz/7J64vRUO7ZzA=",
+        "lastModified": 1788977680,
+        "narHash": "sha256-3vgICcen5N2oAlQrijqJhxn8HEsnXASGPxQLJVYzX0Q=",
         "owner": "jcollie",
         "repo": "zon2nix",
-        "rev": "36de3f085bffe0335774392111bff0ab0e0efeba",
+        "rev": "7b9c43312de08e176097b8c8920f0dd1a46982be",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -108,11 +108,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788969032,
-        "narHash": "sha256-e8kFWqmoPM43Vh5N5JbvE/Nb0LS91BLfIJGHxr36Sk8=",
+        "lastModified": 1788972981,
+        "narHash": "sha256-MxVNwu1U7XWL/8HYzDDiaHjfIFE2yz/7J64vRUO7ZzA=",
         "owner": "jcollie",
         "repo": "zon2nix",
-        "rev": "99f104979784372d3b969dd480d76aeba521b920",
+        "rev": "36de3f085bffe0335774392111bff0ab0e0efeba",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -108,11 +108,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784080626,
-        "narHash": "sha256-Hvnmnuu0VpHiZl+8z+UkMoxC7JZJvRYBqu2Asb0ZJOE=",
+        "lastModified": 1788969032,
+        "narHash": "sha256-e8kFWqmoPM43Vh5N5JbvE/Nb0LS91BLfIJGHxr36Sk8=",
         "owner": "jcollie",
         "repo": "zon2nix",
-        "rev": "776b5f6864a607c141d7966421b433fa1657ba9a",
+        "rev": "99f104979784372d3b969dd480d76aeba521b920",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
1. Speeds up runs by ~3x for projects with a large number of dependencies by downloading in parallel (~55s → 16s on my workstation).

2. Adds some workarounds for Zig 0.16's package management. The changes don't affect Ghostty itself, but do affect downstream projects that embed libghostty-vt and want to create Nix packages of their own.

AI disclosure: Claude was used to diagnose CI failures and suggest fixes.