### PR TITLE
terminal: consume unused row capacity when a page grows managed memory

### DIFF
--- a/src/terminal/PageList.zig
+++ b/src/terminal/PageList.zig
@@ -4165,6 +4165,13 @@ pub const IncreaseCapacityError = error{
 /// (we currently double every time) but callers shouldn't depend on that.
 /// The only guarantee is some amount of growth.
 ///
+/// Growing a managed dimension can push the layout past the standard
+/// page size, which would move the page out of the memory pool onto
+/// its own heap mapping. Before that happens, unused row capacity is
+/// traded for the requested memory: the new page keeps every row the
+/// page currently uses (`size.rows`) but its row capacity may shrink.
+/// Callers must not assume row capacity never decreases.
+///
 /// Adjustment can be null if you want to recreate, reclone the page
 /// with the same capacity. This is a special case used for rehashing since
 /// the logic is otherwise the same. In this case, OutOfMemory is the
@@ -4283,6 +4290,15 @@ pub fn increaseCapacity(
                     break :project;
                 cap = proj_cap;
             }
+
+            // Trade unused row capacity for the requested managed memory so
+            // that the page stays a standard size and therefore pooled (see
+            // the doc comment). If it doesn't fit even with every unused row
+            // gone, the page goes non-standard with its rows intact, as before.
+            if (cap.fitRows(
+                std_size,
+                @max(page.size.rows, 1),
+            )) |fit| cap = fit;
         },
     };
 
@@ -4292,7 +4308,8 @@ pub fn increaseCapacity(
     const new_node = try self.createPage(.{ .cap = cap });
     errdefer self.destroyNode(new_node);
     const new_page: *Page = new_node.page();
-    assert(new_page.capacity.rows >= page.capacity.rows);
+    assert(new_page.capacity.rows >= page.size.rows);
+    assert(new_page.capacity.rows >= 1);
     assert(new_page.capacity.cols >= page.capacity.cols);
     new_page.size.rows = page.size.rows;
     new_page.size.cols = page.size.cols;
@@ -19224,6 +19241,78 @@ test "PageList grow reuses non-standard page without leak" {
     try testing.expectEqual(0, tracked_pin.x);
     try testing.expectEqual(0, tracked_pin.y);
     try testing.expect(tracked_pin.garbage);
+}
+
+test "PageList increaseCapacity sheds unused rows to stay standard" {
+    const testing = std.testing;
+
+    var s = try init(testing.allocator, .{ .cols = 80, .rows = 24 });
+    defer s.deinit();
+
+    // Grow styles repeatedly on a page that uses only its active rows.
+    // Each step gives up unused row capacity instead of leaving the pool.
+    var node = s.pages.first.?;
+    const old_rows = node.capacity().rows;
+    const old_styles = node.capacity().styles;
+    for (0..4) |_| node = try s.increaseCapacity(node, .styles);
+
+    try testing.expect(node.capacity().styles > old_styles);
+    try testing.expect(node.capacity().rows < old_rows);
+    try testing.expect(node.capacity().rows >= node.rows());
+    try testing.expectEqual(@as(usize, 24), node.rows());
+    try testing.expectEqual(Node.Owned.pool, node.owned);
+    try testing.expect(node.page().memory.len <= std_size);
+    try testing.expectEqual(std_size, s.page_size);
+
+    // The page still serves the active area and grows normally into
+    // a fresh standard page once its (smaller) row capacity is used up.
+    while (node.rows() < node.capacity().rows) _ = try s.grow();
+    const fresh = (try s.grow()).?;
+    try testing.expect(fresh != node);
+    try testing.expectEqual(Node.Owned.pool, fresh.owned);
+    try testing.expectEqual(old_rows, fresh.capacity().rows);
+}
+
+test "PageList increaseCapacity keeps rows when none can be shed" {
+    const testing = std.testing;
+
+    var s = try init(testing.allocator, .{ .cols = 80, .rows = 24 });
+    defer s.deinit();
+
+    // Fill the page completely so there is no unused row capacity.
+    var node = s.pages.first.?;
+    while (node.rows() < node.capacity().rows) _ = try s.grow();
+    const full_rows = node.capacity().rows;
+
+    // Growth now has nothing to trade and goes non-standard as before,
+    // with every row intact.
+    node = try s.increaseCapacity(node, .styles);
+    try testing.expectEqual(full_rows, node.capacity().rows);
+    try testing.expectEqual(full_rows, node.rows());
+    try testing.expect(node.page().memory.len > std_size);
+    try testing.expectEqual(Node.Owned.heap, node.owned);
+}
+
+test "PageList increaseCapacity sheds rows down to the used rows" {
+    const testing = std.testing;
+
+    var s = try init(testing.allocator, .{ .cols = 80, .rows = 24 });
+    defer s.deinit();
+
+    // Keep doubling graphemes. Rows are shed as needed until only the
+    // used rows remain, after which the page must leave the pool.
+    var node = s.pages.first.?;
+    var saw_shed = false;
+    while (node.page().memory.len <= std_size) {
+        const before = node.capacity().rows;
+        node = try s.increaseCapacity(node, .grapheme_bytes);
+        try testing.expect(node.capacity().rows >= node.rows());
+        if (node.capacity().rows < before) saw_shed = true;
+    }
+    try testing.expect(saw_shed);
+    try testing.expectEqual(@as(usize, 24), node.rows());
+    try testing.expectEqual(Node.Owned.heap, node.owned);
+    s.assertIntegrity();
 }
 
 test "PageList grow non-standard page prune protection" {

--- a/src/terminal/page.zig
+++ b/src/terminal/page.zig
@@ -1998,6 +1998,46 @@ pub const Capacity = struct {
         return adjusted;
     }
 
+    /// Reduce the row capacity, but never below `min_rows`, until the
+    /// page layout fits within `max_size` bytes. Returns the capacity
+    /// unchanged if it already fits, and null if it can't fit even at
+    /// `min_rows` rows.
+    pub fn fitRows(
+        self: Capacity,
+        max_size: usize,
+        min_rows: size.CellCountInt,
+    ) ?Capacity {
+        assert(min_rows > 0);
+        var adjusted = self;
+        const total = Page.layout(adjusted).total_size;
+        if (total <= max_size) return adjusted;
+        if (adjusted.rows <= min_rows) return null;
+
+        // Jump most of the way with the per-row byte cost. `total` is
+        // rounded up to whole OS pages so this can overshoot by up to a
+        // page worth of rows, and alignment padding between rows, cells
+        // and metadata can make it undershoot by a few rows. Step down
+        // until it fits, then back up to the largest row count that
+        // still fits, so that the shed is minimal.
+        const bytes_per_row: usize = @sizeOf(Row) + @sizeOf(Cell) * @as(usize, self.cols);
+        const shed = std.math.divCeil(usize, total - max_size, bytes_per_row) catch unreachable;
+        adjusted.rows = @intCast(@max(
+            @as(usize, min_rows),
+            @as(usize, adjusted.rows) -| shed,
+        ));
+        while (Page.layout(adjusted).total_size > max_size) {
+            if (adjusted.rows <= min_rows) return null;
+            adjusted.rows -= 1;
+        }
+        while (adjusted.rows < self.rows) {
+            var more = adjusted;
+            more.rows += 1;
+            if (Page.layout(more).total_size > max_size) break;
+            adjusted = more;
+        }
+        return adjusted;
+    }
+
     /// Computes the number of bytes available for the row headers and
     /// cells in the page: the page size minus the metadata block.
     fn availableBytesForGrid(self: Capacity) usize {
@@ -2788,6 +2828,51 @@ test "Cell is zero by default" {
     // The zero value should be output type for semantic content.
     // This is very important for our assumptions elsewhere.
     try std.testing.expectEqual(Cell.SemanticContent.output, cell.semantic_content);
+}
+
+test "Capacity fitRows keeps a fitting capacity" {
+    const budget = Page.layout(std_capacity).total_size;
+    const cap = std_capacity.fitRows(budget, 1).?;
+    try testing.expectEqual(std_capacity, cap);
+}
+
+test "Capacity fitRows sheds only the rows needed" {
+    const budget = Page.layout(std_capacity).total_size;
+
+    var grown = std_capacity;
+    grown.styles *= 8;
+    try testing.expect(Page.layout(grown).total_size > budget);
+
+    const fit = grown.fitRows(budget, 1).?;
+    try testing.expectEqual(grown.cols, fit.cols);
+    try testing.expectEqual(grown.styles, fit.styles);
+    try testing.expectEqual(grown.grapheme_bytes, fit.grapheme_bytes);
+    try testing.expectEqual(grown.hyperlink_bytes, fit.hyperlink_bytes);
+    try testing.expectEqual(grown.string_bytes, fit.string_bytes);
+    try testing.expect(fit.rows < grown.rows);
+    try testing.expect(Page.layout(fit).total_size <= budget);
+
+    // One more row would not fit: the shed is minimal.
+    var one_more = fit;
+    one_more.rows += 1;
+    try testing.expect(Page.layout(one_more).total_size > budget);
+}
+
+test "Capacity fitRows respects the row floor" {
+    const budget = Page.layout(std_capacity).total_size;
+
+    var grown = std_capacity;
+    grown.styles *= 8;
+    const fit = grown.fitRows(budget, 1).?;
+
+    // A floor above what fits means it can't fit.
+    try testing.expect(grown.fitRows(budget, fit.rows + 1) == null);
+    // A floor exactly at what fits is honored.
+    try testing.expectEqual(fit.rows, grown.fitRows(budget, fit.rows).?.rows);
+    // Even a single row can't absorb an absurd managed dimension.
+    var huge = std_capacity;
+    huge.grapheme_bytes = @intCast(budget * 2);
+    try testing.expect(huge.fitRows(budget, 1) == null);
 }
 
 test "Page capacity adjust cols down" {


### PR DESCRIPTION
`Page.increaseCapacity` previously would only try to fit capacity increases for managed memory into remaining `std_size` space. This meant that every single initial increase would exceed std_size and force heap allocation, which is slow for a variety of reasons.

This commit changes `increaseCapacity` to consume unused row capacity if it has it in order to fit more managed memory. Practically: if a page has 350 row capacity, but has only written 40 rows, we'll shrink rows to make room for styles, or whatever.

If it can't fit the desired capacity even by shrinking rows to what is currently used, then the page goes non-standard with the existing capacity retained.

Benchmark is `ghostty-bench +terminal-stream` on a 128MB file of the given general corpus produced by `ghostty-gen`.

macOS (Apple Silicon, 16 KiB pages):

  | Corpus | Base     | This PR           |
  |--------|---------:|---------------:|
  | styled |   651 ms |   588 ms (-10%) |
  | utf8   |   716 ms |   683 ms  (-5%) |
  | mixed  | 5,419 ms | 5,674 ms  (+5%) |
  | osc    | 3,074 ms | 3,095 ms  (+1%) |

EDIT: I should add that the reason that mixed/osc are more expensive is because they don't have the projection optimization I did for graphemes+styles. Under the "laddering" case (double, double, double), this optimization is worse because repeatedly swapping items in the pool is actually more expensive than a heap allocation. I have some fixes for that coming, but I don't think these represent realistic workloads currently and that style-heavy workloads are more realistic.

If I'm wrong then well, its a one-line backout really. 