### PR TITLE
app: add window theme switching action

### DIFF
--- a/include/ghostty.h
+++ b/include/ghostty.h
@@ -863,6 +863,13 @@ typedef struct {
   bool soft;
 } ghostty_action_reload_config_s;
 
+// apprt.action.WindowTheme
+typedef enum {
+  GHOSTTY_ACTION_WINDOW_THEME_DARK,
+  GHOSTTY_ACTION_WINDOW_THEME_LIGHT,
+  GHOSTTY_ACTION_WINDOW_THEME_SYSTEM,
+} ghostty_action_window_theme_e;
+
 // apprt.action.OpenUrlKind
 typedef enum {
   GHOSTTY_ACTION_OPEN_URL_KIND_UNKNOWN,
@@ -1009,6 +1016,7 @@ typedef enum {
   GHOSTTY_ACTION_READONLY,
   GHOSTTY_ACTION_COPY_TITLE_TO_CLIPBOARD,
   GHOSTTY_ACTION_MOVE_TAB_TO_NEW_WINDOW,
+  GHOSTTY_ACTION_SET_WINDOW_THEME,
 } ghostty_action_tag_e;
 
 typedef union {
@@ -1052,6 +1060,7 @@ typedef union {
   ghostty_action_search_selected_s search_selected;
   ghostty_action_readonly_e readonly;
   ghostty_action_open_config_e open_config;
+  ghostty_action_window_theme_e set_window_theme;
 } ghostty_action_u;
 
 typedef struct {

--- a/macos/GhosttyUITests/GhosttyThemeTests.swift
+++ b/macos/GhosttyUITests/GhosttyThemeTests.swift
@@ -144,6 +144,54 @@ final class GhosttyThemeTests: GhosttyCustomConfigCase {
     }
 
     @MainActor
+    func testSwitchingAppearanceFromCommandPalette() async throws {
+        try updateConfig("""
+        title=\(windowTitle)
+        window-theme=dark
+        macos-titlebar-style=native
+        keybind=cmd+shift+l=set_window_theme:light
+        """)
+        XCUIDevice.shared.appearance = .dark
+
+        let app = try ghosttyApplication()
+        app.launch()
+        try assertTitlebarAppearance(.dark, for: app)
+
+        app.menuItems["Command Palette"].firstMatch.click()
+        app.buttons
+            .containing(NSPredicate(format: "label CONTAINS[c] 'Switch to Light Appearance'"))
+            .firstMatch.click()
+        try await Task.sleep(for: .seconds(0.5))
+        try assertTitlebarAppearance(.light, for: app)
+
+        // Reloading without changing window-theme preserves the override.
+        app.typeKey(",", modifierFlags: [.command, .shift])
+        try await Task.sleep(for: .seconds(0.5))
+        try assertTitlebarAppearance(.light, for: app)
+
+        app.menuItems["Command Palette"].firstMatch.click()
+        app.buttons
+            .containing(NSPredicate(format: "label CONTAINS[c] 'Switch to System Appearance'"))
+            .firstMatch.click()
+        try await Task.sleep(for: .seconds(0.5))
+        try assertTitlebarAppearance(.dark, for: app)
+
+        app.typeKey("l", modifierFlags: [.command, .shift])
+        try await Task.sleep(for: .seconds(0.5))
+        try assertTitlebarAppearance(.light, for: app)
+
+        // Changing window-theme also preserves the session override.
+        try updateConfig("""
+        title=\(windowTitle)
+        window-theme=system
+        macos-titlebar-style=native
+        """)
+        app.typeKey(",", modifierFlags: [.command, .shift])
+        try await Task.sleep(for: .seconds(0.5))
+        try assertTitlebarAppearance(.light, for: app)
+    }
+
+    @MainActor
     func testQuickTerminalThemeChange() async throws {
         try updateConfig("title=\(windowTitle) \n theme=light:3024 Day,dark:3024 Night \n confirm-close-surface=false")
         XCUIDevice.shared.appearance = .light

--- a/macos/Sources/App/AppDelegate.swift
+++ b/macos/Sources/App/AppDelegate.swift
@@ -17,6 +17,20 @@ class AppDelegate: NSObject,
         category: String(describing: AppDelegate.self)
     )
 
+    enum Appearance {
+        case dark
+        case light
+        case system
+
+        var nsAppearance: NSAppearance? {
+            switch self {
+            case .dark: NSAppearance(named: .darkAqua)
+            case .light: NSAppearance(named: .aqua)
+            case .system: nil
+            }
+        }
+    }
+
     /// Various menu items so that we can programmatically sync the keyboard shortcut with the Ghostty config
     @IBOutlet private var menuAbout: NSMenuItem?
     @IBOutlet private var menuServices: NSMenu?
@@ -103,6 +117,9 @@ class AppDelegate: NSObject,
 
     /// This is the current configuration from the Ghostty configuration that we need.
     private var derivedConfig: DerivedConfig = DerivedConfig()
+
+    /// The application appearance selected for this session.
+    private(set) var appearanceOverride: Appearance?
 
     /// The ghostty global state. Only one per process.
     let ghostty: Ghostty.App
@@ -852,9 +869,23 @@ class AppDelegate: NSObject,
         updateAppIcon(from: config)
     }
 
+    /// Temporarily override the configured application appearance for this session.
+    func setAppearance(_ appearance: Appearance) {
+        appearanceOverride = appearance
+        syncAppearance(config: ghostty.config)
+
+        NSApplication.shared.windows
+            .compactMap { $0.windowController as? BaseTerminalController }
+            .forEach { $0.syncAppearance() }
+    }
+
     /// Sync the appearance of our app with the theme specified in the config.
     private func syncAppearance(config: Ghostty.Config) {
-        NSApplication.shared.appearance = .init(ghosttyConfig: config)
+        NSApplication.shared.appearance = if let appearanceOverride {
+            appearanceOverride.nsAppearance
+        } else {
+            .init(ghosttyConfig: config)
+        }
     }
 
     private func updateAppIcon(from config: Ghostty.Config) {

--- a/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
+++ b/macos/Sources/Features/Terminal/Window Styles/TerminalWindow.swift
@@ -472,7 +472,11 @@ class TerminalWindow: NSWindow {
         defer { updateColorSchemeForSurfaceTree() }
 
         // Basic properties
-        appearance = surfaceConfig.windowAppearance
+        appearance = if let appearanceOverride = (NSApp.delegate as? AppDelegate)?.appearanceOverride {
+            appearanceOverride.nsAppearance
+        } else {
+            surfaceConfig.windowAppearance
+        }
         hasShadow = surfaceConfig.macosWindowShadow
 
         // Window transparency only takes effect if our window is not native fullscreen.

--- a/macos/Sources/Ghostty/Ghostty.App.swift
+++ b/macos/Sources/Ghostty/Ghostty.App.swift
@@ -723,6 +723,9 @@ extension Ghostty {
             case GHOSTTY_ACTION_RELOAD_CONFIG:
                 configReload(app, target: target, v: action.action.reload_config)
 
+            case GHOSTTY_ACTION_SET_WINDOW_THEME:
+                setWindowTheme(action.action.set_window_theme)
+
             case GHOSTTY_ACTION_COLOR_CHANGE:
                 colorChange(app, target: target, change: action.action.color_change)
 
@@ -2330,6 +2333,21 @@ extension Ghostty {
 
             default:
                 assertionFailure()
+            }
+        }
+
+        private static func setWindowTheme(_ theme: ghostty_action_window_theme_e) {
+            guard let appDelegate = NSApplication.shared.delegate as? AppDelegate else { return }
+
+            switch theme {
+            case GHOSTTY_ACTION_WINDOW_THEME_DARK:
+                appDelegate.setAppearance(.dark)
+            case GHOSTTY_ACTION_WINDOW_THEME_LIGHT:
+                appDelegate.setAppearance(.light)
+            case GHOSTTY_ACTION_WINDOW_THEME_SYSTEM:
+                appDelegate.setAppearance(.system)
+            default:
+                Ghostty.logger.warning("unknown window theme=\(theme.rawValue, privacy: .public)")
             }
         }
 

--- a/po/be.po
+++ b/po/be.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-09-10 10:50-0400\n"
 "PO-Revision-Date: 2026-04-14 00:00+0000\n"
 "Last-Translator: Illia Krauchanka <illiakrauchanka@gmail.com>\n"
 "Language-Team: Belarusian\n"
@@ -49,7 +49,7 @@ msgstr "Перазагрузіць канфігурацыю, каб паказа
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2263
+#: src/apprt/gtk/class/application.zig:2296
 msgid "Cancel"
 msgstr "Скасаваць"
 
@@ -193,7 +193,7 @@ msgid "New Tab"
 msgstr "Новая ўкладка"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:242
-#: src/input/command.zig:613
+#: src/input/command.zig:631
 msgid "Close Tab"
 msgstr "Закрыць укладку"
 
@@ -211,7 +211,7 @@ msgid "New Window"
 msgstr "Новае акно"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:416 src/apprt/gtk/ui/1.5/window.blp:225
-#: src/input/command.zig:630
+#: src/input/command.zig:648
 msgid "Close Window"
 msgstr "Закрыць акно"
 
@@ -255,11 +255,11 @@ msgstr "Палітра каманд"
 msgid "Terminal Inspector"
 msgstr "Інспектар тэрмінала"
 
-#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1991
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1997
 msgid "About Ghostty"
 msgstr "Пра Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:702
+#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:720
 msgid "Quit"
 msgstr "Выйсці"
 
@@ -267,27 +267,27 @@ msgstr "Выйсці"
 msgid "Execute a command…"
 msgstr "Выканаць каманду…"
 
-#: src/apprt/gtk/class/application.zig:1767
+#: src/apprt/gtk/class/application.zig:1779
 msgid "The keybind was revoked by the system."
 msgstr "Спалучэнне клавіш адклікана сістэмай."
 
-#: src/apprt/gtk/class/application.zig:1769
+#: src/apprt/gtk/class/application.zig:1781
 msgid "The keybind was denied by the system."
 msgstr "Спалучэнне клавіш адхілена сістэмай."
 
-#: src/apprt/gtk/class/application.zig:1780
+#: src/apprt/gtk/class/application.zig:1792
 msgid "Global keybind unavailable"
 msgstr "Глабальнае спалучэнне клавіш недаступна."
 
-#: src/apprt/gtk/class/application.zig:2259
+#: src/apprt/gtk/class/application.zig:2292
 msgid "Export Terminal IO Events"
 msgstr "Экспартаваць падзеі ўводу-вываду тэрмінала"
 
-#: src/apprt/gtk/class/application.zig:2262
+#: src/apprt/gtk/class/application.zig:2295
 msgid "Export"
 msgstr "Экспартаваць"
 
-#: src/apprt/gtk/class/application.zig:2783
+#: src/apprt/gtk/class/application.zig:2827
 msgid "Editing configuration file"
 msgstr "Рэдагаванне файла канфігурацыі"
 
@@ -351,16 +351,16 @@ msgstr "Усе сесіі тэрмінала ў гэтым акне будуць
 msgid "The currently running process in this split will be terminated."
 msgstr "Бягучы працэс у гэтым падзеле будзе завершаны."
 
-#: src/apprt/gtk/class/surface.zig:1181
+#: src/apprt/gtk/class/surface.zig:1194
 msgid "Command Finished"
 msgstr "Каманда завершана"
 
-#: src/apprt/gtk/class/surface.zig:1182
+#: src/apprt/gtk/class/surface.zig:1195
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Каманда выканана паспяхова"
 
-#: src/apprt/gtk/class/surface.zig:1183
+#: src/apprt/gtk/class/surface.zig:1196
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Каманда завершылася з памылкай"
@@ -377,19 +377,19 @@ msgstr "Змяніць назву ўкладкі"
 msgid "Change Window Title"
 msgstr "Змяніць назву акна"
 
-#: src/apprt/gtk/class/window.zig:1153
+#: src/apprt/gtk/class/window.zig:1159
 msgid "Reloaded the configuration"
 msgstr "Канфігурацыя перазагружана"
 
-#: src/apprt/gtk/class/window.zig:1830
+#: src/apprt/gtk/class/window.zig:1836
 msgid "Copied to clipboard"
 msgstr "Скапіявана ў буфер абмену"
 
-#: src/apprt/gtk/class/window.zig:1832
+#: src/apprt/gtk/class/window.zig:1838
 msgid "Cleared clipboard"
 msgstr "Буфер абмену ачышчаны"
 
-#: src/apprt/gtk/class/window.zig:1972
+#: src/apprt/gtk/class/window.zig:1978
 msgid "Ghostty Developers"
 msgstr "Распрацоўшчыкі Ghostty"
 
@@ -408,7 +408,9 @@ msgstr "Скапіяваць у буфер абмену"
 #: src/input/command.zig:156
 msgid ""
 "Copy the selected text to the clipboard in both plain and styled formats."
-msgstr "Скапіяваць вылучаны тэкст у буфер абмену ў двух фарматах: звычайным і фарматаваным."
+msgstr ""
+"Скапіяваць вылучаны тэкст у буфер абмену ў двух фарматах: звычайным і "
+"фарматаваным."
 
 #: src/input/command.zig:159
 msgid "Copy Selection as Plain Text to Clipboard"
@@ -424,7 +426,8 @@ msgstr "Скапіяваць вылучэнне як ANSI-паслядоўнас
 
 #: src/input/command.zig:164
 msgid "Copy the selected text as ANSI escape sequences to the clipboard."
-msgstr "Скапіяваць вылучаны тэкст як кіруючыя паслядоўнасці ANSI ў буфер абмену."
+msgstr ""
+"Скапіяваць вылучаны тэкст як кіруючыя паслядоўнасці ANSI ў буфер абмену."
 
 #: src/input/command.zig:167
 msgid "Copy Selection as HTML to Clipboard"
@@ -450,7 +453,9 @@ msgstr "Скапіяваць назву тэрмінала ў буфер абм�
 msgid ""
 "Copy the terminal title to the clipboard. If the terminal title is not set "
 "this has no effect."
-msgstr "Скапіяваць назву тэрмінала ў буфер абмену. Калі назва тэрмінала не ўстаноўлена, дзеянне не мае эфекту."
+msgstr ""
+"Скапіяваць назву тэрмінала ў буфер абмену. Калі назва тэрмінала не "
+"ўстаноўлена, дзеянне не мае эфекту."
 
 #: src/input/command.zig:185
 msgid "Paste from Clipboard"
@@ -596,7 +601,8 @@ msgstr "Скапіяваць экран у часовы файл і скапія
 msgid ""
 "Copy the screen contents to a temporary file and copy the path to the "
 "clipboard."
-msgstr "Скапіяваць змест экрана ў часовы файл і скапіяваць шлях у буфер абмену."
+msgstr ""
+"Скапіяваць змест экрана ў часовы файл і скапіяваць шлях у буфер абмену."
 
 #: src/input/command.zig:291
 msgid "Copy Screen to Temporary File and Paste Path"
@@ -623,7 +629,9 @@ msgstr "Скапіяваць экран як HTML у часовы файл і с
 msgid ""
 "Copy the screen contents as HTML to a temporary file and copy the path to "
 "the clipboard."
-msgstr "Скапіяваць змест экрана як HTML у часовы файл і скапіяваць шлях у буфер абмену."
+msgstr ""
+"Скапіяваць змест экрана як HTML у часовы файл і скапіяваць шлях у буфер "
+"абмену."
 
 #: src/input/command.zig:313
 msgid "Copy Screen as HTML to Temporary File and Paste Path"
@@ -651,7 +659,9 @@ msgstr "Скапіяваць экран як ANSI-паслядоўнасці ў 
 msgid ""
 "Copy the screen contents as ANSI escape sequences to a temporary file and "
 "copy the path to the clipboard."
-msgstr "Скапіяваць змест экрана як кіруючыя паслядоўнасці ANSI ў часовы файл і скапіяваць шлях у буфер абмену."
+msgstr ""
+"Скапіяваць змест экрана як кіруючыя паслядоўнасці ANSI ў часовы файл і "
+"скапіяваць шлях у буфер абмену."
 
 #: src/input/command.zig:338
 msgid "Copy Screen as ANSI Sequences to Temporary File and Paste Path"
@@ -661,7 +671,9 @@ msgstr "Скапіяваць экран як ANSI-паслядоўнасці ў 
 msgid ""
 "Copy the screen contents as ANSI escape sequences to a temporary file and "
 "paste the path to the file."
-msgstr "Скапіяваць змест экрана як кіруючыя паслядоўнасці ANSI ў часовы файл і ўставіць шлях да яго."
+msgstr ""
+"Скапіяваць змест экрана як кіруючыя паслядоўнасці ANSI ў часовы файл і "
+"ўставіць шлях да яго."
 
 #: src/input/command.zig:346
 msgid "Copy Screen as ANSI Sequences to Temporary File and Open"
@@ -671,7 +683,9 @@ msgstr "Скапіяваць экран як ANSI-паслядоўнасці ў 
 msgid ""
 "Copy the screen contents as ANSI escape sequences to a temporary file and "
 "open it."
-msgstr "Скапіяваць змест экрана як кіруючыя паслядоўнасці ANSI ў часовы файл і адкрыць яго."
+msgstr ""
+"Скапіяваць змест экрана як кіруючыя паслядоўнасці ANSI ў часовы файл і "
+"адкрыць яго."
 
 #: src/input/command.zig:354
 msgid "Copy Selection to Temporary File and Copy Path"
@@ -681,7 +695,8 @@ msgstr "Скапіяваць вылучэнне ў часовы файл і ск
 msgid ""
 "Copy the selection contents to a temporary file and copy the path to the "
 "clipboard."
-msgstr "Скапіяваць змест вылучэння ў часовы файл і скапіяваць шлях у буфер абмену."
+msgstr ""
+"Скапіяваць змест вылучэння ў часовы файл і скапіяваць шлях у буфер абмену."
 
 #: src/input/command.zig:359
 msgid "Copy Selection to Temporary File and Paste Path"
@@ -709,7 +724,9 @@ msgstr "Скапіяваць вылучэнне як HTML у часовы фай
 msgid ""
 "Copy the selection contents as HTML to a temporary file and copy the path to "
 "the clipboard."
-msgstr "Скапіяваць змест вылучэння як HTML у часовы файл і скапіяваць шлях у буфер абмену."
+msgstr ""
+"Скапіяваць змест вылучэння як HTML у часовы файл і скапіяваць шлях у буфер "
+"абмену."
 
 #: src/input/command.zig:381
 msgid "Copy Selection as HTML to Temporary File and Paste Path"
@@ -719,7 +736,8 @@ msgstr "Скапіяваць вылучэнне як HTML у часовы фай
 msgid ""
 "Copy the selection contents as HTML to a temporary file and paste the path "
 "to the file."
-msgstr "Скапіяваць змест вылучэння як HTML у часовы файл і ўставіць шлях да яго."
+msgstr ""
+"Скапіяваць змест вылучэння як HTML у часовы файл і ўставіць шлях да яго."
 
 #: src/input/command.zig:389
 msgid "Copy Selection as HTML to Temporary File and Open"
@@ -731,23 +749,29 @@ msgstr "Скапіяваць змест вылучэння як HTML у часо
 
 #: src/input/command.zig:398
 msgid "Copy Selection as ANSI Sequences to Temporary File and Copy Path"
-msgstr "Скапіяваць вылучэнне як ANSI-паслядоўнасці ў часовы файл і скапіяваць шлях"
+msgstr ""
+"Скапіяваць вылучэнне як ANSI-паслядоўнасці ў часовы файл і скапіяваць шлях"
 
 #: src/input/command.zig:399
 msgid ""
 "Copy the selection contents as ANSI escape sequences to a temporary file and "
 "copy the path to the clipboard."
-msgstr "Скапіяваць змест вылучэння як кіруючыя паслядоўнасці ANSI ў часовы файл і скапіяваць шлях у буфер абмену."
+msgstr ""
+"Скапіяваць змест вылучэння як кіруючыя паслядоўнасці ANSI ў часовы файл і "
+"скапіяваць шлях у буфер абмену."
 
 #: src/input/command.zig:406
 msgid "Copy Selection as ANSI Sequences to Temporary File and Paste Path"
-msgstr "Скапіяваць вылучэнне як ANSI-паслядоўнасці ў часовы файл і ўставіць шлях"
+msgstr ""
+"Скапіяваць вылучэнне як ANSI-паслядоўнасці ў часовы файл і ўставіць шлях"
 
 #: src/input/command.zig:407
 msgid ""
 "Copy the selection contents as ANSI escape sequences to a temporary file and "
 "paste the path to the file."
-msgstr "Скапіяваць змест вылучэння як кіруючыя паслядоўнасці ANSI ў часовы файл і ўставіць шлях да яго."
+msgstr ""
+"Скапіяваць змест вылучэння як кіруючыя паслядоўнасці ANSI ў часовы файл і "
+"ўставіць шлях да яго."
 
 #: src/input/command.zig:414
 msgid "Copy Selection as ANSI Sequences to Temporary File and Open"
@@ -757,7 +781,9 @@ msgstr "Скапіяваць вылучэнне як ANSI-паслядоўнас
 msgid ""
 "Copy the selection contents as ANSI escape sequences to a temporary file and "
 "open it."
-msgstr "Скапіяваць змест вылучэння як кіруючыя паслядоўнасці ANSI ў часовы файл і адкрыць яго."
+msgstr ""
+"Скапіяваць змест вылучэння як кіруючыя паслядоўнасці ANSI ў часовы файл і "
+"адкрыць яго."
 
 #: src/input/command.zig:422
 msgid "Open a new window."
@@ -961,7 +987,8 @@ msgstr "Адкрыць канфігурацыю ў новым акне тэрм�
 
 #: src/input/command.zig:594
 msgid "Open the config file in a new window using $EDITOR or $VISUAL."
-msgstr "Адкрыць файл канфігурацыі ў новым акне з дапамогай $EDITOR або $VISUAL."
+msgstr ""
+"Адкрыць файл канфігурацыі ў новым акне з дапамогай $EDITOR або $VISUAL."
 
 #: src/input/command.zig:600
 msgid "Reload Config"
@@ -971,134 +998,158 @@ msgstr "Перазагрузіць канфігурацыю"
 msgid "Reload the config file."
 msgstr "Перазагрузіць файл канфігурацыі."
 
-#: src/input/command.zig:606
+#: src/input/command.zig:607
+msgid "Switch to Dark Appearance"
+msgstr ""
+
+#: src/input/command.zig:608
+msgid "Use a dark application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Switch to Light Appearance"
+msgstr ""
+
+#: src/input/command.zig:613
+msgid "Use a light application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Switch to System Appearance"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Use the system application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:624
 msgid "Close Terminal"
 msgstr "Закрыць тэрмінал"
 
-#: src/input/command.zig:607
+#: src/input/command.zig:625
 msgid "Close the current terminal."
 msgstr "Закрыць бягучы тэрмінал."
 
-#: src/input/command.zig:614
+#: src/input/command.zig:632
 msgid "Close the current tab."
 msgstr "Закрыць бягучую ўкладку."
 
-#: src/input/command.zig:618
+#: src/input/command.zig:636
 msgid "Close Other Tabs"
 msgstr "Закрыць іншыя ўкладкі"
 
-#: src/input/command.zig:619
+#: src/input/command.zig:637
 msgid "Close all tabs in this window except the current one."
 msgstr "Закрыць усе ўкладкі ў гэтым акне, акрамя бягучай."
 
-#: src/input/command.zig:623
+#: src/input/command.zig:641
 msgid "Close Tabs to the Right"
 msgstr "Закрыць укладкі справа"
 
-#: src/input/command.zig:624
+#: src/input/command.zig:642
 msgid "Close all tabs to the right of the current one."
 msgstr "Закрыць усе ўкладкі справа ад бягучай."
 
-#: src/input/command.zig:631
+#: src/input/command.zig:649
 msgid "Close the current window."
 msgstr "Закрыць бягучае акно."
 
-#: src/input/command.zig:636
+#: src/input/command.zig:654
 msgid "Close All Windows"
 msgstr "Закрыць усе акны"
 
-#: src/input/command.zig:637
+#: src/input/command.zig:655
 msgid "Close all windows."
 msgstr "Закрыць усе акны."
 
-#: src/input/command.zig:642
+#: src/input/command.zig:660
 msgid "Toggle Maximize"
 msgstr "Пераключыць разгорнуты стан"
 
-#: src/input/command.zig:643
+#: src/input/command.zig:661
 msgid "Toggle the maximized state of the current window."
 msgstr "Пераключыць разгорнуты стан бягучага акна."
 
-#: src/input/command.zig:648
+#: src/input/command.zig:666
 msgid "Toggle Fullscreen"
 msgstr "Пераключыць поўнаэкранны рэжым"
 
-#: src/input/command.zig:649
+#: src/input/command.zig:667
 msgid "Toggle the fullscreen state of the current window."
 msgstr "Пераключыць поўнаэкранны рэжым бягучага акна."
 
-#: src/input/command.zig:654
+#: src/input/command.zig:672
 msgid "Toggle Window Decorations"
 msgstr "Пераключыць аздабленне акна"
 
-#: src/input/command.zig:655
+#: src/input/command.zig:673
 msgid "Toggle the window decorations."
 msgstr "Пераключыць аздабленне акна."
 
-#: src/input/command.zig:660
+#: src/input/command.zig:678
 msgid "Toggle Float on Top"
 msgstr "Пераключыць рэжым «заўсёды зверху»"
 
-#: src/input/command.zig:661
+#: src/input/command.zig:679
 msgid "Toggle the float on top state of the current window."
 msgstr "Пераключыць рэжым «заўсёды зверху» бягучага акна."
 
-#: src/input/command.zig:666
+#: src/input/command.zig:684
 msgid "Toggle Secure Input"
 msgstr "Пераключыць бяспечны ўвод"
 
-#: src/input/command.zig:667
+#: src/input/command.zig:685
 msgid "Toggle secure input mode."
 msgstr "Пераключыць бяспечны ўвод."
 
-#: src/input/command.zig:672
+#: src/input/command.zig:690
 msgid "Toggle Mouse Reporting"
 msgstr "Пераключыць перадачу падзей мышы"
 
-#: src/input/command.zig:673
+#: src/input/command.zig:691
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr "Пераключыць, ці перадаюцца падзеі мышы праграмам тэрмінала."
 
-#: src/input/command.zig:678
+#: src/input/command.zig:696
 msgid "Toggle Background Opacity"
 msgstr "Пераключыць непразрыстасць фону"
 
-#: src/input/command.zig:679
+#: src/input/command.zig:697
 msgid "Toggle the background opacity of a window that started transparent."
 msgstr "Пераключыць непразрыстасць фону акна, якое было запушчана празрыстым."
 
-#: src/input/command.zig:684
+#: src/input/command.zig:702
 msgid "Check for Updates"
 msgstr "Праверыць абнаўленні"
 
-#: src/input/command.zig:685
+#: src/input/command.zig:703
 msgid "Check for updates to the application."
 msgstr "Праверыць наяўнасць абнаўленняў праграмы."
 
-#: src/input/command.zig:690
+#: src/input/command.zig:708
 msgid "Undo"
 msgstr "Адмяніць"
 
-#: src/input/command.zig:691
+#: src/input/command.zig:709
 msgid "Undo the last action."
 msgstr "Адмяніць апошняе дзеянне."
 
-#: src/input/command.zig:696
+#: src/input/command.zig:714
 msgid "Redo"
 msgstr "Аднавіць"
 
-#: src/input/command.zig:697
+#: src/input/command.zig:715
 msgid "Redo the last undone action."
 msgstr "Аднавіць апошняе адмененае дзеянне."
 
-#: src/input/command.zig:703
+#: src/input/command.zig:721
 msgid "Quit the application."
 msgstr "Выйсці з праграмы."
 
-#: src/input/command.zig:708
+#: src/input/command.zig:726
 msgid "Ghostty"
 msgstr "Ghostty"
 
-#: src/input/command.zig:709
+#: src/input/command.zig:727
 msgid "Put a little Ghostty in your terminal."
 msgstr "Дадаць трохі Ghostty ў свой тэрмінал."

--- a/po/bg.po
+++ b/po/bg.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-09-10 10:50-0400\n"
 "PO-Revision-Date: 2026-08-13 13:40+0300\n"
 "Last-Translator: reo101 <pavel.atanasov2001@gmail.com>\n"
 "Language-Team: Bulgarian <dict@ludost.net>\n"
@@ -49,7 +49,7 @@ msgstr "За да покажеш това съобщение отново, пр�
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2263
+#: src/apprt/gtk/class/application.zig:2296
 msgid "Cancel"
 msgstr "Отказ"
 
@@ -193,7 +193,7 @@ msgid "New Tab"
 msgstr "Нов раздел"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:242
-#: src/input/command.zig:613
+#: src/input/command.zig:631
 msgid "Close Tab"
 msgstr "Затвори раздел"
 
@@ -211,7 +211,7 @@ msgid "New Window"
 msgstr "Нов прозорец"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:416 src/apprt/gtk/ui/1.5/window.blp:225
-#: src/input/command.zig:630
+#: src/input/command.zig:648
 msgid "Close Window"
 msgstr "Затвори прозорец"
 
@@ -255,11 +255,11 @@ msgstr "Командна палитра"
 msgid "Terminal Inspector"
 msgstr "Инспектор на терминала"
 
-#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1991
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1997
 msgid "About Ghostty"
 msgstr "За Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:702
+#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:720
 msgid "Quit"
 msgstr "Изход"
 
@@ -267,27 +267,27 @@ msgstr "Изход"
 msgid "Execute a command…"
 msgstr "Изпълни команда…"
 
-#: src/apprt/gtk/class/application.zig:1767
+#: src/apprt/gtk/class/application.zig:1779
 msgid "The keybind was revoked by the system."
 msgstr "Клавишната комбинация е отменена от системата."
 
-#: src/apprt/gtk/class/application.zig:1769
+#: src/apprt/gtk/class/application.zig:1781
 msgid "The keybind was denied by the system."
 msgstr "Клавишната комбинация е отказана от системата."
 
-#: src/apprt/gtk/class/application.zig:1780
+#: src/apprt/gtk/class/application.zig:1792
 msgid "Global keybind unavailable"
 msgstr "Глобалната клавишна комбинация не е достъпна"
 
-#: src/apprt/gtk/class/application.zig:2259
+#: src/apprt/gtk/class/application.zig:2292
 msgid "Export Terminal IO Events"
 msgstr "Експортиране на входно-изходните събития на терминала"
 
-#: src/apprt/gtk/class/application.zig:2262
+#: src/apprt/gtk/class/application.zig:2295
 msgid "Export"
 msgstr "Експортирай"
 
-#: src/apprt/gtk/class/application.zig:2783
+#: src/apprt/gtk/class/application.zig:2827
 msgid "Editing configuration file"
 msgstr "Редактиране на конфигурационния файл"
 
@@ -351,16 +351,16 @@ msgstr "Всички терминални сесии в този прозоре�
 msgid "The currently running process in this split will be terminated."
 msgstr "Текущият процес в това разделяне ще бъде прекратен."
 
-#: src/apprt/gtk/class/surface.zig:1181
+#: src/apprt/gtk/class/surface.zig:1194
 msgid "Command Finished"
 msgstr "Командата завърши"
 
-#: src/apprt/gtk/class/surface.zig:1182
+#: src/apprt/gtk/class/surface.zig:1195
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Командата завърши успешно"
 
-#: src/apprt/gtk/class/surface.zig:1183
+#: src/apprt/gtk/class/surface.zig:1196
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Командата завърши неуспешно"
@@ -377,19 +377,19 @@ msgstr "Промяна на заглавието на раздела"
 msgid "Change Window Title"
 msgstr "Промяна на заглавието на прозореца"
 
-#: src/apprt/gtk/class/window.zig:1153
+#: src/apprt/gtk/class/window.zig:1159
 msgid "Reloaded the configuration"
 msgstr "Конфигурацията е презаредена"
 
-#: src/apprt/gtk/class/window.zig:1830
+#: src/apprt/gtk/class/window.zig:1836
 msgid "Copied to clipboard"
 msgstr "Копирано в клипборда"
 
-#: src/apprt/gtk/class/window.zig:1832
+#: src/apprt/gtk/class/window.zig:1838
 msgid "Cleared clipboard"
 msgstr "Клипбордът е изчистен"
 
-#: src/apprt/gtk/class/window.zig:1972
+#: src/apprt/gtk/class/window.zig:1978
 msgid "Ghostty Developers"
 msgstr "Разработчици на Ghostty"
 
@@ -1024,139 +1024,163 @@ msgstr "Презареждане на конфигурацията"
 msgid "Reload the config file."
 msgstr "Презареждане на конфигурационния файл."
 
-#: src/input/command.zig:606
+#: src/input/command.zig:607
+msgid "Switch to Dark Appearance"
+msgstr ""
+
+#: src/input/command.zig:608
+msgid "Use a dark application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Switch to Light Appearance"
+msgstr ""
+
+#: src/input/command.zig:613
+msgid "Use a light application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Switch to System Appearance"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Use the system application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:624
 msgid "Close Terminal"
 msgstr "Затваряне на терминала"
 
-#: src/input/command.zig:607
+#: src/input/command.zig:625
 msgid "Close the current terminal."
 msgstr "Затваряне на текущия терминал."
 
-#: src/input/command.zig:614
+#: src/input/command.zig:632
 msgid "Close the current tab."
 msgstr "Затваряне на текущия раздел."
 
-#: src/input/command.zig:618
+#: src/input/command.zig:636
 msgid "Close Other Tabs"
 msgstr "Затваряне на другите раздели"
 
-#: src/input/command.zig:619
+#: src/input/command.zig:637
 msgid "Close all tabs in this window except the current one."
 msgstr "Затваряне на всички раздели в този прозорец освен текущия."
 
-#: src/input/command.zig:623
+#: src/input/command.zig:641
 msgid "Close Tabs to the Right"
 msgstr "Затваряне на разделите отдясно"
 
-#: src/input/command.zig:624
+#: src/input/command.zig:642
 msgid "Close all tabs to the right of the current one."
 msgstr "Затваряне на всички раздели вдясно от текущия."
 
-#: src/input/command.zig:631
+#: src/input/command.zig:649
 msgid "Close the current window."
 msgstr "Затваряне на текущия прозорец."
 
-#: src/input/command.zig:636
+#: src/input/command.zig:654
 msgid "Close All Windows"
 msgstr "Затваряне на всички прозорци"
 
-#: src/input/command.zig:637
+#: src/input/command.zig:655
 msgid "Close all windows."
 msgstr "Затваряне на всички прозорци."
 
-#: src/input/command.zig:642
+#: src/input/command.zig:660
 msgid "Toggle Maximize"
 msgstr "Превключване на максимизирането"
 
-#: src/input/command.zig:643
+#: src/input/command.zig:661
 msgid "Toggle the maximized state of the current window."
 msgstr "Превключване на максимизираното състояние на текущия прозорец."
 
-#: src/input/command.zig:648
+#: src/input/command.zig:666
 msgid "Toggle Fullscreen"
 msgstr "Превключване на цял екран"
 
-#: src/input/command.zig:649
+#: src/input/command.zig:667
 msgid "Toggle the fullscreen state of the current window."
 msgstr "Превключване на състоянието на цял екран на текущия прозорец."
 
-#: src/input/command.zig:654
+#: src/input/command.zig:672
 msgid "Toggle Window Decorations"
 msgstr "Превключване на декорациите на прозореца"
 
-#: src/input/command.zig:655
+#: src/input/command.zig:673
 msgid "Toggle the window decorations."
 msgstr "Показване или скриване на декорациите на прозореца."
 
-#: src/input/command.zig:660
+#: src/input/command.zig:678
 msgid "Toggle Float on Top"
 msgstr "Превключване на задържането на прозореца най-отгоре"
 
-#: src/input/command.zig:661
+#: src/input/command.zig:679
 msgid "Toggle the float on top state of the current window."
 msgstr ""
 "Превключване дали текущият прозорец да остава над всички останали прозорци."
 
-#: src/input/command.zig:666
+#: src/input/command.zig:684
 msgid "Toggle Secure Input"
 msgstr "Превключване на защитеното въвеждане"
 
-#: src/input/command.zig:667
+#: src/input/command.zig:685
 msgid "Toggle secure input mode."
 msgstr "Превключване на режима за защитено въвеждане."
 
-#: src/input/command.zig:672
+#: src/input/command.zig:690
 msgid "Toggle Mouse Reporting"
 msgstr "Превключване на предаването на събития от мишката"
 
-#: src/input/command.zig:673
+#: src/input/command.zig:691
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr ""
 "Превключване дали събитията от мишката да се предават на приложенията в "
 "терминала."
 
-#: src/input/command.zig:678
+#: src/input/command.zig:696
 msgid "Toggle Background Opacity"
 msgstr "Превключване на прозрачността на фона"
 
-#: src/input/command.zig:679
+#: src/input/command.zig:697
 msgid "Toggle the background opacity of a window that started transparent."
 msgstr ""
 "Превключване между прозрачен и непрозрачен фон за прозорец, стартиран с "
 "прозрачен фон."
 
-#: src/input/command.zig:684
+#: src/input/command.zig:702
 msgid "Check for Updates"
 msgstr "Проверка за обновления"
 
-#: src/input/command.zig:685
+#: src/input/command.zig:703
 msgid "Check for updates to the application."
 msgstr "Проверка за обновления на приложението."
 
-#: src/input/command.zig:690
+#: src/input/command.zig:708
 msgid "Undo"
 msgstr "Отмяна"
 
-#: src/input/command.zig:691
+#: src/input/command.zig:709
 msgid "Undo the last action."
 msgstr "Отмяна на последното действие."
 
-#: src/input/command.zig:696
+#: src/input/command.zig:714
 msgid "Redo"
 msgstr "Повтаряне"
 
-#: src/input/command.zig:697
+#: src/input/command.zig:715
 msgid "Redo the last undone action."
 msgstr "Повтаряне на последното отменено действие."
 
-#: src/input/command.zig:703
+#: src/input/command.zig:721
 msgid "Quit the application."
 msgstr "Излизане от приложението."
 
-#: src/input/command.zig:708
+#: src/input/command.zig:726
 msgid "Ghostty"
 msgstr "Ghostty"
 
-#: src/input/command.zig:709
+#: src/input/command.zig:727
 msgid "Put a little Ghostty in your terminal."
 msgstr "Добавете малко Ghostty в терминала си."

--- a/po/ca.po
+++ b/po/ca.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-09-10 10:50-0400\n"
 "PO-Revision-Date: 2025-08-24 19:22+0200\n"
 "Last-Translator: Kristofer Soler "
 "<31729650+KristoferSoler@users.noreply.github.com>\n"
@@ -50,7 +50,7 @@ msgstr "Recarrega la configuració per tornar a mostrar aquest missatge"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2263
+#: src/apprt/gtk/class/application.zig:2296
 msgid "Cancel"
 msgstr "Cancel·la"
 
@@ -195,7 +195,7 @@ msgid "New Tab"
 msgstr "Nova pestanya"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:242
-#: src/input/command.zig:613
+#: src/input/command.zig:631
 msgid "Close Tab"
 msgstr "Tanca la pestanya"
 
@@ -213,7 +213,7 @@ msgid "New Window"
 msgstr "Nova finestra"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:416 src/apprt/gtk/ui/1.5/window.blp:225
-#: src/input/command.zig:630
+#: src/input/command.zig:648
 msgid "Close Window"
 msgstr "Tanca la finestra"
 
@@ -257,11 +257,11 @@ msgstr "Paleta de comandes"
 msgid "Terminal Inspector"
 msgstr "Inspector de terminal"
 
-#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1991
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1997
 msgid "About Ghostty"
 msgstr "Sobre Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:702
+#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:720
 msgid "Quit"
 msgstr "Surt"
 
@@ -269,27 +269,27 @@ msgstr "Surt"
 msgid "Execute a command…"
 msgstr "Executa una ordre…"
 
-#: src/apprt/gtk/class/application.zig:1767
+#: src/apprt/gtk/class/application.zig:1779
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1769
+#: src/apprt/gtk/class/application.zig:1781
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1780
+#: src/apprt/gtk/class/application.zig:1792
 msgid "Global keybind unavailable"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2259
+#: src/apprt/gtk/class/application.zig:2292
 msgid "Export Terminal IO Events"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2262
+#: src/apprt/gtk/class/application.zig:2295
 msgid "Export"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2783
+#: src/apprt/gtk/class/application.zig:2827
 msgid "Editing configuration file"
 msgstr ""
 
@@ -353,16 +353,16 @@ msgstr "Totes les sessions del terminal en aquesta finestra es tancaran."
 msgid "The currently running process in this split will be terminated."
 msgstr "El procés actualment en execució en aquesta divisió es tancarà."
 
-#: src/apprt/gtk/class/surface.zig:1181
+#: src/apprt/gtk/class/surface.zig:1194
 msgid "Command Finished"
 msgstr "Comanda finalitzada"
 
-#: src/apprt/gtk/class/surface.zig:1182
+#: src/apprt/gtk/class/surface.zig:1195
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Comanda completada amb èxit"
 
-#: src/apprt/gtk/class/surface.zig:1183
+#: src/apprt/gtk/class/surface.zig:1196
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Comanda fallida"
@@ -379,19 +379,19 @@ msgstr "Canvia el títol de la pestanya"
 msgid "Change Window Title"
 msgstr ""
 
-#: src/apprt/gtk/class/window.zig:1153
+#: src/apprt/gtk/class/window.zig:1159
 msgid "Reloaded the configuration"
 msgstr "S'ha tornat a carregar la configuració"
 
-#: src/apprt/gtk/class/window.zig:1830
+#: src/apprt/gtk/class/window.zig:1836
 msgid "Copied to clipboard"
 msgstr "Copiat al porta-retalls"
 
-#: src/apprt/gtk/class/window.zig:1832
+#: src/apprt/gtk/class/window.zig:1838
 msgid "Cleared clipboard"
 msgstr "Porta-retalls netejat"
 
-#: src/apprt/gtk/class/window.zig:1972
+#: src/apprt/gtk/class/window.zig:1978
 msgid "Ghostty Developers"
 msgstr "Desenvolupadors de Ghostty"
 
@@ -973,134 +973,158 @@ msgstr ""
 msgid "Reload the config file."
 msgstr ""
 
-#: src/input/command.zig:606
-msgid "Close Terminal"
-msgstr ""
-
 #: src/input/command.zig:607
-msgid "Close the current terminal."
+msgid "Switch to Dark Appearance"
 msgstr ""
 
-#: src/input/command.zig:614
-msgid "Close the current tab."
+#: src/input/command.zig:608
+msgid "Use a dark application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Switch to Light Appearance"
+msgstr ""
+
+#: src/input/command.zig:613
+msgid "Use a light application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Switch to System Appearance"
 msgstr ""
 
 #: src/input/command.zig:618
-msgid "Close Other Tabs"
-msgstr ""
-
-#: src/input/command.zig:619
-msgid "Close all tabs in this window except the current one."
-msgstr ""
-
-#: src/input/command.zig:623
-msgid "Close Tabs to the Right"
+msgid "Use the system application appearance for this session."
 msgstr ""
 
 #: src/input/command.zig:624
-msgid "Close all tabs to the right of the current one."
+msgid "Close Terminal"
 msgstr ""
 
-#: src/input/command.zig:631
-msgid "Close the current window."
+#: src/input/command.zig:625
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:632
+msgid "Close the current tab."
 msgstr ""
 
 #: src/input/command.zig:636
-msgid "Close All Windows"
+msgid "Close Other Tabs"
 msgstr ""
 
 #: src/input/command.zig:637
-msgid "Close all windows."
+msgid "Close all tabs in this window except the current one."
+msgstr ""
+
+#: src/input/command.zig:641
+msgid "Close Tabs to the Right"
 msgstr ""
 
 #: src/input/command.zig:642
-msgid "Toggle Maximize"
-msgstr ""
-
-#: src/input/command.zig:643
-msgid "Toggle the maximized state of the current window."
-msgstr ""
-
-#: src/input/command.zig:648
-msgid "Toggle Fullscreen"
+msgid "Close all tabs to the right of the current one."
 msgstr ""
 
 #: src/input/command.zig:649
-msgid "Toggle the fullscreen state of the current window."
+msgid "Close the current window."
 msgstr ""
 
 #: src/input/command.zig:654
-msgid "Toggle Window Decorations"
+msgid "Close All Windows"
 msgstr ""
 
 #: src/input/command.zig:655
-msgid "Toggle the window decorations."
+msgid "Close all windows."
 msgstr ""
 
 #: src/input/command.zig:660
-msgid "Toggle Float on Top"
+msgid "Toggle Maximize"
 msgstr ""
 
 #: src/input/command.zig:661
-msgid "Toggle the float on top state of the current window."
+msgid "Toggle the maximized state of the current window."
 msgstr ""
 
 #: src/input/command.zig:666
-msgid "Toggle Secure Input"
+msgid "Toggle Fullscreen"
 msgstr ""
 
 #: src/input/command.zig:667
-msgid "Toggle secure input mode."
+msgid "Toggle the fullscreen state of the current window."
 msgstr ""
 
 #: src/input/command.zig:672
-msgid "Toggle Mouse Reporting"
+msgid "Toggle Window Decorations"
 msgstr ""
 
 #: src/input/command.zig:673
-msgid "Toggle whether mouse events are reported to terminal applications."
+msgid "Toggle the window decorations."
 msgstr ""
 
 #: src/input/command.zig:678
-msgid "Toggle Background Opacity"
+msgid "Toggle Float on Top"
 msgstr ""
 
 #: src/input/command.zig:679
-msgid "Toggle the background opacity of a window that started transparent."
+msgid "Toggle the float on top state of the current window."
 msgstr ""
 
 #: src/input/command.zig:684
-msgid "Check for Updates"
+msgid "Toggle Secure Input"
 msgstr ""
 
 #: src/input/command.zig:685
-msgid "Check for updates to the application."
+msgid "Toggle secure input mode."
 msgstr ""
 
 #: src/input/command.zig:690
-msgid "Undo"
+msgid "Toggle Mouse Reporting"
 msgstr ""
 
 #: src/input/command.zig:691
-msgid "Undo the last action."
+msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr ""
 
 #: src/input/command.zig:696
-msgid "Redo"
+msgid "Toggle Background Opacity"
 msgstr ""
 
 #: src/input/command.zig:697
-msgid "Redo the last undone action."
+msgid "Toggle the background opacity of a window that started transparent."
+msgstr ""
+
+#: src/input/command.zig:702
+msgid "Check for Updates"
 msgstr ""
 
 #: src/input/command.zig:703
-msgid "Quit the application."
+msgid "Check for updates to the application."
 msgstr ""
 
 #: src/input/command.zig:708
-msgid "Ghostty"
+msgid "Undo"
 msgstr ""
 
 #: src/input/command.zig:709
+msgid "Undo the last action."
+msgstr ""
+
+#: src/input/command.zig:714
+msgid "Redo"
+msgstr ""
+
+#: src/input/command.zig:715
+msgid "Redo the last undone action."
+msgstr ""
+
+#: src/input/command.zig:721
+msgid "Quit the application."
+msgstr ""
+
+#: src/input/command.zig:726
+msgid "Ghostty"
+msgstr ""
+
+#: src/input/command.zig:727
 msgid "Put a little Ghostty in your terminal."
 msgstr ""

--- a/po/com.mitchellh.ghostty.pot
+++ b/po/com.mitchellh.ghostty.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-09-10 10:50-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -48,7 +48,7 @@ msgstr ""
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2263
+#: src/apprt/gtk/class/application.zig:2296
 msgid "Cancel"
 msgstr ""
 
@@ -186,7 +186,7 @@ msgid "New Tab"
 msgstr ""
 
 #: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:242
-#: src/input/command.zig:613
+#: src/input/command.zig:631
 msgid "Close Tab"
 msgstr ""
 
@@ -204,7 +204,7 @@ msgid "New Window"
 msgstr ""
 
 #: src/apprt/gtk/ui/1.2/surface.blp:416 src/apprt/gtk/ui/1.5/window.blp:225
-#: src/input/command.zig:630
+#: src/input/command.zig:648
 msgid "Close Window"
 msgstr ""
 
@@ -248,11 +248,11 @@ msgstr ""
 msgid "Terminal Inspector"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1991
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1997
 msgid "About Ghostty"
 msgstr ""
 
-#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:702
+#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:720
 msgid "Quit"
 msgstr ""
 
@@ -260,27 +260,27 @@ msgstr ""
 msgid "Execute a command…"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1767
+#: src/apprt/gtk/class/application.zig:1779
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1769
+#: src/apprt/gtk/class/application.zig:1781
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1780
+#: src/apprt/gtk/class/application.zig:1792
 msgid "Global keybind unavailable"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2259
+#: src/apprt/gtk/class/application.zig:2292
 msgid "Export Terminal IO Events"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2262
+#: src/apprt/gtk/class/application.zig:2295
 msgid "Export"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2783
+#: src/apprt/gtk/class/application.zig:2827
 msgid "Editing configuration file"
 msgstr ""
 
@@ -338,16 +338,16 @@ msgstr ""
 msgid "The currently running process in this split will be terminated."
 msgstr ""
 
-#: src/apprt/gtk/class/surface.zig:1181
+#: src/apprt/gtk/class/surface.zig:1194
 msgid "Command Finished"
 msgstr ""
 
-#: src/apprt/gtk/class/surface.zig:1182
+#: src/apprt/gtk/class/surface.zig:1195
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr ""
 
-#: src/apprt/gtk/class/surface.zig:1183
+#: src/apprt/gtk/class/surface.zig:1196
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr ""
@@ -364,19 +364,19 @@ msgstr ""
 msgid "Change Window Title"
 msgstr ""
 
-#: src/apprt/gtk/class/window.zig:1153
+#: src/apprt/gtk/class/window.zig:1159
 msgid "Reloaded the configuration"
 msgstr ""
 
-#: src/apprt/gtk/class/window.zig:1830
+#: src/apprt/gtk/class/window.zig:1836
 msgid "Copied to clipboard"
 msgstr ""
 
-#: src/apprt/gtk/class/window.zig:1832
+#: src/apprt/gtk/class/window.zig:1838
 msgid "Cleared clipboard"
 msgstr ""
 
-#: src/apprt/gtk/class/window.zig:1972
+#: src/apprt/gtk/class/window.zig:1978
 msgid "Ghostty Developers"
 msgstr ""
 
@@ -958,134 +958,158 @@ msgstr ""
 msgid "Reload the config file."
 msgstr ""
 
-#: src/input/command.zig:606
-msgid "Close Terminal"
-msgstr ""
-
 #: src/input/command.zig:607
-msgid "Close the current terminal."
+msgid "Switch to Dark Appearance"
 msgstr ""
 
-#: src/input/command.zig:614
-msgid "Close the current tab."
+#: src/input/command.zig:608
+msgid "Use a dark application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Switch to Light Appearance"
+msgstr ""
+
+#: src/input/command.zig:613
+msgid "Use a light application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Switch to System Appearance"
 msgstr ""
 
 #: src/input/command.zig:618
-msgid "Close Other Tabs"
-msgstr ""
-
-#: src/input/command.zig:619
-msgid "Close all tabs in this window except the current one."
-msgstr ""
-
-#: src/input/command.zig:623
-msgid "Close Tabs to the Right"
+msgid "Use the system application appearance for this session."
 msgstr ""
 
 #: src/input/command.zig:624
-msgid "Close all tabs to the right of the current one."
+msgid "Close Terminal"
 msgstr ""
 
-#: src/input/command.zig:631
-msgid "Close the current window."
+#: src/input/command.zig:625
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:632
+msgid "Close the current tab."
 msgstr ""
 
 #: src/input/command.zig:636
-msgid "Close All Windows"
+msgid "Close Other Tabs"
 msgstr ""
 
 #: src/input/command.zig:637
-msgid "Close all windows."
+msgid "Close all tabs in this window except the current one."
+msgstr ""
+
+#: src/input/command.zig:641
+msgid "Close Tabs to the Right"
 msgstr ""
 
 #: src/input/command.zig:642
-msgid "Toggle Maximize"
-msgstr ""
-
-#: src/input/command.zig:643
-msgid "Toggle the maximized state of the current window."
-msgstr ""
-
-#: src/input/command.zig:648
-msgid "Toggle Fullscreen"
+msgid "Close all tabs to the right of the current one."
 msgstr ""
 
 #: src/input/command.zig:649
-msgid "Toggle the fullscreen state of the current window."
+msgid "Close the current window."
 msgstr ""
 
 #: src/input/command.zig:654
-msgid "Toggle Window Decorations"
+msgid "Close All Windows"
 msgstr ""
 
 #: src/input/command.zig:655
-msgid "Toggle the window decorations."
+msgid "Close all windows."
 msgstr ""
 
 #: src/input/command.zig:660
-msgid "Toggle Float on Top"
+msgid "Toggle Maximize"
 msgstr ""
 
 #: src/input/command.zig:661
-msgid "Toggle the float on top state of the current window."
+msgid "Toggle the maximized state of the current window."
 msgstr ""
 
 #: src/input/command.zig:666
-msgid "Toggle Secure Input"
+msgid "Toggle Fullscreen"
 msgstr ""
 
 #: src/input/command.zig:667
-msgid "Toggle secure input mode."
+msgid "Toggle the fullscreen state of the current window."
 msgstr ""
 
 #: src/input/command.zig:672
-msgid "Toggle Mouse Reporting"
+msgid "Toggle Window Decorations"
 msgstr ""
 
 #: src/input/command.zig:673
-msgid "Toggle whether mouse events are reported to terminal applications."
+msgid "Toggle the window decorations."
 msgstr ""
 
 #: src/input/command.zig:678
-msgid "Toggle Background Opacity"
+msgid "Toggle Float on Top"
 msgstr ""
 
 #: src/input/command.zig:679
-msgid "Toggle the background opacity of a window that started transparent."
+msgid "Toggle the float on top state of the current window."
 msgstr ""
 
 #: src/input/command.zig:684
-msgid "Check for Updates"
+msgid "Toggle Secure Input"
 msgstr ""
 
 #: src/input/command.zig:685
-msgid "Check for updates to the application."
+msgid "Toggle secure input mode."
 msgstr ""
 
 #: src/input/command.zig:690
-msgid "Undo"
+msgid "Toggle Mouse Reporting"
 msgstr ""
 
 #: src/input/command.zig:691
-msgid "Undo the last action."
+msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr ""
 
 #: src/input/command.zig:696
-msgid "Redo"
+msgid "Toggle Background Opacity"
 msgstr ""
 
 #: src/input/command.zig:697
-msgid "Redo the last undone action."
+msgid "Toggle the background opacity of a window that started transparent."
+msgstr ""
+
+#: src/input/command.zig:702
+msgid "Check for Updates"
 msgstr ""
 
 #: src/input/command.zig:703
-msgid "Quit the application."
+msgid "Check for updates to the application."
 msgstr ""
 
 #: src/input/command.zig:708
-msgid "Ghostty"
+msgid "Undo"
 msgstr ""
 
 #: src/input/command.zig:709
+msgid "Undo the last action."
+msgstr ""
+
+#: src/input/command.zig:714
+msgid "Redo"
+msgstr ""
+
+#: src/input/command.zig:715
+msgid "Redo the last undone action."
+msgstr ""
+
+#: src/input/command.zig:721
+msgid "Quit the application."
+msgstr ""
+
+#: src/input/command.zig:726
+msgid "Ghostty"
+msgstr ""
+
+#: src/input/command.zig:727
 msgid "Put a little Ghostty in your terminal."
 msgstr ""

--- a/po/da.po
+++ b/po/da.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-09-10 10:50-0400\n"
 "PO-Revision-Date: 2026-08-13 12:00+0200\n"
 "Last-Translator: Carl Villads Priisholm <carl.priisholm@gmail.com>\n"
 "Language-Team: Danish <dansk@dansk-gruppen.dk>\n"
@@ -48,7 +48,7 @@ msgstr "Genindlæs konfigurationen for at se denne dialog igen"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2263
+#: src/apprt/gtk/class/application.zig:2296
 msgid "Cancel"
 msgstr "Annullér"
 
@@ -194,7 +194,7 @@ msgid "New Tab"
 msgstr "Ny fane"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:242
-#: src/input/command.zig:613
+#: src/input/command.zig:631
 msgid "Close Tab"
 msgstr "Luk fane"
 
@@ -212,7 +212,7 @@ msgid "New Window"
 msgstr "Nyt vindue"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:416 src/apprt/gtk/ui/1.5/window.blp:225
-#: src/input/command.zig:630
+#: src/input/command.zig:648
 msgid "Close Window"
 msgstr "Luk vindue"
 
@@ -257,11 +257,11 @@ msgstr "Kommandopalet"
 msgid "Terminal Inspector"
 msgstr "Terminalinspektør"
 
-#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1991
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1997
 msgid "About Ghostty"
 msgstr "Om Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:702
+#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:720
 msgid "Quit"
 msgstr "Luk ned"
 
@@ -269,27 +269,27 @@ msgstr "Luk ned"
 msgid "Execute a command…"
 msgstr "Eksekver en kommando…"
 
-#: src/apprt/gtk/class/application.zig:1767
+#: src/apprt/gtk/class/application.zig:1779
 msgid "The keybind was revoked by the system."
 msgstr "Tastaturgenvejen blev ophævet af systemet."
 
-#: src/apprt/gtk/class/application.zig:1769
+#: src/apprt/gtk/class/application.zig:1781
 msgid "The keybind was denied by the system."
 msgstr "Tastaturgenvejen blev afvist af systemet."
 
-#: src/apprt/gtk/class/application.zig:1780
+#: src/apprt/gtk/class/application.zig:1792
 msgid "Global keybind unavailable"
 msgstr "Global tastaturgenvej utilgængelig"
 
-#: src/apprt/gtk/class/application.zig:2259
+#: src/apprt/gtk/class/application.zig:2292
 msgid "Export Terminal IO Events"
 msgstr "Eksportér terminal IO-begivenheder"
 
-#: src/apprt/gtk/class/application.zig:2262
+#: src/apprt/gtk/class/application.zig:2295
 msgid "Export"
 msgstr "Eksportér"
 
-#: src/apprt/gtk/class/application.zig:2783
+#: src/apprt/gtk/class/application.zig:2827
 msgid "Editing configuration file"
 msgstr "Redigerer konfigurationsfil"
 
@@ -298,16 +298,16 @@ msgid ""
 "An application is attempting to write to the clipboard. The current "
 "clipboard contents are shown below."
 msgstr ""
-"Et program prøver at skrive til udklipsholderen. Indholdet af den "
-"nuværende udklipsholder er vist nedenfor."
+"Et program prøver at skrive til udklipsholderen. Indholdet af den nuværende "
+"udklipsholder er vist nedenfor."
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:202
 msgid ""
 "An application is attempting to read from the clipboard. The current "
 "clipboard contents are shown below."
 msgstr ""
-"Et program prøver at læse fra udklipsholderen. Indholdet af den "
-"nuværende udklipsholder er vist nedenfor."
+"Et program prøver at læse fra udklipsholderen. Indholdet af den nuværende "
+"udklipsholder er vist nedenfor."
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:205
 msgid "Warning: Potentially Unsafe Paste"
@@ -354,16 +354,16 @@ msgstr "Alle terminalsessioner i dette vindue vil blive afsluttet."
 msgid "The currently running process in this split will be terminated."
 msgstr "Den kørende proces i denne opdeling vil blive afsluttet."
 
-#: src/apprt/gtk/class/surface.zig:1181
+#: src/apprt/gtk/class/surface.zig:1194
 msgid "Command Finished"
 msgstr "Kommandoen er færdig"
 
-#: src/apprt/gtk/class/surface.zig:1182
+#: src/apprt/gtk/class/surface.zig:1195
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Kommandoen lykkedes"
 
-#: src/apprt/gtk/class/surface.zig:1183
+#: src/apprt/gtk/class/surface.zig:1196
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Kommandoen fejlede"
@@ -380,19 +380,19 @@ msgstr "Skift fanetitel"
 msgid "Change Window Title"
 msgstr "Skift vinduestitel"
 
-#: src/apprt/gtk/class/window.zig:1153
+#: src/apprt/gtk/class/window.zig:1159
 msgid "Reloaded the configuration"
 msgstr "Konfigurationen blev genindlæst"
 
-#: src/apprt/gtk/class/window.zig:1830
+#: src/apprt/gtk/class/window.zig:1836
 msgid "Copied to clipboard"
 msgstr "Kopieret til udklipsholder"
 
-#: src/apprt/gtk/class/window.zig:1832
+#: src/apprt/gtk/class/window.zig:1838
 msgid "Cleared clipboard"
 msgstr "Udklipsholderen blev ryddet"
 
-#: src/apprt/gtk/class/window.zig:1972
+#: src/apprt/gtk/class/window.zig:1978
 msgid "Ghostty Developers"
 msgstr "Ghostty udviklerne"
 
@@ -412,7 +412,8 @@ msgstr "Kopiér til udklipsholder"
 msgid ""
 "Copy the selected text to the clipboard in both plain and styled formats."
 msgstr ""
-"Kopiér den valgte tekst i både almindelig og stiliseret format til udklipsholderen."
+"Kopiér den valgte tekst i både almindelig og stiliseret format til "
+"udklipsholderen."
 
 #: src/input/command.zig:159
 msgid "Copy Selection as Plain Text to Clipboard"
@@ -496,7 +497,9 @@ msgstr "Afslut søgning"
 
 #: src/input/command.zig:210
 msgid "End the current search if any and hide any GUI elements."
-msgstr "Afslut den nuværende søgning hvis den findes, og skjul eventuelle GUI-elementer."
+msgstr ""
+"Afslut den nuværende søgning hvis den findes, og skjul eventuelle GUI-"
+"elementer."
 
 #: src/input/command.zig:215
 msgid "Next Search Result"
@@ -603,8 +606,8 @@ msgid ""
 "Copy the screen contents to a temporary file and copy the path to the "
 "clipboard."
 msgstr ""
-"Kopiér indholdet af skærmen til en midlertidig fil, og kopiér stien "
-"til udklipsholderen."
+"Kopiér indholdet af skærmen til en midlertidig fil, og kopiér stien til "
+"udklipsholderen."
 
 #: src/input/command.zig:291
 msgid "Copy Screen to Temporary File and Paste Path"
@@ -614,7 +617,8 @@ msgstr "Kopiér skærm til midlertidig fil og indsæt sti"
 msgid ""
 "Copy the screen contents to a temporary file and paste the path to the file."
 msgstr ""
-"Kopiér indholdet af skærmen til en midlertidig fil, og indsæt stien til filen."
+"Kopiér indholdet af skærmen til en midlertidig fil, og indsæt stien til "
+"filen."
 
 #: src/input/command.zig:296
 msgid "Copy Screen to Temporary File and Open"
@@ -654,7 +658,8 @@ msgstr "Kopiér skærm som HTML til en midlertidig fil og åben"
 
 #: src/input/command.zig:322
 msgid "Copy the screen contents as HTML to a temporary file and open it."
-msgstr "Kopiér indholdet af skærmen som HTML til en midlertidig fil og åben den."
+msgstr ""
+"Kopiér indholdet af skærmen som HTML til en midlertidig fil og åben den."
 
 #: src/input/command.zig:330
 msgid "Copy Screen as ANSI Sequences to Temporary File and Copy Path"
@@ -701,8 +706,8 @@ msgid ""
 "Copy the selection contents to a temporary file and copy the path to the "
 "clipboard."
 msgstr ""
-"Kopiér indholdet af markeringen til en midlertidig fil, og kopiér stien "
-"til udklipsholderen."
+"Kopiér indholdet af markeringen til en midlertidig fil, og kopiér stien til "
+"udklipsholderen."
 
 #: src/input/command.zig:359
 msgid "Copy Selection to Temporary File and Paste Path"
@@ -713,8 +718,8 @@ msgid ""
 "Copy the selection contents to a temporary file and paste the path to the "
 "file."
 msgstr ""
-"Kopiér indholdet af markeringen til en midlertidig fil, og indsæt stien "
-"til filen."
+"Kopiér indholdet af markeringen til en midlertidig fil, og indsæt stien til "
+"filen."
 
 #: src/input/command.zig:364
 msgid "Copy Selection to Temporary File and Open"
@@ -754,7 +759,8 @@ msgstr "Kopiér markering som HTML til midlertidig fil og åben"
 
 #: src/input/command.zig:390
 msgid "Copy the selection contents as HTML to a temporary file and open it."
-msgstr "Kopiér indholdet af markeringen som HTML til en midlertidig fil, og åben den."
+msgstr ""
+"Kopiér indholdet af markeringen som HTML til en midlertidig fil, og åben den."
 
 #: src/input/command.zig:398
 msgid "Copy Selection as ANSI Sequences to Temporary File and Copy Path"
@@ -1005,134 +1011,161 @@ msgstr "Genindlæs konfiguration"
 msgid "Reload the config file."
 msgstr "Genindlæs konfigurationsfilen."
 
-#: src/input/command.zig:606
+#: src/input/command.zig:607
+msgid "Switch to Dark Appearance"
+msgstr ""
+
+#: src/input/command.zig:608
+msgid "Use a dark application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Switch to Light Appearance"
+msgstr ""
+
+#: src/input/command.zig:613
+msgid "Use a light application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Switch to System Appearance"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Use the system application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:624
 msgid "Close Terminal"
 msgstr "Luk terminal"
 
-#: src/input/command.zig:607
+#: src/input/command.zig:625
 msgid "Close the current terminal."
 msgstr "Luk den nuværende terminal."
 
-#: src/input/command.zig:614
+#: src/input/command.zig:632
 msgid "Close the current tab."
 msgstr "Luk den nuværende fane."
 
-#: src/input/command.zig:618
+#: src/input/command.zig:636
 msgid "Close Other Tabs"
 msgstr "Luk andre faner"
 
-#: src/input/command.zig:619
+#: src/input/command.zig:637
 msgid "Close all tabs in this window except the current one."
 msgstr "Luk alle faner i dette vindue, bortset fra den nuværende."
 
-#: src/input/command.zig:623
+#: src/input/command.zig:641
 msgid "Close Tabs to the Right"
 msgstr "Luk alle faner til højre"
 
-#: src/input/command.zig:624
+#: src/input/command.zig:642
 msgid "Close all tabs to the right of the current one."
 msgstr "Luk alle faner til højre for den nuværende."
 
-#: src/input/command.zig:631
+#: src/input/command.zig:649
 msgid "Close the current window."
 msgstr "Luk det nuværende vindue."
 
-#: src/input/command.zig:636
+#: src/input/command.zig:654
 msgid "Close All Windows"
 msgstr "Luk alle vinduer"
 
-#: src/input/command.zig:637
+#: src/input/command.zig:655
 msgid "Close all windows."
 msgstr "Luk alle vinduer."
 
-#: src/input/command.zig:642
+#: src/input/command.zig:660
 msgid "Toggle Maximize"
 msgstr "Slå maksimering til/fra"
 
-#: src/input/command.zig:643
+#: src/input/command.zig:661
 msgid "Toggle the maximized state of the current window."
 msgstr "Slå den maksimerede tilstand af det nuværende vindue til eller fra."
 
-#: src/input/command.zig:648
+#: src/input/command.zig:666
 msgid "Toggle Fullscreen"
 msgstr "Slå fuld skærm til/fra"
 
-#: src/input/command.zig:649
+#: src/input/command.zig:667
 msgid "Toggle the fullscreen state of the current window."
 msgstr "Slå fuldskærmstilstanden til eller fra for det nuværende vindue."
 
-#: src/input/command.zig:654
+#: src/input/command.zig:672
 msgid "Toggle Window Decorations"
 msgstr "Slå vinduesdekorationer til/fra"
 
-#: src/input/command.zig:655
+#: src/input/command.zig:673
 msgid "Toggle the window decorations."
 msgstr "Slå vinduesdekorationerne til eller fra."
 
-#: src/input/command.zig:660
+#: src/input/command.zig:678
 msgid "Toggle Float on Top"
 msgstr "Slå vis altid øverst til/fra"
 
-#: src/input/command.zig:661
+#: src/input/command.zig:679
 msgid "Toggle the float on top state of the current window."
 msgstr "Slå tilstanden for altid at vise vinduet øverst til eller fra."
 
-#: src/input/command.zig:666
+#: src/input/command.zig:684
 msgid "Toggle Secure Input"
 msgstr "Slå sikker input til/fra"
 
-#: src/input/command.zig:667
+#: src/input/command.zig:685
 msgid "Toggle secure input mode."
 msgstr "Slå sikker inputstilstanden til eller fra."
 
-#: src/input/command.zig:672
+#: src/input/command.zig:690
 msgid "Toggle Mouse Reporting"
 msgstr "Slå muserapportering til/fra"
 
-#: src/input/command.zig:673
+#: src/input/command.zig:691
 msgid "Toggle whether mouse events are reported to terminal applications."
-msgstr "Slå til eller fra, om musehændelser skal rapporteres til terminalprogrammer."
+msgstr ""
+"Slå til eller fra, om musehændelser skal rapporteres til terminalprogrammer."
 
-#: src/input/command.zig:678
+#: src/input/command.zig:696
 msgid "Toggle Background Opacity"
 msgstr "Slå baggrundsgennemskinnelighed til/fra"
 
-#: src/input/command.zig:679
+#: src/input/command.zig:697
 msgid "Toggle the background opacity of a window that started transparent."
-msgstr "Slå baggrundsgennemskinneligheden til eller fra for et vindue, der startede som gennemsigtigt."
+msgstr ""
+"Slå baggrundsgennemskinneligheden til eller fra for et vindue, der startede "
+"som gennemsigtigt."
 
-#: src/input/command.zig:684
+#: src/input/command.zig:702
 msgid "Check for Updates"
 msgstr "Tjek efter opdateringer"
 
-#: src/input/command.zig:685
+#: src/input/command.zig:703
 msgid "Check for updates to the application."
 msgstr "Tjek efter opdateringer for programmet."
 
-#: src/input/command.zig:690
+#: src/input/command.zig:708
 msgid "Undo"
 msgstr "Fortryd"
 
-#: src/input/command.zig:691
+#: src/input/command.zig:709
 msgid "Undo the last action."
 msgstr "Fortryd den sidste handling."
 
-#: src/input/command.zig:696
+#: src/input/command.zig:714
 msgid "Redo"
 msgstr "Gentag"
 
-#: src/input/command.zig:697
+#: src/input/command.zig:715
 msgid "Redo the last undone action."
 msgstr "Gentag den sidste fortrudte handling."
 
-#: src/input/command.zig:703
+#: src/input/command.zig:721
 msgid "Quit the application."
 msgstr "Luk ned for programmet."
 
-#: src/input/command.zig:708
+#: src/input/command.zig:726
 msgid "Ghostty"
 msgstr "Ghostty"
 
-#: src/input/command.zig:709
+#: src/input/command.zig:727
 msgid "Put a little Ghostty in your terminal."
 msgstr "Sæt en lille Ghostty i din terminal."

--- a/po/de.po
+++ b/po/de.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-09-10 10:50-0400\n"
 "PO-Revision-Date: 2026-02-13 08:05+0100\n"
 "Last-Translator: Klaus Hipp <khipp@users.noreply.github.com>\n"
 "Language-Team: German <translation-team-de@lists.sourceforge.net>\n"
@@ -52,7 +52,7 @@ msgstr ""
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2263
+#: src/apprt/gtk/class/application.zig:2296
 msgid "Cancel"
 msgstr "Abbrechen"
 
@@ -198,7 +198,7 @@ msgid "New Tab"
 msgstr "Neuer Tab"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:242
-#: src/input/command.zig:613
+#: src/input/command.zig:631
 msgid "Close Tab"
 msgstr "Tab schließen"
 
@@ -216,7 +216,7 @@ msgid "New Window"
 msgstr "Neues Fenster"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:416 src/apprt/gtk/ui/1.5/window.blp:225
-#: src/input/command.zig:630
+#: src/input/command.zig:648
 msgid "Close Window"
 msgstr "Fenster schließen"
 
@@ -260,11 +260,11 @@ msgstr "Befehlspalette"
 msgid "Terminal Inspector"
 msgstr "Terminalinspektor"
 
-#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1991
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1997
 msgid "About Ghostty"
 msgstr "Über Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:702
+#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:720
 msgid "Quit"
 msgstr "Beenden"
 
@@ -272,27 +272,27 @@ msgstr "Beenden"
 msgid "Execute a command…"
 msgstr "Einen Befehl ausführen…"
 
-#: src/apprt/gtk/class/application.zig:1767
+#: src/apprt/gtk/class/application.zig:1779
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1769
+#: src/apprt/gtk/class/application.zig:1781
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1780
+#: src/apprt/gtk/class/application.zig:1792
 msgid "Global keybind unavailable"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2259
+#: src/apprt/gtk/class/application.zig:2292
 msgid "Export Terminal IO Events"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2262
+#: src/apprt/gtk/class/application.zig:2295
 msgid "Export"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2783
+#: src/apprt/gtk/class/application.zig:2827
 msgid "Editing configuration file"
 msgstr ""
 
@@ -356,16 +356,16 @@ msgstr "Alle Terminalsitzungen in diesem Fenster werden beendet."
 msgid "The currently running process in this split will be terminated."
 msgstr "Der aktuell laufende Prozess in diesem geteilten Fenster wird beendet."
 
-#: src/apprt/gtk/class/surface.zig:1181
+#: src/apprt/gtk/class/surface.zig:1194
 msgid "Command Finished"
 msgstr "Befehl abgeschlossen"
 
-#: src/apprt/gtk/class/surface.zig:1182
+#: src/apprt/gtk/class/surface.zig:1195
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Befehl erfolgreich"
 
-#: src/apprt/gtk/class/surface.zig:1183
+#: src/apprt/gtk/class/surface.zig:1196
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Befehl fehlgeschlagen"
@@ -382,19 +382,19 @@ msgstr "Tab-Titel ändern"
 msgid "Change Window Title"
 msgstr ""
 
-#: src/apprt/gtk/class/window.zig:1153
+#: src/apprt/gtk/class/window.zig:1159
 msgid "Reloaded the configuration"
 msgstr "Konfiguration wurde neu geladen"
 
-#: src/apprt/gtk/class/window.zig:1830
+#: src/apprt/gtk/class/window.zig:1836
 msgid "Copied to clipboard"
 msgstr "In die Zwischenablage kopiert"
 
-#: src/apprt/gtk/class/window.zig:1832
+#: src/apprt/gtk/class/window.zig:1838
 msgid "Cleared clipboard"
 msgstr "Zwischenablage geleert"
 
-#: src/apprt/gtk/class/window.zig:1972
+#: src/apprt/gtk/class/window.zig:1978
 msgid "Ghostty Developers"
 msgstr "Ghostty-Entwickler"
 
@@ -976,134 +976,158 @@ msgstr ""
 msgid "Reload the config file."
 msgstr ""
 
-#: src/input/command.zig:606
-msgid "Close Terminal"
-msgstr ""
-
 #: src/input/command.zig:607
-msgid "Close the current terminal."
+msgid "Switch to Dark Appearance"
 msgstr ""
 
-#: src/input/command.zig:614
-msgid "Close the current tab."
+#: src/input/command.zig:608
+msgid "Use a dark application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Switch to Light Appearance"
+msgstr ""
+
+#: src/input/command.zig:613
+msgid "Use a light application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Switch to System Appearance"
 msgstr ""
 
 #: src/input/command.zig:618
-msgid "Close Other Tabs"
-msgstr ""
-
-#: src/input/command.zig:619
-msgid "Close all tabs in this window except the current one."
-msgstr ""
-
-#: src/input/command.zig:623
-msgid "Close Tabs to the Right"
+msgid "Use the system application appearance for this session."
 msgstr ""
 
 #: src/input/command.zig:624
-msgid "Close all tabs to the right of the current one."
+msgid "Close Terminal"
 msgstr ""
 
-#: src/input/command.zig:631
-msgid "Close the current window."
+#: src/input/command.zig:625
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:632
+msgid "Close the current tab."
 msgstr ""
 
 #: src/input/command.zig:636
-msgid "Close All Windows"
+msgid "Close Other Tabs"
 msgstr ""
 
 #: src/input/command.zig:637
-msgid "Close all windows."
+msgid "Close all tabs in this window except the current one."
+msgstr ""
+
+#: src/input/command.zig:641
+msgid "Close Tabs to the Right"
 msgstr ""
 
 #: src/input/command.zig:642
-msgid "Toggle Maximize"
-msgstr ""
-
-#: src/input/command.zig:643
-msgid "Toggle the maximized state of the current window."
-msgstr ""
-
-#: src/input/command.zig:648
-msgid "Toggle Fullscreen"
+msgid "Close all tabs to the right of the current one."
 msgstr ""
 
 #: src/input/command.zig:649
-msgid "Toggle the fullscreen state of the current window."
+msgid "Close the current window."
 msgstr ""
 
 #: src/input/command.zig:654
-msgid "Toggle Window Decorations"
+msgid "Close All Windows"
 msgstr ""
 
 #: src/input/command.zig:655
-msgid "Toggle the window decorations."
+msgid "Close all windows."
 msgstr ""
 
 #: src/input/command.zig:660
-msgid "Toggle Float on Top"
+msgid "Toggle Maximize"
 msgstr ""
 
 #: src/input/command.zig:661
-msgid "Toggle the float on top state of the current window."
+msgid "Toggle the maximized state of the current window."
 msgstr ""
 
 #: src/input/command.zig:666
-msgid "Toggle Secure Input"
+msgid "Toggle Fullscreen"
 msgstr ""
 
 #: src/input/command.zig:667
-msgid "Toggle secure input mode."
+msgid "Toggle the fullscreen state of the current window."
 msgstr ""
 
 #: src/input/command.zig:672
-msgid "Toggle Mouse Reporting"
+msgid "Toggle Window Decorations"
 msgstr ""
 
 #: src/input/command.zig:673
-msgid "Toggle whether mouse events are reported to terminal applications."
+msgid "Toggle the window decorations."
 msgstr ""
 
 #: src/input/command.zig:678
-msgid "Toggle Background Opacity"
+msgid "Toggle Float on Top"
 msgstr ""
 
 #: src/input/command.zig:679
-msgid "Toggle the background opacity of a window that started transparent."
+msgid "Toggle the float on top state of the current window."
 msgstr ""
 
 #: src/input/command.zig:684
-msgid "Check for Updates"
+msgid "Toggle Secure Input"
 msgstr ""
 
 #: src/input/command.zig:685
-msgid "Check for updates to the application."
+msgid "Toggle secure input mode."
 msgstr ""
 
 #: src/input/command.zig:690
-msgid "Undo"
+msgid "Toggle Mouse Reporting"
 msgstr ""
 
 #: src/input/command.zig:691
-msgid "Undo the last action."
+msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr ""
 
 #: src/input/command.zig:696
-msgid "Redo"
+msgid "Toggle Background Opacity"
 msgstr ""
 
 #: src/input/command.zig:697
-msgid "Redo the last undone action."
+msgid "Toggle the background opacity of a window that started transparent."
+msgstr ""
+
+#: src/input/command.zig:702
+msgid "Check for Updates"
 msgstr ""
 
 #: src/input/command.zig:703
-msgid "Quit the application."
+msgid "Check for updates to the application."
 msgstr ""
 
 #: src/input/command.zig:708
-msgid "Ghostty"
+msgid "Undo"
 msgstr ""
 
 #: src/input/command.zig:709
+msgid "Undo the last action."
+msgstr ""
+
+#: src/input/command.zig:714
+msgid "Redo"
+msgstr ""
+
+#: src/input/command.zig:715
+msgid "Redo the last undone action."
+msgstr ""
+
+#: src/input/command.zig:721
+msgid "Quit the application."
+msgstr ""
+
+#: src/input/command.zig:726
+msgid "Ghostty"
+msgstr ""
+
+#: src/input/command.zig:727
 msgid "Put a little Ghostty in your terminal."
 msgstr ""

--- a/po/es_AR.po
+++ b/po/es_AR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-09-10 10:50-0400\n"
 "PO-Revision-Date: 2026-08-13 12:56-0300\n"
 "Last-Translator: Alan Moyano <alanmoyano203@gmail.com>\n"
 "Language-Team: Argentinian <es@tp.org.es>\n"
@@ -48,7 +48,7 @@ msgstr "Recargar la configuración para volver a mostrar este mensaje"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2263
+#: src/apprt/gtk/class/application.zig:2296
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -193,7 +193,7 @@ msgid "New Tab"
 msgstr "Nueva pestaña"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:242
-#: src/input/command.zig:613
+#: src/input/command.zig:631
 msgid "Close Tab"
 msgstr "Cerrar pestaña"
 
@@ -211,7 +211,7 @@ msgid "New Window"
 msgstr "Nueva ventana"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:416 src/apprt/gtk/ui/1.5/window.blp:225
-#: src/input/command.zig:630
+#: src/input/command.zig:648
 msgid "Close Window"
 msgstr "Cerrar ventana"
 
@@ -255,11 +255,11 @@ msgstr "Paleta de comandos"
 msgid "Terminal Inspector"
 msgstr "Inspector de la terminal"
 
-#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1991
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1997
 msgid "About Ghostty"
 msgstr "Acerca de Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:702
+#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:720
 msgid "Quit"
 msgstr "Salir"
 
@@ -267,27 +267,27 @@ msgstr "Salir"
 msgid "Execute a command…"
 msgstr "Ejecutar un comando…"
 
-#: src/apprt/gtk/class/application.zig:1767
+#: src/apprt/gtk/class/application.zig:1779
 msgid "The keybind was revoked by the system."
 msgstr "El sistema operativo revocó el atajo de teclado."
 
-#: src/apprt/gtk/class/application.zig:1769
+#: src/apprt/gtk/class/application.zig:1781
 msgid "The keybind was denied by the system."
 msgstr "El sistema operativo denegó el atajo de teclado."
 
-#: src/apprt/gtk/class/application.zig:1780
+#: src/apprt/gtk/class/application.zig:1792
 msgid "Global keybind unavailable"
 msgstr "Atajo de teclado global no disponible"
 
-#: src/apprt/gtk/class/application.zig:2259
+#: src/apprt/gtk/class/application.zig:2292
 msgid "Export Terminal IO Events"
 msgstr "Exportar eventos de entrada/salida de la terminal"
 
-#: src/apprt/gtk/class/application.zig:2262
+#: src/apprt/gtk/class/application.zig:2295
 msgid "Export"
 msgstr "Exportar"
 
-#: src/apprt/gtk/class/application.zig:2783
+#: src/apprt/gtk/class/application.zig:2827
 msgid "Editing configuration file"
 msgstr "Editando el archivo de configuración"
 
@@ -351,16 +351,16 @@ msgstr "Todas las sesiones de terminal en esta ventana se finalizarán."
 msgid "The currently running process in this split will be terminated."
 msgstr "El proceso en ejecución en esta división se finalizará."
 
-#: src/apprt/gtk/class/surface.zig:1181
+#: src/apprt/gtk/class/surface.zig:1194
 msgid "Command Finished"
 msgstr "Comando finalizado"
 
-#: src/apprt/gtk/class/surface.zig:1182
+#: src/apprt/gtk/class/surface.zig:1195
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Comando ejecutado correctamente"
 
-#: src/apprt/gtk/class/surface.zig:1183
+#: src/apprt/gtk/class/surface.zig:1196
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Comando fallido"
@@ -377,19 +377,19 @@ msgstr "Cambiar título de la pestaña"
 msgid "Change Window Title"
 msgstr "Cambiar título de la ventana"
 
-#: src/apprt/gtk/class/window.zig:1153
+#: src/apprt/gtk/class/window.zig:1159
 msgid "Reloaded the configuration"
 msgstr "Configuración recargada"
 
-#: src/apprt/gtk/class/window.zig:1830
+#: src/apprt/gtk/class/window.zig:1836
 msgid "Copied to clipboard"
 msgstr "Se copió al portapapeles"
 
-#: src/apprt/gtk/class/window.zig:1832
+#: src/apprt/gtk/class/window.zig:1838
 msgid "Cleared clipboard"
 msgstr "Se limpió el portapapeles"
 
-#: src/apprt/gtk/class/window.zig:1972
+#: src/apprt/gtk/class/window.zig:1978
 msgid "Ghostty Developers"
 msgstr "Desarrolladores de Ghostty"
 
@@ -495,8 +495,8 @@ msgstr "Finalizar búsqueda"
 #: src/input/command.zig:210
 msgid "End the current search if any and hide any GUI elements."
 msgstr ""
-"Finaliza la búsqueda actual, si la hay, y oculta los elementos "
-"de la interfaz."
+"Finaliza la búsqueda actual, si la hay, y oculta los elementos de la "
+"interfaz."
 
 #: src/input/command.zig:215
 msgid "Next Search Result"
@@ -603,8 +603,8 @@ msgid ""
 "Copy the screen contents to a temporary file and copy the path to the "
 "clipboard."
 msgstr ""
-"Copia el contenido de la pantalla en un archivo temporal y copia su ruta "
-"al portapapeles."
+"Copia el contenido de la pantalla en un archivo temporal y copia su ruta al "
+"portapapeles."
 
 #: src/input/command.zig:291
 msgid "Copy Screen to Temporary File and Paste Path"
@@ -633,8 +633,8 @@ msgid ""
 "Copy the screen contents as HTML to a temporary file and copy the path to "
 "the clipboard."
 msgstr ""
-"Copia el contenido de la pantalla como HTML en un archivo temporal y "
-"copia su ruta al portapapeles."
+"Copia el contenido de la pantalla como HTML en un archivo temporal y copia "
+"su ruta al portapapeles."
 
 #: src/input/command.zig:313
 msgid "Copy Screen as HTML to Temporary File and Paste Path"
@@ -645,8 +645,8 @@ msgid ""
 "Copy the screen contents as HTML to a temporary file and paste the path to "
 "the file."
 msgstr ""
-"Copia el contenido de la pantalla como HTML en un archivo temporal y pega "
-"su ruta."
+"Copia el contenido de la pantalla como HTML en un archivo temporal y pega su "
+"ruta."
 
 #: src/input/command.zig:321
 msgid "Copy Screen as HTML to Temporary File and Open"
@@ -655,8 +655,7 @@ msgstr "Copiar pantalla como HTML en un archivo temporal y abrirlo"
 #: src/input/command.zig:322
 msgid "Copy the screen contents as HTML to a temporary file and open it."
 msgstr ""
-"Copia el contenido de la pantalla como HTML en un archivo temporal "
-"y lo abre."
+"Copia el contenido de la pantalla como HTML en un archivo temporal y lo abre."
 
 #: src/input/command.zig:330
 msgid "Copy Screen as ANSI Sequences to Temporary File and Copy Path"
@@ -686,8 +685,7 @@ msgstr ""
 
 #: src/input/command.zig:346
 msgid "Copy Screen as ANSI Sequences to Temporary File and Open"
-msgstr ""
-"Copiar pantalla como secuencias ANSI en un archivo temporal y abrirlo"
+msgstr "Copiar pantalla como secuencias ANSI en un archivo temporal y abrirlo"
 
 #: src/input/command.zig:347
 msgid ""
@@ -706,8 +704,8 @@ msgid ""
 "Copy the selection contents to a temporary file and copy the path to the "
 "clipboard."
 msgstr ""
-"Copia el contenido de la selección en un archivo temporal y copia su ruta "
-"al portapapeles."
+"Copia el contenido de la selección en un archivo temporal y copia su ruta al "
+"portapapeles."
 
 #: src/input/command.zig:359
 msgid "Copy Selection to Temporary File and Paste Path"
@@ -737,8 +735,8 @@ msgid ""
 "Copy the selection contents as HTML to a temporary file and copy the path to "
 "the clipboard."
 msgstr ""
-"Copia el contenido de la selección como HTML en un archivo temporal y "
-"copia su ruta al portapapeles."
+"Copia el contenido de la selección como HTML en un archivo temporal y copia "
+"su ruta al portapapeles."
 
 #: src/input/command.zig:381
 msgid "Copy Selection as HTML to Temporary File and Paste Path"
@@ -758,8 +756,9 @@ msgstr "Copiar selección como HTML en un archivo temporal y abrirlo"
 
 #: src/input/command.zig:390
 msgid "Copy the selection contents as HTML to a temporary file and open it."
-msgstr "Copia el contenido de la selección como HTML en un archivo temporal y "
-"lo abre."
+msgstr ""
+"Copia el contenido de la selección como HTML en un archivo temporal y lo "
+"abre."
 
 #: src/input/command.zig:398
 msgid "Copy Selection as ANSI Sequences to Temporary File and Copy Path"
@@ -789,8 +788,7 @@ msgstr ""
 
 #: src/input/command.zig:414
 msgid "Copy Selection as ANSI Sequences to Temporary File and Open"
-msgstr ""
-"Copiar selección como secuencias ANSI en un archivo temporal y abrirlo"
+msgstr "Copiar selección como secuencias ANSI en un archivo temporal y abrirlo"
 
 #: src/input/command.zig:415
 msgid ""
@@ -994,8 +992,9 @@ msgstr "Abrir configuración en el editor predeterminado del sistema operativo"
 
 #: src/input/command.zig:589
 msgid "Open the config file with the OS's default editor."
-msgstr "Abre el archivo de configuración con el editor predeterminado "
-"del sistema operativo."
+msgstr ""
+"Abre el archivo de configuración con el editor predeterminado del sistema "
+"operativo."
 
 #: src/input/command.zig:593
 msgid "Open Config in New Terminal Window"
@@ -1003,8 +1002,9 @@ msgstr "Abrir configuración en una nueva ventana de terminal"
 
 #: src/input/command.zig:594
 msgid "Open the config file in a new window using $EDITOR or $VISUAL."
-msgstr "Abre el archivo de configuración en una nueva ventana usando "
-"$EDITOR o $VISUAL."
+msgstr ""
+"Abre el archivo de configuración en una nueva ventana usando $EDITOR o "
+"$VISUAL."
 
 #: src/input/command.zig:600
 msgid "Reload Config"
@@ -1014,136 +1014,160 @@ msgstr "Recargar configuración"
 msgid "Reload the config file."
 msgstr "Recarga el archivo de configuración."
 
-#: src/input/command.zig:606
+#: src/input/command.zig:607
+msgid "Switch to Dark Appearance"
+msgstr ""
+
+#: src/input/command.zig:608
+msgid "Use a dark application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Switch to Light Appearance"
+msgstr ""
+
+#: src/input/command.zig:613
+msgid "Use a light application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Switch to System Appearance"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Use the system application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:624
 msgid "Close Terminal"
 msgstr "Cerrar terminal"
 
-#: src/input/command.zig:607
+#: src/input/command.zig:625
 msgid "Close the current terminal."
 msgstr "Cierra la terminal actual."
 
-#: src/input/command.zig:614
+#: src/input/command.zig:632
 msgid "Close the current tab."
 msgstr "Cierra la pestaña actual."
 
-#: src/input/command.zig:618
+#: src/input/command.zig:636
 msgid "Close Other Tabs"
 msgstr "Cerrar otras pestañas"
 
-#: src/input/command.zig:619
+#: src/input/command.zig:637
 msgid "Close all tabs in this window except the current one."
 msgstr "Cierra todas las pestañas en esta ventana excepto la actual."
 
-#: src/input/command.zig:623
+#: src/input/command.zig:641
 msgid "Close Tabs to the Right"
 msgstr "Cerrar pestañas a la derecha"
 
-#: src/input/command.zig:624
+#: src/input/command.zig:642
 msgid "Close all tabs to the right of the current one."
 msgstr "Cierra todas las pestañas a la derecha de la actual."
 
-#: src/input/command.zig:631
+#: src/input/command.zig:649
 msgid "Close the current window."
 msgstr "Cierra la ventana actual."
 
-#: src/input/command.zig:636
+#: src/input/command.zig:654
 msgid "Close All Windows"
 msgstr "Cerrar todas las ventanas"
 
-#: src/input/command.zig:637
+#: src/input/command.zig:655
 msgid "Close all windows."
 msgstr "Cierra todas las ventanas."
 
-#: src/input/command.zig:642
+#: src/input/command.zig:660
 msgid "Toggle Maximize"
 msgstr "Maximizar/restaurar ventana"
 
-#: src/input/command.zig:643
+#: src/input/command.zig:661
 msgid "Toggle the maximized state of the current window."
 msgstr "Alterna el estado maximizado de la ventana actual."
 
-#: src/input/command.zig:648
+#: src/input/command.zig:666
 msgid "Toggle Fullscreen"
 msgstr "Alternar pantalla completa"
 
-#: src/input/command.zig:649
+#: src/input/command.zig:667
 msgid "Toggle the fullscreen state of the current window."
 msgstr "Alterna el estado de pantalla completa de la ventana actual."
 
-#: src/input/command.zig:654
+#: src/input/command.zig:672
 msgid "Toggle Window Decorations"
 msgstr "Alternar decoraciones de ventana"
 
-#: src/input/command.zig:655
+#: src/input/command.zig:673
 msgid "Toggle the window decorations."
 msgstr "Alterna las decoraciones de la ventana."
 
-#: src/input/command.zig:660
+#: src/input/command.zig:678
 msgid "Toggle Float on Top"
 msgstr "Alternar ventana flotante"
 
-#: src/input/command.zig:661
+#: src/input/command.zig:679
 msgid "Toggle the float on top state of the current window."
 msgstr "Alterna si la ventana actual se mantiene sobre las demás."
 
-#: src/input/command.zig:666
+#: src/input/command.zig:684
 msgid "Toggle Secure Input"
 msgstr "Alternar entrada segura"
 
-#: src/input/command.zig:667
+#: src/input/command.zig:685
 msgid "Toggle secure input mode."
 msgstr "Alterna el modo de entrada segura."
 
-#: src/input/command.zig:672
+#: src/input/command.zig:690
 msgid "Toggle Mouse Reporting"
 msgstr "Alternar reporte de eventos del mouse"
 
-#: src/input/command.zig:673
+#: src/input/command.zig:691
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr ""
 "Alterna si los eventos del mouse se envían a las aplicaciones de terminal."
 
-#: src/input/command.zig:678
+#: src/input/command.zig:696
 msgid "Toggle Background Opacity"
 msgstr "Alternar opacidad del fondo"
 
-#: src/input/command.zig:679
+#: src/input/command.zig:697
 msgid "Toggle the background opacity of a window that started transparent."
-msgstr "Alterna la opacidad del fondo de una ventana que se abrió con "
-"transparencia."
+msgstr ""
+"Alterna la opacidad del fondo de una ventana que se abrió con transparencia."
 
-#: src/input/command.zig:684
+#: src/input/command.zig:702
 msgid "Check for Updates"
 msgstr "Buscar actualizaciones"
 
-#: src/input/command.zig:685
+#: src/input/command.zig:703
 msgid "Check for updates to the application."
 msgstr "Busca actualizaciones de la aplicación."
 
-#: src/input/command.zig:690
+#: src/input/command.zig:708
 msgid "Undo"
 msgstr "Deshacer"
 
-#: src/input/command.zig:691
+#: src/input/command.zig:709
 msgid "Undo the last action."
 msgstr "Deshace la última acción."
 
-#: src/input/command.zig:696
+#: src/input/command.zig:714
 msgid "Redo"
 msgstr "Rehacer"
 
-#: src/input/command.zig:697
+#: src/input/command.zig:715
 msgid "Redo the last undone action."
 msgstr "Rehace la última acción deshecha."
 
-#: src/input/command.zig:703
+#: src/input/command.zig:721
 msgid "Quit the application."
 msgstr "Sale de la aplicación."
 
-#: src/input/command.zig:708
+#: src/input/command.zig:726
 msgid "Ghostty"
 msgstr "Ghostty"
 
-#: src/input/command.zig:709
+#: src/input/command.zig:727
 msgid "Put a little Ghostty in your terminal."
 msgstr "Poné un pequeño Ghostty en tu terminal."

--- a/po/es_BO.po
+++ b/po/es_BO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-09-10 10:50-0400\n"
 "PO-Revision-Date: 2026-08-13 17:33+0300\n"
 "Last-Translator: Miguel Peredo <miguelp@quientienemail.com>\n"
 "Language-Team: Spanish <es@tp.org.es>\n"
@@ -48,7 +48,7 @@ msgstr "Recargar configuración para mostrar este aviso nuevamente"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2263
+#: src/apprt/gtk/class/application.zig:2296
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -193,7 +193,7 @@ msgid "New Tab"
 msgstr "Nueva pestaña"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:242
-#: src/input/command.zig:613
+#: src/input/command.zig:631
 msgid "Close Tab"
 msgstr "Cerrar pestaña"
 
@@ -211,7 +211,7 @@ msgid "New Window"
 msgstr "Nueva ventana"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:416 src/apprt/gtk/ui/1.5/window.blp:225
-#: src/input/command.zig:630
+#: src/input/command.zig:648
 msgid "Close Window"
 msgstr "Cerrar ventana"
 
@@ -255,11 +255,11 @@ msgstr "Paleta de comandos"
 msgid "Terminal Inspector"
 msgstr "Inspector de la terminal"
 
-#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1991
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1997
 msgid "About Ghostty"
 msgstr "Acerca de Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:702
+#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:720
 msgid "Quit"
 msgstr "Salir"
 
@@ -267,27 +267,27 @@ msgstr "Salir"
 msgid "Execute a command…"
 msgstr "Ejecutar comando…"
 
-#: src/apprt/gtk/class/application.zig:1767
+#: src/apprt/gtk/class/application.zig:1779
 msgid "The keybind was revoked by the system."
 msgstr "El sistema revocó el atajo de teclado."
 
-#: src/apprt/gtk/class/application.zig:1769
+#: src/apprt/gtk/class/application.zig:1781
 msgid "The keybind was denied by the system."
 msgstr "El sistema denegó el atajo de teclado."
 
-#: src/apprt/gtk/class/application.zig:1780
+#: src/apprt/gtk/class/application.zig:1792
 msgid "Global keybind unavailable"
 msgstr "Atajo de teclado global no disponible"
 
-#: src/apprt/gtk/class/application.zig:2259
+#: src/apprt/gtk/class/application.zig:2292
 msgid "Export Terminal IO Events"
 msgstr "Exportar eventos de E/S de la terminal"
 
-#: src/apprt/gtk/class/application.zig:2262
+#: src/apprt/gtk/class/application.zig:2295
 msgid "Export"
 msgstr "Exportar"
 
-#: src/apprt/gtk/class/application.zig:2783
+#: src/apprt/gtk/class/application.zig:2827
 msgid "Editing configuration file"
 msgstr "Editando el archivo de configuración"
 
@@ -351,16 +351,16 @@ msgstr "Todas las sesiones de terminal en esta ventana serán terminadas."
 msgid "The currently running process in this split will be terminated."
 msgstr "El proceso actualmente en ejecución en esta división será terminado."
 
-#: src/apprt/gtk/class/surface.zig:1181
+#: src/apprt/gtk/class/surface.zig:1194
 msgid "Command Finished"
 msgstr "Comando finalizado"
 
-#: src/apprt/gtk/class/surface.zig:1182
+#: src/apprt/gtk/class/surface.zig:1195
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Comando exitoso"
 
-#: src/apprt/gtk/class/surface.zig:1183
+#: src/apprt/gtk/class/surface.zig:1196
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Comando fallido"
@@ -377,19 +377,19 @@ msgstr "Cambiar el título de la pestaña"
 msgid "Change Window Title"
 msgstr "Cambiar el título de la ventana"
 
-#: src/apprt/gtk/class/window.zig:1153
+#: src/apprt/gtk/class/window.zig:1159
 msgid "Reloaded the configuration"
 msgstr "Configuración recargada"
 
-#: src/apprt/gtk/class/window.zig:1830
+#: src/apprt/gtk/class/window.zig:1836
 msgid "Copied to clipboard"
 msgstr "Copiado al portapapeles"
 
-#: src/apprt/gtk/class/window.zig:1832
+#: src/apprt/gtk/class/window.zig:1838
 msgid "Cleared clipboard"
 msgstr "El portapapeles está limpio"
 
-#: src/apprt/gtk/class/window.zig:1972
+#: src/apprt/gtk/class/window.zig:1978
 msgid "Ghostty Developers"
 msgstr "Desarrolladores de Ghostty"
 
@@ -495,7 +495,8 @@ msgstr "Finalizar búsqueda"
 
 #: src/input/command.zig:210
 msgid "End the current search if any and hide any GUI elements."
-msgstr "Finalizar la búsqueda actual, si existe, y ocultar la interfaz gráfica."
+msgstr ""
+"Finalizar la búsqueda actual, si existe, y ocultar la interfaz gráfica."
 
 #: src/input/command.zig:215
 msgid "Next Search Result"
@@ -602,8 +603,8 @@ msgid ""
 "Copy the screen contents to a temporary file and copy the path to the "
 "clipboard."
 msgstr ""
-"Copiar el contenido de la pantalla a un archivo temporal y copiar la ruta "
-"al portapapeles."
+"Copiar el contenido de la pantalla a un archivo temporal y copiar la ruta al "
+"portapapeles."
 
 #: src/input/command.zig:291
 msgid "Copy Screen to Temporary File and Paste Path"
@@ -613,8 +614,8 @@ msgstr "Copiar pantalla a un archivo temporal y pegar la ruta"
 msgid ""
 "Copy the screen contents to a temporary file and paste the path to the file."
 msgstr ""
-"Copiar el contenido de la pantalla a un archivo temporal y pegar la ruta "
-"del archivo."
+"Copiar el contenido de la pantalla a un archivo temporal y pegar la ruta del "
+"archivo."
 
 #: src/input/command.zig:296
 msgid "Copy Screen to Temporary File and Open"
@@ -736,8 +737,8 @@ msgid ""
 "Copy the selection contents as HTML to a temporary file and copy the path to "
 "the clipboard."
 msgstr ""
-"Copiar el contenido de la selección como HTML a un archivo temporal y "
-"copiar la ruta al portapapeles."
+"Copiar el contenido de la selección como HTML a un archivo temporal y copiar "
+"la ruta al portapapeles."
 
 #: src/input/command.zig:381
 msgid "Copy Selection as HTML to Temporary File and Paste Path"
@@ -758,7 +759,8 @@ msgstr "Copiar selección como HTML a un archivo temporal y abrirlo"
 #: src/input/command.zig:390
 msgid "Copy the selection contents as HTML to a temporary file and open it."
 msgstr ""
-"Copiar el contenido de la selección como HTML a un archivo temporal y abrirlo."
+"Copiar el contenido de la selección como HTML a un archivo temporal y "
+"abrirlo."
 
 #: src/input/command.zig:398
 msgid "Copy Selection as ANSI Sequences to Temporary File and Copy Path"
@@ -1014,137 +1016,161 @@ msgstr "Recargar configuración"
 msgid "Reload the config file."
 msgstr "Recargar el archivo de configuración."
 
-#: src/input/command.zig:606
+#: src/input/command.zig:607
+msgid "Switch to Dark Appearance"
+msgstr ""
+
+#: src/input/command.zig:608
+msgid "Use a dark application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Switch to Light Appearance"
+msgstr ""
+
+#: src/input/command.zig:613
+msgid "Use a light application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Switch to System Appearance"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Use the system application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:624
 msgid "Close Terminal"
 msgstr "Cerrar terminal"
 
-#: src/input/command.zig:607
+#: src/input/command.zig:625
 msgid "Close the current terminal."
 msgstr "Cerrar la terminal actual."
 
-#: src/input/command.zig:614
+#: src/input/command.zig:632
 msgid "Close the current tab."
 msgstr "Cerrar la pestaña actual."
 
-#: src/input/command.zig:618
+#: src/input/command.zig:636
 msgid "Close Other Tabs"
 msgstr "Cerrar las demás pestañas"
 
-#: src/input/command.zig:619
+#: src/input/command.zig:637
 msgid "Close all tabs in this window except the current one."
 msgstr "Cerrar todas las pestañas de esta ventana, excepto la actual."
 
-#: src/input/command.zig:623
+#: src/input/command.zig:641
 msgid "Close Tabs to the Right"
 msgstr "Cerrar pestañas a la derecha"
 
-#: src/input/command.zig:624
+#: src/input/command.zig:642
 msgid "Close all tabs to the right of the current one."
 msgstr "Cerrar todas las pestañas situadas a la derecha de la actual."
 
-#: src/input/command.zig:631
+#: src/input/command.zig:649
 msgid "Close the current window."
 msgstr "Cerrar la ventana actual."
 
-#: src/input/command.zig:636
+#: src/input/command.zig:654
 msgid "Close All Windows"
 msgstr "Cerrar todas las ventanas"
 
-#: src/input/command.zig:637
+#: src/input/command.zig:655
 msgid "Close all windows."
 msgstr "Cerrar todas las ventanas."
 
-#: src/input/command.zig:642
+#: src/input/command.zig:660
 msgid "Toggle Maximize"
 msgstr "Alternar maximización"
 
-#: src/input/command.zig:643
+#: src/input/command.zig:661
 msgid "Toggle the maximized state of the current window."
 msgstr "Maximizar o restaurar la ventana actual."
 
-#: src/input/command.zig:648
+#: src/input/command.zig:666
 msgid "Toggle Fullscreen"
 msgstr "Alternar pantalla completa"
 
-#: src/input/command.zig:649
+#: src/input/command.zig:667
 msgid "Toggle the fullscreen state of the current window."
 msgstr "Activar o desactivar la pantalla completa de la ventana actual."
 
-#: src/input/command.zig:654
+#: src/input/command.zig:672
 msgid "Toggle Window Decorations"
 msgstr "Alternar decoraciones de la ventana"
 
-#: src/input/command.zig:655
+#: src/input/command.zig:673
 msgid "Toggle the window decorations."
 msgstr "Mostrar u ocultar las decoraciones de la ventana."
 
-#: src/input/command.zig:660
+#: src/input/command.zig:678
 msgid "Toggle Float on Top"
 msgstr "Alternar ventana siempre visible"
 
-#: src/input/command.zig:661
+#: src/input/command.zig:679
 msgid "Toggle the float on top state of the current window."
 msgstr "Activar o desactivar el estado siempre visible de la ventana actual."
 
-#: src/input/command.zig:666
+#: src/input/command.zig:684
 msgid "Toggle Secure Input"
 msgstr "Alternar entrada segura"
 
-#: src/input/command.zig:667
+#: src/input/command.zig:685
 msgid "Toggle secure input mode."
 msgstr "Activar o desactivar el modo de entrada segura."
 
-#: src/input/command.zig:672
+#: src/input/command.zig:690
 msgid "Toggle Mouse Reporting"
 msgstr "Alternar envío de eventos del mouse"
 
-#: src/input/command.zig:673
+#: src/input/command.zig:691
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr ""
 "Activar o desactivar el envío de eventos del mouse a las aplicaciones de "
 "terminal."
 
-#: src/input/command.zig:678
+#: src/input/command.zig:696
 msgid "Toggle Background Opacity"
 msgstr "Alternar opacidad del fondo"
 
-#: src/input/command.zig:679
+#: src/input/command.zig:697
 msgid "Toggle the background opacity of a window that started transparent."
 msgstr ""
 "Alternar la opacidad del fondo de una ventana que se inició transparente."
 
-#: src/input/command.zig:684
+#: src/input/command.zig:702
 msgid "Check for Updates"
 msgstr "Buscar actualizaciones"
 
-#: src/input/command.zig:685
+#: src/input/command.zig:703
 msgid "Check for updates to the application."
 msgstr "Buscar actualizaciones de la aplicación."
 
-#: src/input/command.zig:690
+#: src/input/command.zig:708
 msgid "Undo"
 msgstr "Deshacer"
 
-#: src/input/command.zig:691
+#: src/input/command.zig:709
 msgid "Undo the last action."
 msgstr "Deshacer la última acción."
 
-#: src/input/command.zig:696
+#: src/input/command.zig:714
 msgid "Redo"
 msgstr "Rehacer"
 
-#: src/input/command.zig:697
+#: src/input/command.zig:715
 msgid "Redo the last undone action."
 msgstr "Rehacer la última acción deshecha."
 
-#: src/input/command.zig:703
+#: src/input/command.zig:721
 msgid "Quit the application."
 msgstr "Salir de la aplicación."
 
-#: src/input/command.zig:708
+#: src/input/command.zig:726
 msgid "Ghostty"
 msgstr "Ghostty"
 
-#: src/input/command.zig:709
+#: src/input/command.zig:727
 msgid "Put a little Ghostty in your terminal."
 msgstr "Pon un poco de Ghostty en tu terminal."

--- a/po/es_ES.po
+++ b/po/es_ES.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-09-10 10:50-0400\n"
 "PO-Revision-Date: 2026-08-13 21:24+0200\n"
 "Last-Translator: José Miguel Sarasola <alosarjos@gmail.com>\n"
 "Language-Team: \n"
@@ -49,7 +49,7 @@ msgstr "Recargar configuración para volver a mostrar este aviso"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2263
+#: src/apprt/gtk/class/application.zig:2296
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -194,7 +194,7 @@ msgid "New Tab"
 msgstr "Nueva pestaña"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:242
-#: src/input/command.zig:613
+#: src/input/command.zig:631
 msgid "Close Tab"
 msgstr "Cerrar pestaña"
 
@@ -212,7 +212,7 @@ msgid "New Window"
 msgstr "Nueva ventana"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:416 src/apprt/gtk/ui/1.5/window.blp:225
-#: src/input/command.zig:630
+#: src/input/command.zig:648
 msgid "Close Window"
 msgstr "Cerrar ventana"
 
@@ -256,11 +256,11 @@ msgstr "Paleta de comandos"
 msgid "Terminal Inspector"
 msgstr "Inspector de terminal"
 
-#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1991
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1997
 msgid "About Ghostty"
 msgstr "Acerca de Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:702
+#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:720
 msgid "Quit"
 msgstr "Salir"
 
@@ -268,27 +268,27 @@ msgstr "Salir"
 msgid "Execute a command…"
 msgstr "Ejecutar un comando…"
 
-#: src/apprt/gtk/class/application.zig:1767
+#: src/apprt/gtk/class/application.zig:1779
 msgid "The keybind was revoked by the system."
 msgstr "El atajo de teclado fue revocado por el sistema."
 
-#: src/apprt/gtk/class/application.zig:1769
+#: src/apprt/gtk/class/application.zig:1781
 msgid "The keybind was denied by the system."
 msgstr "El atajo de teclado fue denegado por el sistema."
 
-#: src/apprt/gtk/class/application.zig:1780
+#: src/apprt/gtk/class/application.zig:1792
 msgid "Global keybind unavailable"
 msgstr "Atajo de teclado global no disponible"
 
-#: src/apprt/gtk/class/application.zig:2259
+#: src/apprt/gtk/class/application.zig:2292
 msgid "Export Terminal IO Events"
 msgstr "Exportar eventos de E/S del terminal"
 
-#: src/apprt/gtk/class/application.zig:2262
+#: src/apprt/gtk/class/application.zig:2295
 msgid "Export"
 msgstr "Exportar"
 
-#: src/apprt/gtk/class/application.zig:2783
+#: src/apprt/gtk/class/application.zig:2827
 msgid "Editing configuration file"
 msgstr "Editando el fichero de configuración"
 
@@ -352,16 +352,16 @@ msgstr "Todas las sesiones del terminal en esta ventana serán finalizadas."
 msgid "The currently running process in this split will be terminated."
 msgstr "El proceso ejecutándose en esta división será finalizado."
 
-#: src/apprt/gtk/class/surface.zig:1181
+#: src/apprt/gtk/class/surface.zig:1194
 msgid "Command Finished"
 msgstr "Comando finalizado"
 
-#: src/apprt/gtk/class/surface.zig:1182
+#: src/apprt/gtk/class/surface.zig:1195
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Comando completado"
 
-#: src/apprt/gtk/class/surface.zig:1183
+#: src/apprt/gtk/class/surface.zig:1196
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Comando fallido"
@@ -378,19 +378,19 @@ msgstr "Cambiar el título de la pestaña"
 msgid "Change Window Title"
 msgstr "Cambiar el título de la ventana"
 
-#: src/apprt/gtk/class/window.zig:1153
+#: src/apprt/gtk/class/window.zig:1159
 msgid "Reloaded the configuration"
 msgstr "Configuración recargada"
 
-#: src/apprt/gtk/class/window.zig:1830
+#: src/apprt/gtk/class/window.zig:1836
 msgid "Copied to clipboard"
 msgstr "Copiado al portapapeles"
 
-#: src/apprt/gtk/class/window.zig:1832
+#: src/apprt/gtk/class/window.zig:1838
 msgid "Cleared clipboard"
 msgstr "Portapapeles vaciado"
 
-#: src/apprt/gtk/class/window.zig:1972
+#: src/apprt/gtk/class/window.zig:1978
 msgid "Ghostty Developers"
 msgstr "Desarrolladores de Ghostty"
 
@@ -1018,137 +1018,161 @@ msgstr "Recargar configuración"
 msgid "Reload the config file."
 msgstr "Recargar el fichero de configuración."
 
-#: src/input/command.zig:606
+#: src/input/command.zig:607
+msgid "Switch to Dark Appearance"
+msgstr ""
+
+#: src/input/command.zig:608
+msgid "Use a dark application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Switch to Light Appearance"
+msgstr ""
+
+#: src/input/command.zig:613
+msgid "Use a light application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Switch to System Appearance"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Use the system application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:624
 msgid "Close Terminal"
 msgstr "Cerrar terminal"
 
-#: src/input/command.zig:607
+#: src/input/command.zig:625
 msgid "Close the current terminal."
 msgstr "Cerrar el terminal actual."
 
-#: src/input/command.zig:614
+#: src/input/command.zig:632
 msgid "Close the current tab."
 msgstr "Cerrar la pestaña actual."
 
-#: src/input/command.zig:618
+#: src/input/command.zig:636
 msgid "Close Other Tabs"
 msgstr "Cerrar otras pestañas"
 
-#: src/input/command.zig:619
+#: src/input/command.zig:637
 msgid "Close all tabs in this window except the current one."
 msgstr "Cerrar todas las pestañas de esta ventana excepto la actual."
 
-#: src/input/command.zig:623
+#: src/input/command.zig:641
 msgid "Close Tabs to the Right"
 msgstr "Cerrar pestañas a la derecha"
 
-#: src/input/command.zig:624
+#: src/input/command.zig:642
 msgid "Close all tabs to the right of the current one."
 msgstr "Cerrar todas las pestañas a la derecha de la actual."
 
-#: src/input/command.zig:631
+#: src/input/command.zig:649
 msgid "Close the current window."
 msgstr "Cerrar la ventana actual."
 
-#: src/input/command.zig:636
+#: src/input/command.zig:654
 msgid "Close All Windows"
 msgstr "Cerrar todas las ventanas"
 
-#: src/input/command.zig:637
+#: src/input/command.zig:655
 msgid "Close all windows."
 msgstr "Cerrar todas las ventanas."
 
-#: src/input/command.zig:642
+#: src/input/command.zig:660
 msgid "Toggle Maximize"
 msgstr "Alternar maximizado"
 
-#: src/input/command.zig:643
+#: src/input/command.zig:661
 msgid "Toggle the maximized state of the current window."
 msgstr "Alternar el estado de maximizado de la ventana actual."
 
-#: src/input/command.zig:648
+#: src/input/command.zig:666
 msgid "Toggle Fullscreen"
 msgstr "Alternar pantalla completa"
 
-#: src/input/command.zig:649
+#: src/input/command.zig:667
 msgid "Toggle the fullscreen state of the current window."
 msgstr "Alternar el estado de pantalla completa de la ventana actual."
 
-#: src/input/command.zig:654
+#: src/input/command.zig:672
 msgid "Toggle Window Decorations"
 msgstr "Alternar decoraciones de ventana"
 
-#: src/input/command.zig:655
+#: src/input/command.zig:673
 msgid "Toggle the window decorations."
 msgstr "Alternar las decoraciones de la ventana."
 
-#: src/input/command.zig:660
+#: src/input/command.zig:678
 msgid "Toggle Float on Top"
 msgstr "Alternar modo siempre encima"
 
-#: src/input/command.zig:661
+#: src/input/command.zig:679
 msgid "Toggle the float on top state of the current window."
 msgstr "Alternar si la ventana actual permanece siempre encima de las demás."
 
-#: src/input/command.zig:666
+#: src/input/command.zig:684
 msgid "Toggle Secure Input"
 msgstr "Alternar entrada segura"
 
-#: src/input/command.zig:667
+#: src/input/command.zig:685
 msgid "Toggle secure input mode."
 msgstr "Alternar el modo de entrada segura."
 
-#: src/input/command.zig:672
+#: src/input/command.zig:690
 msgid "Toggle Mouse Reporting"
 msgstr "Alternar informe del ratón"
 
-#: src/input/command.zig:673
+#: src/input/command.zig:691
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr ""
 "Alternar si los eventos del ratón se envían a las aplicaciones del terminal."
 
-#: src/input/command.zig:678
+#: src/input/command.zig:696
 msgid "Toggle Background Opacity"
 msgstr "Alternar opacidad del fondo"
 
-#: src/input/command.zig:679
+#: src/input/command.zig:697
 msgid "Toggle the background opacity of a window that started transparent."
 msgstr ""
 "Alternar la opacidad del fondo de una ventana que se inició como "
 "transparente."
 
-#: src/input/command.zig:684
+#: src/input/command.zig:702
 msgid "Check for Updates"
 msgstr "Buscar actualizaciones"
 
-#: src/input/command.zig:685
+#: src/input/command.zig:703
 msgid "Check for updates to the application."
 msgstr "Buscar actualizaciones de la aplicación."
 
-#: src/input/command.zig:690
+#: src/input/command.zig:708
 msgid "Undo"
 msgstr "Deshacer"
 
-#: src/input/command.zig:691
+#: src/input/command.zig:709
 msgid "Undo the last action."
 msgstr "Deshacer la última acción."
 
-#: src/input/command.zig:696
+#: src/input/command.zig:714
 msgid "Redo"
 msgstr "Rehacer"
 
-#: src/input/command.zig:697
+#: src/input/command.zig:715
 msgid "Redo the last undone action."
 msgstr "Rehacer la última acción deshecha."
 
-#: src/input/command.zig:703
+#: src/input/command.zig:721
 msgid "Quit the application."
 msgstr "Salir de la aplicación."
 
-#: src/input/command.zig:708
+#: src/input/command.zig:726
 msgid "Ghostty"
 msgstr "Ghostty"
 
-#: src/input/command.zig:709
+#: src/input/command.zig:727
 msgid "Put a little Ghostty in your terminal."
 msgstr "Pon un poco de Ghostty en tu terminal."

--- a/po/eu.po
+++ b/po/eu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-09-10 10:50-0400\n"
 "PO-Revision-Date: 2026-08-31 15:18+0200\n"
 "Last-Translator: Mikel Larreategi <mlarreategi@codesyntax.com>\n"
 "Language-Team: Language eu\n"
@@ -48,7 +48,7 @@ msgstr "Birkargatu konfigurazioa eta erakutsi hau berriz"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2263
+#: src/apprt/gtk/class/application.zig:2296
 msgid "Cancel"
 msgstr "Utzi"
 
@@ -192,7 +192,7 @@ msgid "New Tab"
 msgstr "Fitxa berria"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:242
-#: src/input/command.zig:613
+#: src/input/command.zig:631
 msgid "Close Tab"
 msgstr "Itxi fitxa"
 
@@ -210,7 +210,7 @@ msgid "New Window"
 msgstr "Leiho berria"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:416 src/apprt/gtk/ui/1.5/window.blp:225
-#: src/input/command.zig:630
+#: src/input/command.zig:648
 msgid "Close Window"
 msgstr "Itxi leihoa"
 
@@ -254,11 +254,11 @@ msgstr "Komando paleta"
 msgid "Terminal Inspector"
 msgstr "Terminal ikuskatzailea"
 
-#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1991
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1997
 msgid "About Ghostty"
 msgstr "Ghosttyri buruz"
 
-#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:702
+#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:720
 msgid "Quit"
 msgstr "Irten"
 
@@ -266,27 +266,27 @@ msgstr "Irten"
 msgid "Execute a command…"
 msgstr "Exekutatu komando bat…"
 
-#: src/apprt/gtk/class/application.zig:1767
+#: src/apprt/gtk/class/application.zig:1779
 msgid "The keybind was revoked by the system."
 msgstr "Sistemak laster-tekla baztertu egin du."
 
-#: src/apprt/gtk/class/application.zig:1769
+#: src/apprt/gtk/class/application.zig:1781
 msgid "The keybind was denied by the system."
 msgstr "Sistemak laster-tekla ukatu egin du."
 
-#: src/apprt/gtk/class/application.zig:1780
+#: src/apprt/gtk/class/application.zig:1792
 msgid "Global keybind unavailable"
 msgstr "Laster-tekla globala ezin da erabili"
 
-#: src/apprt/gtk/class/application.zig:2259
+#: src/apprt/gtk/class/application.zig:2292
 msgid "Export Terminal IO Events"
 msgstr "Esportatu terminalaren sarrera/irteera ebentuak"
 
-#: src/apprt/gtk/class/application.zig:2262
+#: src/apprt/gtk/class/application.zig:2295
 msgid "Export"
 msgstr "Esportatu"
 
-#: src/apprt/gtk/class/application.zig:2783
+#: src/apprt/gtk/class/application.zig:2827
 msgid "Editing configuration file"
 msgstr "Konfigurazio fitxategia editatzen"
 
@@ -349,16 +349,16 @@ msgstr "Leiho honetako terminal saio guztiak itxi egingo dira."
 msgid "The currently running process in this split will be terminated."
 msgstr "Zatikatze honetan martxan dagoen prozesua itxi egingo da."
 
-#: src/apprt/gtk/class/surface.zig:1181
+#: src/apprt/gtk/class/surface.zig:1194
 msgid "Command Finished"
 msgstr "Komandoa amaitu da"
 
-#: src/apprt/gtk/class/surface.zig:1182
+#: src/apprt/gtk/class/surface.zig:1195
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Komandoa ondo amaitu da"
 
-#: src/apprt/gtk/class/surface.zig:1183
+#: src/apprt/gtk/class/surface.zig:1196
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Komandoak huts egin du"
@@ -375,19 +375,19 @@ msgstr "Aldatu fitxaren izenburua"
 msgid "Change Window Title"
 msgstr "Aldatu leihoaren izenburua"
 
-#: src/apprt/gtk/class/window.zig:1153
+#: src/apprt/gtk/class/window.zig:1159
 msgid "Reloaded the configuration"
 msgstr "Konfigurazioa berriz kargatu da"
 
-#: src/apprt/gtk/class/window.zig:1830
+#: src/apprt/gtk/class/window.zig:1836
 msgid "Copied to clipboard"
 msgstr "Arbelera kopiatu da"
 
-#: src/apprt/gtk/class/window.zig:1832
+#: src/apprt/gtk/class/window.zig:1838
 msgid "Cleared clipboard"
 msgstr "Arbela garbitu da"
 
-#: src/apprt/gtk/class/window.zig:1972
+#: src/apprt/gtk/class/window.zig:1978
 msgid "Ghostty Developers"
 msgstr "Ghostty garatzaileak"
 
@@ -591,24 +591,28 @@ msgstr "Joan orrialde bat behera."
 
 #: src/input/command.zig:286
 msgid "Copy Screen to Temporary File and Copy Path"
-msgstr "Kopiatu pantaila behin-behineko fitxategi batera eta kopiatu bere bidea"
+msgstr ""
+"Kopiatu pantaila behin-behineko fitxategi batera eta kopiatu bere bidea"
 
 #: src/input/command.zig:287
 msgid ""
 "Copy the screen contents to a temporary file and copy the path to the "
 "clipboard."
 msgstr ""
-"Kopiatu pantailaren edukia behin-behineko fitxategi batera eta kopiatu fitxategiaren bidea arbelera."
+"Kopiatu pantailaren edukia behin-behineko fitxategi batera eta kopiatu "
+"fitxategiaren bidea arbelera."
 
 #: src/input/command.zig:291
 msgid "Copy Screen to Temporary File and Paste Path"
-msgstr "Kopiatu pantaila behin-behineko fitxategi batera eta itsatsi bere bidea"
+msgstr ""
+"Kopiatu pantaila behin-behineko fitxategi batera eta itsatsi bere bidea"
 
 #: src/input/command.zig:292
 msgid ""
 "Copy the screen contents to a temporary file and paste the path to the file."
 msgstr ""
-"Kopiatu pantailaren edukia behin-behineko fitxategi batera eta fitxategiaren bidea itsatsi."
+"Kopiatu pantailaren edukia behin-behineko fitxategi batera eta fitxategiaren "
+"bidea itsatsi."
 
 #: src/input/command.zig:296
 msgid "Copy Screen to Temporary File and Open"
@@ -616,31 +620,36 @@ msgstr "Kopiatu pantaila behin-behineko fitxategi batera eta ireki"
 
 #: src/input/command.zig:297
 msgid "Copy the screen contents to a temporary file and open it."
-msgstr "Kopiatu pantailaren edukia behin-behineko fitxategi batera eta fitxategia ireki."
+msgstr ""
+"Kopiatu pantailaren edukia behin-behineko fitxategi batera eta fitxategia "
+"ireki."
 
 #: src/input/command.zig:305
 msgid "Copy Screen as HTML to Temporary File and Copy Path"
-msgstr "Kopiatu pantaila HTML gisa behin-behineko fitxategi batera eta kopiatu bidea."
+msgstr ""
+"Kopiatu pantaila HTML gisa behin-behineko fitxategi batera eta kopiatu bidea."
 
 #: src/input/command.zig:306
 msgid ""
 "Copy the screen contents as HTML to a temporary file and copy the path to "
 "the clipboard."
 msgstr ""
-"Kopiatu pantailaren edukia HTML gisa behin-behineko fitxategi batera eta kopiatu bere bidea "
-"arbelera."
+"Kopiatu pantailaren edukia HTML gisa behin-behineko fitxategi batera eta "
+"kopiatu bere bidea arbelera."
 
 #: src/input/command.zig:313
 msgid "Copy Screen as HTML to Temporary File and Paste Path"
-msgstr "Kopiatu pantaila HTML gisa behin-behineko fitxategi batera eta itsatsi bere bidea"
+msgstr ""
+"Kopiatu pantaila HTML gisa behin-behineko fitxategi batera eta itsatsi bere "
+"bidea"
 
 #: src/input/command.zig:314
 msgid ""
 "Copy the screen contents as HTML to a temporary file and paste the path to "
 "the file."
 msgstr ""
-"Kopiatu pantailaren edukia HTML gisa behin-behineko fitxategi batera eta fitxategiaren "
-"bidea itsatsi."
+"Kopiatu pantailaren edukia HTML gisa behin-behineko fitxategi batera eta "
+"fitxategiaren bidea itsatsi."
 
 #: src/input/command.zig:321
 msgid "Copy Screen as HTML to Temporary File and Open"
@@ -649,65 +658,76 @@ msgstr "Kopiatu pantaila HTML gisa behin-behineko fitxategi batera eta ireki"
 #: src/input/command.zig:322
 msgid "Copy the screen contents as HTML to a temporary file and open it."
 msgstr ""
-"Kopiatu pantailaren edukia HTML gisa behin-behineko fitxategi batera eta fitxategia ireki."
+"Kopiatu pantailaren edukia HTML gisa behin-behineko fitxategi batera eta "
+"fitxategia ireki."
 
 #: src/input/command.zig:330
 msgid "Copy Screen as ANSI Sequences to Temporary File and Copy Path"
 msgstr ""
-"Kopiatu pantaila ANSI sekuentzia gisa behin-behineko fitxategi batera eta kopiatu bidea."
+"Kopiatu pantaila ANSI sekuentzia gisa behin-behineko fitxategi batera eta "
+"kopiatu bidea."
 
 #: src/input/command.zig:331
 msgid ""
 "Copy the screen contents as ANSI escape sequences to a temporary file and "
 "copy the path to the clipboard."
 msgstr ""
-"Kopiatu pantailaren edukia ANSI eskape-sekuentzia gisa behin-behineko fitxategi batera eta kopiatu "
-"bere bidea arbelera."
+"Kopiatu pantailaren edukia ANSI eskape-sekuentzia gisa behin-behineko "
+"fitxategi batera eta kopiatu bere bidea arbelera."
 
 #: src/input/command.zig:338
 msgid "Copy Screen as ANSI Sequences to Temporary File and Paste Path"
 msgstr ""
-"Kopiatu pantaila ANSI sekuentzia gisa behin-behineko fitxategi batera eta itsatsi bere bidea"
+"Kopiatu pantaila ANSI sekuentzia gisa behin-behineko fitxategi batera eta "
+"itsatsi bere bidea"
 
 #: src/input/command.zig:339
 msgid ""
 "Copy the screen contents as ANSI escape sequences to a temporary file and "
 "paste the path to the file."
 msgstr ""
-"Kopiatu pantailaren edukia ANSI eskape-sekuentzia gisa behin-behineko fitxategi batera eta "
-"fitxategiaren bidea itsatsi."
+"Kopiatu pantailaren edukia ANSI eskape-sekuentzia gisa behin-behineko "
+"fitxategi batera eta fitxategiaren bidea itsatsi."
 
 #: src/input/command.zig:346
 msgid "Copy Screen as ANSI Sequences to Temporary File and Open"
-msgstr "Kopiatu pantaila ANSI sekuentzia gisa behin-behineko fitxategi batera eta ireki"
+msgstr ""
+"Kopiatu pantaila ANSI sekuentzia gisa behin-behineko fitxategi batera eta "
+"ireki"
 
 #: src/input/command.zig:347
 msgid ""
 "Copy the screen contents as ANSI escape sequences to a temporary file and "
 "open it."
 msgstr ""
-"Kopiatu pantailaren edukia ANSI eskape-sekuentzia gisa behin-behineko fitxategi batera eta "
-"fitxategia ireki."
+"Kopiatu pantailaren edukia ANSI eskape-sekuentzia gisa behin-behineko "
+"fitxategi batera eta fitxategia ireki."
 
 #: src/input/command.zig:354
 msgid "Copy Selection to Temporary File and Copy Path"
-msgstr "Kopiatu aukeratutakoa behin-behineko fitxategi batera eta kopiatu bidea"
+msgstr ""
+"Kopiatu aukeratutakoa behin-behineko fitxategi batera eta kopiatu bidea"
 
 #: src/input/command.zig:355
 msgid ""
 "Copy the selection contents to a temporary file and copy the path to the "
 "clipboard."
-msgstr "Kopiatu aukeratutakoa behin-behineko fitxategi batera eta kopiatu bidea arbelera."
+msgstr ""
+"Kopiatu aukeratutakoa behin-behineko fitxategi batera eta kopiatu bidea "
+"arbelera."
 
 #: src/input/command.zig:359
 msgid "Copy Selection to Temporary File and Paste Path"
-msgstr "Kopiatu aukeratutakoa behin-behineko fitxategi batera eta itsatsi bidea"
+msgstr ""
+"Kopiatu aukeratutakoa behin-behineko fitxategi batera eta itsatsi bidea"
 
 #: src/input/command.zig:360
 msgid ""
 "Copy the selection contents to a temporary file and paste the path to the "
 "file."
-msgstr "Kopiatu aukeratutakoa behin-behineko fitxategi batera eta itsatsi bidea fitxategian."
+msgstr ""
+"Kopiatu aukeratutakoa behin-behineko fitxategi batera eta itsatsi bidea "
+"fitxategian."
 
 #: src/input/command.zig:364
 msgid "Copy Selection to Temporary File and Open"
@@ -719,72 +739,83 @@ msgstr "Kopiatu aukeratutakoa behin-behineko fitxategi batera eta ireki."
 
 #: src/input/command.zig:373
 msgid "Copy Selection as HTML to Temporary File and Copy Path"
-msgstr "Kopiatu aukeratutakoa HTML gisa behin-behineko fitxategi batera eta kopiatu bidea"
+msgstr ""
+"Kopiatu aukeratutakoa HTML gisa behin-behineko fitxategi batera eta kopiatu "
+"bidea"
 
 #: src/input/command.zig:374
 msgid ""
 "Copy the selection contents as HTML to a temporary file and copy the path to "
 "the clipboard."
 msgstr ""
-"Kopiatu aukeratutakoa HTML gisa behin-behineko fitxategi batera eta kopiatu bidea arbelera."
+"Kopiatu aukeratutakoa HTML gisa behin-behineko fitxategi batera eta kopiatu "
+"bidea arbelera."
 
 #: src/input/command.zig:381
 msgid "Copy Selection as HTML to Temporary File and Paste Path"
-msgstr "Kopiatu aukeratutakoa HTML gisa behin-behineko fitxategi batera eta itsatsi bidea"
+msgstr ""
+"Kopiatu aukeratutakoa HTML gisa behin-behineko fitxategi batera eta itsatsi "
+"bidea"
 
 #: src/input/command.zig:382
 msgid ""
 "Copy the selection contents as HTML to a temporary file and paste the path "
 "to the file."
 msgstr ""
-"Kopiatu aukeratutakoa HTML gisa behin-behineko fitxategi batera eta itsatsi bidea "
-"fitxategian."
+"Kopiatu aukeratutakoa HTML gisa behin-behineko fitxategi batera eta itsatsi "
+"bidea fitxategian."
 
 #: src/input/command.zig:389
 msgid "Copy Selection as HTML to Temporary File and Open"
-msgstr "Kopiatu aukeratutakoa HTML gisa behin-behineko fitxategi batera eta ireki"
+msgstr ""
+"Kopiatu aukeratutakoa HTML gisa behin-behineko fitxategi batera eta ireki"
 
 #: src/input/command.zig:390
 msgid "Copy the selection contents as HTML to a temporary file and open it."
-msgstr "Kopiatu aukeratutakoa HTML gisa behin-behineko fitxategi batera eta ireki."
+msgstr ""
+"Kopiatu aukeratutakoa HTML gisa behin-behineko fitxategi batera eta ireki."
 
 #: src/input/command.zig:398
 msgid "Copy Selection as ANSI Sequences to Temporary File and Copy Path"
 msgstr ""
-"Kopiatu aukeratutakoa ANSI sekuentzia gisa behin-behineko fitxategi batera eta kopiatu bidea"
+"Kopiatu aukeratutakoa ANSI sekuentzia gisa behin-behineko fitxategi batera "
+"eta kopiatu bidea"
 
 #: src/input/command.zig:399
 msgid ""
 "Copy the selection contents as ANSI escape sequences to a temporary file and "
 "copy the path to the clipboard."
 msgstr ""
-"Kopiatu aukeratutakoa ANSI eskape-sekuentzia gisa behin-behineko fitxategi batera eta kopiatu "
-"bidea arbelera."
+"Kopiatu aukeratutakoa ANSI eskape-sekuentzia gisa behin-behineko fitxategi "
+"batera eta kopiatu bidea arbelera."
 
 #: src/input/command.zig:406
 msgid "Copy Selection as ANSI Sequences to Temporary File and Paste Path"
 msgstr ""
-"Kopiatu aukeratutakoa ANSI sekuentzia gisa behin-behineko fitxategi batera eta itsatsi bidea"
+"Kopiatu aukeratutakoa ANSI sekuentzia gisa behin-behineko fitxategi batera "
+"eta itsatsi bidea"
 
 #: src/input/command.zig:407
 msgid ""
 "Copy the selection contents as ANSI escape sequences to a temporary file and "
 "paste the path to the file."
 msgstr ""
-"Kopiatu aukeratutakoa ANSI eskape-sekuentzia gisa behin-behineko fitxategi batera eta itsatsi "
-"bidea fitxategian."
+"Kopiatu aukeratutakoa ANSI eskape-sekuentzia gisa behin-behineko fitxategi "
+"batera eta itsatsi bidea fitxategian."
 
 #: src/input/command.zig:414
 msgid "Copy Selection as ANSI Sequences to Temporary File and Open"
-msgstr "Kopiatu aukeratutakoa ANSI sekuentzia gisa behin-behineko fitxategi batera eta ireki"
+msgstr ""
+"Kopiatu aukeratutakoa ANSI sekuentzia gisa behin-behineko fitxategi batera "
+"eta ireki"
 
 #: src/input/command.zig:415
 msgid ""
 "Copy the selection contents as ANSI escape sequences to a temporary file and "
 "open it."
 msgstr ""
-"Kopiatu hautapenaren edukiak ANSI eskape-sekuentzia gisa behin-behineko fitxategi batera eta ireki."
-"open it."
+"Kopiatu hautapenaren edukiak ANSI eskape-sekuentzia gisa behin-behineko "
+"fitxategi batera eta ireki.open it."
 
 #: src/input/command.zig:422
 msgid "Open a new window."
@@ -1000,134 +1031,158 @@ msgstr "Birgarkatu konfigurazioa"
 msgid "Reload the config file."
 msgstr "Birkargatu konfigurazio-fitxategia."
 
-#: src/input/command.zig:606
+#: src/input/command.zig:607
+msgid "Switch to Dark Appearance"
+msgstr ""
+
+#: src/input/command.zig:608
+msgid "Use a dark application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Switch to Light Appearance"
+msgstr ""
+
+#: src/input/command.zig:613
+msgid "Use a light application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Switch to System Appearance"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Use the system application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:624
 msgid "Close Terminal"
 msgstr "Itxi terminala"
 
-#: src/input/command.zig:607
+#: src/input/command.zig:625
 msgid "Close the current terminal."
 msgstr "Itxi uneko terminala."
 
-#: src/input/command.zig:614
+#: src/input/command.zig:632
 msgid "Close the current tab."
 msgstr "Itxi uneko fitxa."
 
-#: src/input/command.zig:618
+#: src/input/command.zig:636
 msgid "Close Other Tabs"
 msgstr "Itxi beste fitxak"
 
-#: src/input/command.zig:619
+#: src/input/command.zig:637
 msgid "Close all tabs in this window except the current one."
 msgstr "Itxi fitxa guztian unekoa ezik."
 
-#: src/input/command.zig:623
+#: src/input/command.zig:641
 msgid "Close Tabs to the Right"
 msgstr "Itxi eskuineko fitxak"
 
-#: src/input/command.zig:624
+#: src/input/command.zig:642
 msgid "Close all tabs to the right of the current one."
 msgstr "Itxi unekoaren eskuinean dauden fitxa guztiak."
 
-#: src/input/command.zig:631
+#: src/input/command.zig:649
 msgid "Close the current window."
 msgstr "Itxi uneko leihoa"
 
-#: src/input/command.zig:636
+#: src/input/command.zig:654
 msgid "Close All Windows"
 msgstr "Itxi leiho guztiak"
 
-#: src/input/command.zig:637
+#: src/input/command.zig:655
 msgid "Close all windows."
 msgstr "Itxi leiho guztiak."
 
-#: src/input/command.zig:642
+#: src/input/command.zig:660
 msgid "Toggle Maximize"
 msgstr "Aldatu maximizatzea"
 
-#: src/input/command.zig:643
+#: src/input/command.zig:661
 msgid "Toggle the maximized state of the current window."
 msgstr "Aldatu uneko leihoa maximizatzeko egoerara."
 
-#: src/input/command.zig:648
+#: src/input/command.zig:666
 msgid "Toggle Fullscreen"
 msgstr "Aldatu pantaila osoa"
 
-#: src/input/command.zig:649
+#: src/input/command.zig:667
 msgid "Toggle the fullscreen state of the current window."
 msgstr "Aldatu pantaila osoko egoerara."
 
-#: src/input/command.zig:654
+#: src/input/command.zig:672
 msgid "Toggle Window Decorations"
 msgstr "Aldatu leihoaren dekorazioak"
 
-#: src/input/command.zig:655
+#: src/input/command.zig:673
 msgid "Toggle the window decorations."
 msgstr "Aldatu leihoaren dekorazioak."
 
-#: src/input/command.zig:660
+#: src/input/command.zig:678
 msgid "Toggle Float on Top"
 msgstr "Aldatu gainean flotatzea"
 
-#: src/input/command.zig:661
+#: src/input/command.zig:679
 msgid "Toggle the float on top state of the current window."
 msgstr "Aldatu uneko leihoa gainean flotatzeko egoerara."
 
-#: src/input/command.zig:666
+#: src/input/command.zig:684
 msgid "Toggle Secure Input"
 msgstr "Aldatu sarrera segurua"
 
-#: src/input/command.zig:667
+#: src/input/command.zig:685
 msgid "Toggle secure input mode."
 msgstr "Aldatu sarrera seguruko modua."
 
-#: src/input/command.zig:672
+#: src/input/command.zig:690
 msgid "Toggle Mouse Reporting"
 msgstr "Aldatu sagua informatzea"
 
-#: src/input/command.zig:673
+#: src/input/command.zig:691
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr "Aldatu saguaren mugimenduak terminaleko aplikazioei informatzeko modua"
 
-#: src/input/command.zig:678
+#: src/input/command.zig:696
 msgid "Toggle Background Opacity"
 msgstr "Aldatu atzeko-planoaren opakotasuna"
 
-#: src/input/command.zig:679
+#: src/input/command.zig:697
 msgid "Toggle the background opacity of a window that started transparent."
 msgstr "Aldatu atzeko planoaren opakotasuna, garden hasi den leiho batentzat."
 
-#: src/input/command.zig:684
+#: src/input/command.zig:702
 msgid "Check for Updates"
 msgstr "Bilatu eguneraketak"
 
-#: src/input/command.zig:685
+#: src/input/command.zig:703
 msgid "Check for updates to the application."
 msgstr "Bilatu aplikazioaren eguneraketak"
 
-#: src/input/command.zig:690
+#: src/input/command.zig:708
 msgid "Undo"
 msgstr "Desegin"
 
-#: src/input/command.zig:691
+#: src/input/command.zig:709
 msgid "Undo the last action."
 msgstr "Desegin azken eragiketa."
 
-#: src/input/command.zig:696
+#: src/input/command.zig:714
 msgid "Redo"
 msgstr "Berregin"
 
-#: src/input/command.zig:697
+#: src/input/command.zig:715
 msgid "Redo the last undone action."
 msgstr "Berregin desegindako azken eragiketa."
 
-#: src/input/command.zig:703
+#: src/input/command.zig:721
 msgid "Quit the application."
 msgstr "Itxi aplikazioa"
 
-#: src/input/command.zig:708
+#: src/input/command.zig:726
 msgid "Ghostty"
 msgstr "Ghostty"
 
-#: src/input/command.zig:709
+#: src/input/command.zig:727
 msgid "Put a little Ghostty in your terminal."
 msgstr "Jarri Ghostty txiki bat zure terminalean."

--- a/po/fr.po
+++ b/po/fr.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-09-10 10:50-0400\n"
 "PO-Revision-Date: 2026-08-22 11:30+0200\n"
 "Last-Translator: flou <flou@proton.me>\n"
 "Language-Team: French <traduc@traduc.org>\n"
@@ -51,7 +51,7 @@ msgstr "Recharger la configuration pour afficher à nouveau ce message"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2263
+#: src/apprt/gtk/class/application.zig:2296
 msgid "Cancel"
 msgstr "Annuler"
 
@@ -70,8 +70,9 @@ msgid ""
 "One or more configuration errors were found. Please review the errors below, "
 "and either reload your configuration or ignore these errors."
 msgstr ""
-"Une ou plusieurs erreurs de configuration ont été détectées. Veuillez examiner "
-"les erreurs ci-dessous, puis recharger votre configuration ou ignorer ces erreurs."
+"Une ou plusieurs erreurs de configuration ont été détectées. Veuillez "
+"examiner les erreurs ci-dessous, puis recharger votre configuration ou "
+"ignorer ces erreurs."
 
 #: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:12
 msgid "Ignore"
@@ -196,7 +197,7 @@ msgid "New Tab"
 msgstr "Nouvel onglet"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:242
-#: src/input/command.zig:613
+#: src/input/command.zig:631
 msgid "Close Tab"
 msgstr "Fermer l'onglet"
 
@@ -214,7 +215,7 @@ msgid "New Window"
 msgstr "Nouvelle fenêtre"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:416 src/apprt/gtk/ui/1.5/window.blp:225
-#: src/input/command.zig:630
+#: src/input/command.zig:648
 msgid "Close Window"
 msgstr "Fermer la fenêtre"
 
@@ -258,11 +259,11 @@ msgstr "Palette de commandes"
 msgid "Terminal Inspector"
 msgstr "Inspecteur de terminal"
 
-#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1991
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1997
 msgid "About Ghostty"
 msgstr "À propos de Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:702
+#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:720
 msgid "Quit"
 msgstr "Quitter"
 
@@ -270,27 +271,27 @@ msgstr "Quitter"
 msgid "Execute a command…"
 msgstr "Exécuter une commande…"
 
-#: src/apprt/gtk/class/application.zig:1767
+#: src/apprt/gtk/class/application.zig:1779
 msgid "The keybind was revoked by the system."
 msgstr "Le raccourci clavier a été révoqué par le système."
 
-#: src/apprt/gtk/class/application.zig:1769
+#: src/apprt/gtk/class/application.zig:1781
 msgid "The keybind was denied by the system."
 msgstr "Le raccourci clavier a été refusé par le système."
 
-#: src/apprt/gtk/class/application.zig:1780
+#: src/apprt/gtk/class/application.zig:1792
 msgid "Global keybind unavailable"
 msgstr "Raccourci clavier global indisponible"
 
-#: src/apprt/gtk/class/application.zig:2259
+#: src/apprt/gtk/class/application.zig:2292
 msgid "Export Terminal IO Events"
 msgstr "Exporter les événements d'E/S du terminal"
 
-#: src/apprt/gtk/class/application.zig:2262
+#: src/apprt/gtk/class/application.zig:2295
 msgid "Export"
 msgstr "Exporter"
 
-#: src/apprt/gtk/class/application.zig:2783
+#: src/apprt/gtk/class/application.zig:2827
 msgid "Editing configuration file"
 msgstr "Modification du fichier de configuration"
 
@@ -354,16 +355,16 @@ msgstr "Toutes les sessions de cette fenêtre vont être arrêtées."
 msgid "The currently running process in this split will be terminated."
 msgstr "Le processus en cours dans ce panneau va être arrêté."
 
-#: src/apprt/gtk/class/surface.zig:1181
+#: src/apprt/gtk/class/surface.zig:1194
 msgid "Command Finished"
 msgstr "Commande terminée"
 
-#: src/apprt/gtk/class/surface.zig:1182
+#: src/apprt/gtk/class/surface.zig:1195
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Commande exécutée avec succès"
 
-#: src/apprt/gtk/class/surface.zig:1183
+#: src/apprt/gtk/class/surface.zig:1196
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Échec de la commande"
@@ -380,19 +381,19 @@ msgstr "Changer le titre de l'onglet"
 msgid "Change Window Title"
 msgstr "Changer le titre de la fenêtre"
 
-#: src/apprt/gtk/class/window.zig:1153
+#: src/apprt/gtk/class/window.zig:1159
 msgid "Reloaded the configuration"
 msgstr "Configuration rechargée"
 
-#: src/apprt/gtk/class/window.zig:1830
+#: src/apprt/gtk/class/window.zig:1836
 msgid "Copied to clipboard"
 msgstr "Copié dans le presse-papiers"
 
-#: src/apprt/gtk/class/window.zig:1832
+#: src/apprt/gtk/class/window.zig:1838
 msgid "Cleared clipboard"
 msgstr "Presse-papiers vidé"
 
-#: src/apprt/gtk/class/window.zig:1972
+#: src/apprt/gtk/class/window.zig:1978
 msgid "Ghostty Developers"
 msgstr "Les développeurs de Ghostty"
 
@@ -412,7 +413,8 @@ msgstr "Copier dans le presse-papiers"
 msgid ""
 "Copy the selected text to the clipboard in both plain and styled formats."
 msgstr ""
-"Copier le texte sélectionné dans le presse-papiers aux formats brut et mis en forme."
+"Copier le texte sélectionné dans le presse-papiers aux formats brut et mis "
+"en forme."
 
 #: src/input/command.zig:159
 msgid "Copy Selection as Plain Text to Clipboard"
@@ -428,7 +430,9 @@ msgstr "Copier la sélection en séquences ANSI dans le presse-papiers"
 
 #: src/input/command.zig:164
 msgid "Copy the selected text as ANSI escape sequences to the clipboard."
-msgstr "Copier le texte sélectionné en séquences d'échappement ANSI dans le presse-papiers."
+msgstr ""
+"Copier le texte sélectionné en séquences d'échappement ANSI dans le presse-"
+"papiers."
 
 #: src/input/command.zig:167
 msgid "Copy Selection as HTML to Clipboard"
@@ -496,7 +500,9 @@ msgstr "Terminer la recherche"
 
 #: src/input/command.zig:210
 msgid "End the current search if any and hide any GUI elements."
-msgstr "Terminer la recherche en cours s'il y en a une et masquer les éléments d'interface."
+msgstr ""
+"Terminer la recherche en cours s'il y en a une et masquer les éléments "
+"d'interface."
 
 #: src/input/command.zig:215
 msgid "Next Search Result"
@@ -655,11 +661,14 @@ msgstr "Copier l'écran en HTML dans un fichier temporaire et l'ouvrir"
 
 #: src/input/command.zig:322
 msgid "Copy the screen contents as HTML to a temporary file and open it."
-msgstr "Copier le contenu de l'écran en HTML dans un fichier temporaire et l'ouvrir."
+msgstr ""
+"Copier le contenu de l'écran en HTML dans un fichier temporaire et l'ouvrir."
 
 #: src/input/command.zig:330
 msgid "Copy Screen as ANSI Sequences to Temporary File and Copy Path"
-msgstr "Copier l'écran en séquences ANSI dans un fichier temporaire et copier le chemin"
+msgstr ""
+"Copier l'écran en séquences ANSI dans un fichier temporaire et copier le "
+"chemin"
 
 #: src/input/command.zig:331
 msgid ""
@@ -671,7 +680,9 @@ msgstr ""
 
 #: src/input/command.zig:338
 msgid "Copy Screen as ANSI Sequences to Temporary File and Paste Path"
-msgstr "Copier l'écran en séquences ANSI dans un fichier temporaire et coller le chemin"
+msgstr ""
+"Copier l'écran en séquences ANSI dans un fichier temporaire et coller le "
+"chemin"
 
 #: src/input/command.zig:339
 msgid ""
@@ -683,7 +694,8 @@ msgstr ""
 
 #: src/input/command.zig:346
 msgid "Copy Screen as ANSI Sequences to Temporary File and Open"
-msgstr "Copier l'écran en séquences ANSI dans un fichier temporaire et l'ouvrir"
+msgstr ""
+"Copier l'écran en séquences ANSI dans un fichier temporaire et l'ouvrir"
 
 #: src/input/command.zig:347
 msgid ""
@@ -723,11 +735,13 @@ msgstr "Copier la sélection dans un fichier temporaire et l'ouvrir"
 
 #: src/input/command.zig:365
 msgid "Copy the selection contents to a temporary file and open it."
-msgstr "Copier le contenu de la sélection dans un fichier temporaire et l'ouvrir."
+msgstr ""
+"Copier le contenu de la sélection dans un fichier temporaire et l'ouvrir."
 
 #: src/input/command.zig:373
 msgid "Copy Selection as HTML to Temporary File and Copy Path"
-msgstr "Copier la sélection en HTML dans un fichier temporaire et copier le chemin"
+msgstr ""
+"Copier la sélection en HTML dans un fichier temporaire et copier le chemin"
 
 #: src/input/command.zig:374
 msgid ""
@@ -739,7 +753,8 @@ msgstr ""
 
 #: src/input/command.zig:381
 msgid "Copy Selection as HTML to Temporary File and Paste Path"
-msgstr "Copier la sélection en HTML dans un fichier temporaire et coller le chemin"
+msgstr ""
+"Copier la sélection en HTML dans un fichier temporaire et coller le chemin"
 
 #: src/input/command.zig:382
 msgid ""
@@ -755,11 +770,15 @@ msgstr "Copier la sélection en HTML dans un fichier temporaire et l'ouvrir"
 
 #: src/input/command.zig:390
 msgid "Copy the selection contents as HTML to a temporary file and open it."
-msgstr "Copier le contenu de la sélection en HTML dans un fichier temporaire et l'ouvrir."
+msgstr ""
+"Copier le contenu de la sélection en HTML dans un fichier temporaire et "
+"l'ouvrir."
 
 #: src/input/command.zig:398
 msgid "Copy Selection as ANSI Sequences to Temporary File and Copy Path"
-msgstr "Copier la sélection en séquences ANSI dans un fichier temporaire et copier le chemin"
+msgstr ""
+"Copier la sélection en séquences ANSI dans un fichier temporaire et copier "
+"le chemin"
 
 #: src/input/command.zig:399
 msgid ""
@@ -771,7 +790,9 @@ msgstr ""
 
 #: src/input/command.zig:406
 msgid "Copy Selection as ANSI Sequences to Temporary File and Paste Path"
-msgstr "Copier la sélection en séquences ANSI dans un fichier temporaire et coller le chemin"
+msgstr ""
+"Copier la sélection en séquences ANSI dans un fichier temporaire et coller "
+"le chemin"
 
 #: src/input/command.zig:407
 msgid ""
@@ -783,7 +804,8 @@ msgstr ""
 
 #: src/input/command.zig:414
 msgid "Copy Selection as ANSI Sequences to Temporary File and Open"
-msgstr "Copier la sélection en séquences ANSI dans un fichier temporaire et l'ouvrir"
+msgstr ""
+"Copier la sélection en séquences ANSI dans un fichier temporaire et l'ouvrir"
 
 #: src/input/command.zig:415
 msgid ""
@@ -987,7 +1009,8 @@ msgstr "Ouvrir la configuration avec l'éditeur du système"
 
 #: src/input/command.zig:589
 msgid "Open the config file with the OS's default editor."
-msgstr "Ouvrir le fichier de configuration avec l'éditeur par défaut du système."
+msgstr ""
+"Ouvrir le fichier de configuration avec l'éditeur par défaut du système."
 
 #: src/input/command.zig:593
 msgid "Open Config in New Terminal Window"
@@ -995,7 +1018,9 @@ msgstr "Ouvrir la configuration dans une nouvelle fenêtre de terminal"
 
 #: src/input/command.zig:594
 msgid "Open the config file in a new window using $EDITOR or $VISUAL."
-msgstr "Ouvrir le fichier de configuration dans une nouvelle fenêtre avec $EDITOR ou $VISUAL."
+msgstr ""
+"Ouvrir le fichier de configuration dans une nouvelle fenêtre avec $EDITOR ou "
+"$VISUAL."
 
 #: src/input/command.zig:600
 msgid "Reload Config"
@@ -1005,134 +1030,163 @@ msgstr "Recharger la configuration"
 msgid "Reload the config file."
 msgstr "Recharger le fichier de configuration."
 
-#: src/input/command.zig:606
+#: src/input/command.zig:607
+msgid "Switch to Dark Appearance"
+msgstr ""
+
+#: src/input/command.zig:608
+msgid "Use a dark application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Switch to Light Appearance"
+msgstr ""
+
+#: src/input/command.zig:613
+msgid "Use a light application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Switch to System Appearance"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Use the system application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:624
 msgid "Close Terminal"
 msgstr "Fermer le terminal"
 
-#: src/input/command.zig:607
+#: src/input/command.zig:625
 msgid "Close the current terminal."
 msgstr "Fermer le terminal actuel."
 
-#: src/input/command.zig:614
+#: src/input/command.zig:632
 msgid "Close the current tab."
 msgstr "Fermer l'onglet actuel."
 
-#: src/input/command.zig:618
+#: src/input/command.zig:636
 msgid "Close Other Tabs"
 msgstr "Fermer les autres onglets"
 
-#: src/input/command.zig:619
+#: src/input/command.zig:637
 msgid "Close all tabs in this window except the current one."
 msgstr "Fermer tous les onglets de cette fenêtre sauf l'onglet actuel."
 
-#: src/input/command.zig:623
+#: src/input/command.zig:641
 msgid "Close Tabs to the Right"
 msgstr "Fermer les onglets à droite"
 
-#: src/input/command.zig:624
+#: src/input/command.zig:642
 msgid "Close all tabs to the right of the current one."
 msgstr "Fermer tous les onglets à droite de l'onglet actuel."
 
-#: src/input/command.zig:631
+#: src/input/command.zig:649
 msgid "Close the current window."
 msgstr "Fermer la fenêtre actuelle."
 
-#: src/input/command.zig:636
+#: src/input/command.zig:654
 msgid "Close All Windows"
 msgstr "Fermer toutes les fenêtres"
 
-#: src/input/command.zig:637
+#: src/input/command.zig:655
 msgid "Close all windows."
 msgstr "Fermer toutes les fenêtres."
 
-#: src/input/command.zig:642
+#: src/input/command.zig:660
 msgid "Toggle Maximize"
 msgstr "Activer/désactiver l'agrandissement"
 
-#: src/input/command.zig:643
+#: src/input/command.zig:661
 msgid "Toggle the maximized state of the current window."
 msgstr "Activer ou désactiver l'état agrandi de la fenêtre actuelle."
 
-#: src/input/command.zig:648
+#: src/input/command.zig:666
 msgid "Toggle Fullscreen"
 msgstr "Activer/désactiver le plein écran"
 
-#: src/input/command.zig:649
+#: src/input/command.zig:667
 msgid "Toggle the fullscreen state of the current window."
 msgstr "Activer ou désactiver le plein écran de la fenêtre actuelle."
 
-#: src/input/command.zig:654
+#: src/input/command.zig:672
 msgid "Toggle Window Decorations"
 msgstr "Activer/désactiver les décorations de fenêtre"
 
-#: src/input/command.zig:655
+#: src/input/command.zig:673
 msgid "Toggle the window decorations."
 msgstr "Activer ou désactiver les décorations de la fenêtre."
 
-#: src/input/command.zig:660
+#: src/input/command.zig:678
 msgid "Toggle Float on Top"
 msgstr "Activer/désactiver le maintien au premier plan"
 
-#: src/input/command.zig:661
+#: src/input/command.zig:679
 msgid "Toggle the float on top state of the current window."
-msgstr "Activer ou désactiver le maintien de la fenêtre actuelle au premier plan."
+msgstr ""
+"Activer ou désactiver le maintien de la fenêtre actuelle au premier plan."
 
-#: src/input/command.zig:666
+#: src/input/command.zig:684
 msgid "Toggle Secure Input"
 msgstr "Activer/désactiver la saisie sécurisée"
 
-#: src/input/command.zig:667
+#: src/input/command.zig:685
 msgid "Toggle secure input mode."
 msgstr "Activer ou désactiver le mode de saisie sécurisée."
 
-#: src/input/command.zig:672
+#: src/input/command.zig:690
 msgid "Toggle Mouse Reporting"
 msgstr "Activer/désactiver le rapport de souris"
 
-#: src/input/command.zig:673
+#: src/input/command.zig:691
 msgid "Toggle whether mouse events are reported to terminal applications."
-msgstr "Activer ou désactiver le signalement des événements de souris aux applications du terminal."
+msgstr ""
+"Activer ou désactiver le signalement des événements de souris aux "
+"applications du terminal."
 
-#: src/input/command.zig:678
+#: src/input/command.zig:696
 msgid "Toggle Background Opacity"
 msgstr "Activer/désactiver l'opacité de l'arrière-plan"
 
-#: src/input/command.zig:679
+#: src/input/command.zig:697
 msgid "Toggle the background opacity of a window that started transparent."
-msgstr "Activer ou désactiver l'opacité de l'arrière-plan d'une fenêtre qui a démarré transparente."
+msgstr ""
+"Activer ou désactiver l'opacité de l'arrière-plan d'une fenêtre qui a "
+"démarré transparente."
 
-#: src/input/command.zig:684
+#: src/input/command.zig:702
 msgid "Check for Updates"
 msgstr "Rechercher des mises à jour"
 
-#: src/input/command.zig:685
+#: src/input/command.zig:703
 msgid "Check for updates to the application."
 msgstr "Rechercher des mises à jour pour l'application."
 
-#: src/input/command.zig:690
+#: src/input/command.zig:708
 msgid "Undo"
 msgstr "Annuler"
 
-#: src/input/command.zig:691
+#: src/input/command.zig:709
 msgid "Undo the last action."
 msgstr "Annuler la dernière action."
 
-#: src/input/command.zig:696
+#: src/input/command.zig:714
 msgid "Redo"
 msgstr "Rétablir"
 
-#: src/input/command.zig:697
+#: src/input/command.zig:715
 msgid "Redo the last undone action."
 msgstr "Rétablir la dernière action annulée."
 
-#: src/input/command.zig:703
+#: src/input/command.zig:721
 msgid "Quit the application."
 msgstr "Quitter l'application."
 
-#: src/input/command.zig:708
+#: src/input/command.zig:726
 msgid "Ghostty"
 msgstr "Ghostty"
 
-#: src/input/command.zig:709
+#: src/input/command.zig:727
 msgid "Put a little Ghostty in your terminal."
 msgstr "Mettre un petit Ghostty dans votre terminal."

--- a/po/ga.po
+++ b/po/ga.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-09-10 10:50-0400\n"
 "PO-Revision-Date: 2026-02-18 14:32+0000\n"
 "Last-Translator: Aindriú Mac Giolla Eoin <aindriu80@yahoo.com>\n"
 "Language-Team: Irish <gaeilge-gnulinux@lists.sourceforge.net>\n"
@@ -48,7 +48,7 @@ msgstr "Athlódáil an chumraíocht chun an teachtaireacht seo a thaispeáint ar
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2263
+#: src/apprt/gtk/class/application.zig:2296
 msgid "Cancel"
 msgstr "Cealaigh"
 
@@ -192,7 +192,7 @@ msgid "New Tab"
 msgstr "Táb nua"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:242
-#: src/input/command.zig:613
+#: src/input/command.zig:631
 msgid "Close Tab"
 msgstr "Dún táb"
 
@@ -210,7 +210,7 @@ msgid "New Window"
 msgstr "Fuinneog nua"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:416 src/apprt/gtk/ui/1.5/window.blp:225
-#: src/input/command.zig:630
+#: src/input/command.zig:648
 msgid "Close Window"
 msgstr "Dún fuinneog"
 
@@ -254,11 +254,11 @@ msgstr "Pailéad ordaithe"
 msgid "Terminal Inspector"
 msgstr "Cigire teirminéil"
 
-#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1991
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1997
 msgid "About Ghostty"
 msgstr "Maidir le Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:702
+#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:720
 msgid "Quit"
 msgstr "Scoir"
 
@@ -266,27 +266,27 @@ msgstr "Scoir"
 msgid "Execute a command…"
 msgstr "Rith ordú…"
 
-#: src/apprt/gtk/class/application.zig:1767
+#: src/apprt/gtk/class/application.zig:1779
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1769
+#: src/apprt/gtk/class/application.zig:1781
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1780
+#: src/apprt/gtk/class/application.zig:1792
 msgid "Global keybind unavailable"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2259
+#: src/apprt/gtk/class/application.zig:2292
 msgid "Export Terminal IO Events"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2262
+#: src/apprt/gtk/class/application.zig:2295
 msgid "Export"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2783
+#: src/apprt/gtk/class/application.zig:2827
 msgid "Editing configuration file"
 msgstr ""
 
@@ -351,16 +351,16 @@ msgid "The currently running process in this split will be terminated."
 msgstr ""
 "Cuirfear deireadh leis an bpróiseas atá ar siúl faoi láthair sa scoilt seo."
 
-#: src/apprt/gtk/class/surface.zig:1181
+#: src/apprt/gtk/class/surface.zig:1194
 msgid "Command Finished"
 msgstr "Ordú críochnaithe"
 
-#: src/apprt/gtk/class/surface.zig:1182
+#: src/apprt/gtk/class/surface.zig:1195
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "D’éirigh leis an ordú"
 
-#: src/apprt/gtk/class/surface.zig:1183
+#: src/apprt/gtk/class/surface.zig:1196
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Theip ar an ordú"
@@ -377,19 +377,19 @@ msgstr "Athraigh teideal an táb"
 msgid "Change Window Title"
 msgstr ""
 
-#: src/apprt/gtk/class/window.zig:1153
+#: src/apprt/gtk/class/window.zig:1159
 msgid "Reloaded the configuration"
 msgstr "Tá an chumraíocht athlódáilte"
 
-#: src/apprt/gtk/class/window.zig:1830
+#: src/apprt/gtk/class/window.zig:1836
 msgid "Copied to clipboard"
 msgstr "Cóipeáilte chuig an ghearrthaisce"
 
-#: src/apprt/gtk/class/window.zig:1832
+#: src/apprt/gtk/class/window.zig:1838
 msgid "Cleared clipboard"
 msgstr "Gearrthaisce glanta"
 
-#: src/apprt/gtk/class/window.zig:1972
+#: src/apprt/gtk/class/window.zig:1978
 msgid "Ghostty Developers"
 msgstr "Forbróirí Ghostty"
 
@@ -971,134 +971,158 @@ msgstr ""
 msgid "Reload the config file."
 msgstr ""
 
-#: src/input/command.zig:606
-msgid "Close Terminal"
-msgstr ""
-
 #: src/input/command.zig:607
-msgid "Close the current terminal."
+msgid "Switch to Dark Appearance"
 msgstr ""
 
-#: src/input/command.zig:614
-msgid "Close the current tab."
+#: src/input/command.zig:608
+msgid "Use a dark application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Switch to Light Appearance"
+msgstr ""
+
+#: src/input/command.zig:613
+msgid "Use a light application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Switch to System Appearance"
 msgstr ""
 
 #: src/input/command.zig:618
-msgid "Close Other Tabs"
-msgstr ""
-
-#: src/input/command.zig:619
-msgid "Close all tabs in this window except the current one."
-msgstr ""
-
-#: src/input/command.zig:623
-msgid "Close Tabs to the Right"
+msgid "Use the system application appearance for this session."
 msgstr ""
 
 #: src/input/command.zig:624
-msgid "Close all tabs to the right of the current one."
+msgid "Close Terminal"
 msgstr ""
 
-#: src/input/command.zig:631
-msgid "Close the current window."
+#: src/input/command.zig:625
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:632
+msgid "Close the current tab."
 msgstr ""
 
 #: src/input/command.zig:636
-msgid "Close All Windows"
+msgid "Close Other Tabs"
 msgstr ""
 
 #: src/input/command.zig:637
-msgid "Close all windows."
+msgid "Close all tabs in this window except the current one."
+msgstr ""
+
+#: src/input/command.zig:641
+msgid "Close Tabs to the Right"
 msgstr ""
 
 #: src/input/command.zig:642
-msgid "Toggle Maximize"
-msgstr ""
-
-#: src/input/command.zig:643
-msgid "Toggle the maximized state of the current window."
-msgstr ""
-
-#: src/input/command.zig:648
-msgid "Toggle Fullscreen"
+msgid "Close all tabs to the right of the current one."
 msgstr ""
 
 #: src/input/command.zig:649
-msgid "Toggle the fullscreen state of the current window."
+msgid "Close the current window."
 msgstr ""
 
 #: src/input/command.zig:654
-msgid "Toggle Window Decorations"
+msgid "Close All Windows"
 msgstr ""
 
 #: src/input/command.zig:655
-msgid "Toggle the window decorations."
+msgid "Close all windows."
 msgstr ""
 
 #: src/input/command.zig:660
-msgid "Toggle Float on Top"
+msgid "Toggle Maximize"
 msgstr ""
 
 #: src/input/command.zig:661
-msgid "Toggle the float on top state of the current window."
+msgid "Toggle the maximized state of the current window."
 msgstr ""
 
 #: src/input/command.zig:666
-msgid "Toggle Secure Input"
+msgid "Toggle Fullscreen"
 msgstr ""
 
 #: src/input/command.zig:667
-msgid "Toggle secure input mode."
+msgid "Toggle the fullscreen state of the current window."
 msgstr ""
 
 #: src/input/command.zig:672
-msgid "Toggle Mouse Reporting"
+msgid "Toggle Window Decorations"
 msgstr ""
 
 #: src/input/command.zig:673
-msgid "Toggle whether mouse events are reported to terminal applications."
+msgid "Toggle the window decorations."
 msgstr ""
 
 #: src/input/command.zig:678
-msgid "Toggle Background Opacity"
+msgid "Toggle Float on Top"
 msgstr ""
 
 #: src/input/command.zig:679
-msgid "Toggle the background opacity of a window that started transparent."
+msgid "Toggle the float on top state of the current window."
 msgstr ""
 
 #: src/input/command.zig:684
-msgid "Check for Updates"
+msgid "Toggle Secure Input"
 msgstr ""
 
 #: src/input/command.zig:685
-msgid "Check for updates to the application."
+msgid "Toggle secure input mode."
 msgstr ""
 
 #: src/input/command.zig:690
-msgid "Undo"
+msgid "Toggle Mouse Reporting"
 msgstr ""
 
 #: src/input/command.zig:691
-msgid "Undo the last action."
+msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr ""
 
 #: src/input/command.zig:696
-msgid "Redo"
+msgid "Toggle Background Opacity"
 msgstr ""
 
 #: src/input/command.zig:697
-msgid "Redo the last undone action."
+msgid "Toggle the background opacity of a window that started transparent."
+msgstr ""
+
+#: src/input/command.zig:702
+msgid "Check for Updates"
 msgstr ""
 
 #: src/input/command.zig:703
-msgid "Quit the application."
+msgid "Check for updates to the application."
 msgstr ""
 
 #: src/input/command.zig:708
-msgid "Ghostty"
+msgid "Undo"
 msgstr ""
 
 #: src/input/command.zig:709
+msgid "Undo the last action."
+msgstr ""
+
+#: src/input/command.zig:714
+msgid "Redo"
+msgstr ""
+
+#: src/input/command.zig:715
+msgid "Redo the last undone action."
+msgstr ""
+
+#: src/input/command.zig:721
+msgid "Quit the application."
+msgstr ""
+
+#: src/input/command.zig:726
+msgid "Ghostty"
+msgstr ""
+
+#: src/input/command.zig:727
 msgid "Put a little Ghostty in your terminal."
 msgstr ""

--- a/po/he.po
+++ b/po/he.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-09-10 10:50-0400\n"
 "PO-Revision-Date: 2026-08-13 19:14+0300\n"
 "Last-Translator: Sl (Shahaf Levi), Sl's Repository Ltd "
 "<ghostty@slsrepo.com>\n"
@@ -51,7 +51,7 @@ msgstr "טען/י את ההגדרות מחדש כדי להציג את הבקשה
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2263
+#: src/apprt/gtk/class/application.zig:2296
 msgid "Cancel"
 msgstr "ביטול"
 
@@ -193,7 +193,7 @@ msgid "New Tab"
 msgstr "כרטיסייה חדשה"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:242
-#: src/input/command.zig:613
+#: src/input/command.zig:631
 msgid "Close Tab"
 msgstr "סגירת כרטיסייה"
 
@@ -211,7 +211,7 @@ msgid "New Window"
 msgstr "חלון חדש"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:416 src/apprt/gtk/ui/1.5/window.blp:225
-#: src/input/command.zig:630
+#: src/input/command.zig:648
 msgid "Close Window"
 msgstr "סגירת החלון"
 
@@ -255,11 +255,11 @@ msgstr "לוח פקודות"
 msgid "Terminal Inspector"
 msgstr "בודק המסוף"
 
-#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1991
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1997
 msgid "About Ghostty"
 msgstr "אודות Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:702
+#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:720
 msgid "Quit"
 msgstr "יציאה"
 
@@ -267,27 +267,27 @@ msgstr "יציאה"
 msgid "Execute a command…"
 msgstr "הרץ/י פקודה…"
 
-#: src/apprt/gtk/class/application.zig:1767
+#: src/apprt/gtk/class/application.zig:1779
 msgid "The keybind was revoked by the system."
 msgstr "קיצור המקשים נשלל על ידי המערכת."
 
-#: src/apprt/gtk/class/application.zig:1769
+#: src/apprt/gtk/class/application.zig:1781
 msgid "The keybind was denied by the system."
 msgstr "קיצור המקשים נדחה על ידי המערכת."
 
-#: src/apprt/gtk/class/application.zig:1780
+#: src/apprt/gtk/class/application.zig:1792
 msgid "Global keybind unavailable"
 msgstr "קיצור המקשים הגלובלי אינו זמין"
 
-#: src/apprt/gtk/class/application.zig:2259
+#: src/apprt/gtk/class/application.zig:2292
 msgid "Export Terminal IO Events"
 msgstr "ייצוא אירועי קלט/פלט של המסוף"
 
-#: src/apprt/gtk/class/application.zig:2262
+#: src/apprt/gtk/class/application.zig:2295
 msgid "Export"
 msgstr "ייצוא"
 
-#: src/apprt/gtk/class/application.zig:2783
+#: src/apprt/gtk/class/application.zig:2827
 msgid "Editing configuration file"
 msgstr "עריכת קובץ הגדרות"
 
@@ -348,16 +348,16 @@ msgstr "כל הפעלות המסוף בחלון זה יסתיימו."
 msgid "The currently running process in this split will be terminated."
 msgstr "התהליך שרץ כרגע בפיצול זה יסתיים."
 
-#: src/apprt/gtk/class/surface.zig:1181
+#: src/apprt/gtk/class/surface.zig:1194
 msgid "Command Finished"
 msgstr "הפקודה הסתיימה"
 
-#: src/apprt/gtk/class/surface.zig:1182
+#: src/apprt/gtk/class/surface.zig:1195
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "הפקודה הצליחה"
 
-#: src/apprt/gtk/class/surface.zig:1183
+#: src/apprt/gtk/class/surface.zig:1196
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "הפקודה נכשלה"
@@ -374,19 +374,19 @@ msgstr "שינוי כותרת הכרטיסייה"
 msgid "Change Window Title"
 msgstr "שינוי כותרת החלון"
 
-#: src/apprt/gtk/class/window.zig:1153
+#: src/apprt/gtk/class/window.zig:1159
 msgid "Reloaded the configuration"
 msgstr "ההגדרות נטענו מחדש"
 
-#: src/apprt/gtk/class/window.zig:1830
+#: src/apprt/gtk/class/window.zig:1836
 msgid "Copied to clipboard"
 msgstr "הועתק ללוח ההעתקה"
 
-#: src/apprt/gtk/class/window.zig:1832
+#: src/apprt/gtk/class/window.zig:1838
 msgid "Cleared clipboard"
 msgstr "לוח ההעתקה רוקן"
 
-#: src/apprt/gtk/class/window.zig:1972
+#: src/apprt/gtk/class/window.zig:1978
 msgid "Ghostty Developers"
 msgstr "המפתחים של Ghostty"
 
@@ -447,7 +447,9 @@ msgstr "העתקת כותרת המסוף ללוח ההעתקה"
 msgid ""
 "Copy the terminal title to the clipboard. If the terminal title is not set "
 "this has no effect."
-msgstr "העתק/י את כותרת המסוף ללוח ההעתקה. אם כותרת המסוף לא הוגדרה, לא תהיה לכך השפעה."
+msgstr ""
+"העתק/י את כותרת המסוף ללוח ההעתקה. אם כותרת המסוף לא הוגדרה, לא תהיה לכך "
+"השפעה."
 
 #: src/input/command.zig:185
 msgid "Paste from Clipboard"
@@ -593,7 +595,9 @@ msgstr "העתקת המסך לקובץ זמני והעתקת הנתיב לקוב
 msgid ""
 "Copy the screen contents to a temporary file and copy the path to the "
 "clipboard."
-msgstr "העתק/י את תוכן המסך לקובץ זמני ולאחר מכן העתק/י את הנתיב לקובץ הזמני אל לוח ההעתקה."
+msgstr ""
+"העתק/י את תוכן המסך לקובץ זמני ולאחר מכן העתק/י את הנתיב לקובץ הזמני אל לוח "
+"ההעתקה."
 
 #: src/input/command.zig:291
 msgid "Copy Screen to Temporary File and Paste Path"
@@ -602,7 +606,8 @@ msgstr "העתקת המסך לקובץ זמני והדבקת הנתיב לקוב
 #: src/input/command.zig:292
 msgid ""
 "Copy the screen contents to a temporary file and paste the path to the file."
-msgstr "העתק/י את תוכן המסך לקובץ זמני ולאחר מכן הדבק/י את הנתיב לקובץ אל המסוף."
+msgstr ""
+"העתק/י את תוכן המסך לקובץ זמני ולאחר מכן הדבק/י את הנתיב לקובץ אל המסוף."
 
 #: src/input/command.zig:296
 msgid "Copy Screen to Temporary File and Open"
@@ -620,7 +625,9 @@ msgstr "העתקת המסך כHTML לקובץ זמני והעתקת הנתיב �
 msgid ""
 "Copy the screen contents as HTML to a temporary file and copy the path to "
 "the clipboard."
-msgstr "העתק/י את תוכן המסך כHTML ולאחר מכן העתק/י את הנתיב לקובץ הזמני אל לוח ההעתקה."
+msgstr ""
+"העתק/י את תוכן המסך כHTML ולאחר מכן העתק/י את הנתיב לקובץ הזמני אל לוח "
+"ההעתקה."
 
 #: src/input/command.zig:313
 msgid "Copy Screen as HTML to Temporary File and Paste Path"
@@ -630,7 +637,9 @@ msgstr "העתקת המסך כHTML לקובץ זמני והדבקת הנתיב �
 msgid ""
 "Copy the screen contents as HTML to a temporary file and paste the path to "
 "the file."
-msgstr "העתק/י את תוכן המסך כHTML לקובץ זמני ולאחר מכן הדבק/י את הנתיב לקובץ אל המסוף."
+msgstr ""
+"העתק/י את תוכן המסך כHTML לקובץ זמני ולאחר מכן הדבק/י את הנתיב לקובץ אל "
+"המסוף."
 
 #: src/input/command.zig:321
 msgid "Copy Screen as HTML to Temporary File and Open"
@@ -648,7 +657,9 @@ msgstr "העתקת תוכן המסך כרצפי ANSI לקובץ זמני והע�
 msgid ""
 "Copy the screen contents as ANSI escape sequences to a temporary file and "
 "copy the path to the clipboard."
-msgstr "העתק/י את תוכן המסך כרצפי בריחה של ANSI ולאחר מכן העתק/י את הנתיב לקובץ הזמני אל לוח ההעתקה."
+msgstr ""
+"העתק/י את תוכן המסך כרצפי בריחה של ANSI ולאחר מכן העתק/י את הנתיב לקובץ "
+"הזמני אל לוח ההעתקה."
 
 #: src/input/command.zig:338
 msgid "Copy Screen as ANSI Sequences to Temporary File and Paste Path"
@@ -658,7 +669,9 @@ msgstr "העתקת תוכן המסך כרצפי ANSI לקובץ זמני והד�
 msgid ""
 "Copy the screen contents as ANSI escape sequences to a temporary file and "
 "paste the path to the file."
-msgstr "העתק/י את תוכן המסך כרצפי בריחה של ANSI לקובץ זמני ולאחר מכן הדבק/י את הנתיב לקובץ אל המסוף."
+msgstr ""
+"העתק/י את תוכן המסך כרצפי בריחה של ANSI לקובץ זמני ולאחר מכן הדבק/י את הנתיב "
+"לקובץ אל המסוף."
 
 #: src/input/command.zig:346
 msgid "Copy Screen as ANSI Sequences to Temporary File and Open"
@@ -668,7 +681,8 @@ msgstr "העתקת תוכן המסך כרצפי ANSI לקובץ זמני ופת�
 msgid ""
 "Copy the screen contents as ANSI escape sequences to a temporary file and "
 "open it."
-msgstr "העתק/י את תוכן המסך כרצפי בריחה של ANSI לקובץ זמני ולאחר מכן פתח/י את הקובץ."
+msgstr ""
+"העתק/י את תוכן המסך כרצפי בריחה של ANSI לקובץ זמני ולאחר מכן פתח/י את הקובץ."
 
 #: src/input/command.zig:354
 msgid "Copy Selection to Temporary File and Copy Path"
@@ -678,7 +692,8 @@ msgstr "העתק/י את הבחירה לקובץ זמני והעתקת הנתי�
 msgid ""
 "Copy the selection contents to a temporary file and copy the path to the "
 "clipboard."
-msgstr "העתק/י את תוכן הבחירה ולאחר מכן העתק/י את הנתיב לקובץ הזמני אל לוח ההעתקה."
+msgstr ""
+"העתק/י את תוכן הבחירה ולאחר מכן העתק/י את הנתיב לקובץ הזמני אל לוח ההעתקה."
 
 #: src/input/command.zig:359
 msgid "Copy Selection to Temporary File and Paste Path"
@@ -688,7 +703,8 @@ msgstr "העתקת הבחירה לקובץ זמני והדבקת הנתיב לק
 msgid ""
 "Copy the selection contents to a temporary file and paste the path to the "
 "file."
-msgstr "העתק/י את תוכן הבחירה לקובץ זמני ולאחר מכן הדבק/י את הנתיב לקובץ אל המסוף."
+msgstr ""
+"העתק/י את תוכן הבחירה לקובץ זמני ולאחר מכן הדבק/י את הנתיב לקובץ אל המסוף."
 
 #: src/input/command.zig:364
 msgid "Copy Selection to Temporary File and Open"
@@ -706,7 +722,9 @@ msgstr "העתקת הבחירה כHTML לקובץ זמני והעתקת הנתי
 msgid ""
 "Copy the selection contents as HTML to a temporary file and copy the path to "
 "the clipboard."
-msgstr "העתק/י את תוכן הבחירה כHTML ולאחר מכן העתק/י את הנתיב לקובץ הזמני אל לוח ההעתקה."
+msgstr ""
+"העתק/י את תוכן הבחירה כHTML ולאחר מכן העתק/י את הנתיב לקובץ הזמני אל לוח "
+"ההעתקה."
 
 #: src/input/command.zig:381
 msgid "Copy Selection as HTML to Temporary File and Paste Path"
@@ -716,7 +734,8 @@ msgstr "העתקת הבחירה כHTML לקובץ זמני והדבקת הנתי
 msgid ""
 "Copy the selection contents as HTML to a temporary file and paste the path "
 "to the file."
-msgstr "העתקת תוכן הבחירה כHTML לקובץ זמני ולאחר מכן הדבק/י את הנתיב לקובץ אל המסוף."
+msgstr ""
+"העתקת תוכן הבחירה כHTML לקובץ זמני ולאחר מכן הדבק/י את הנתיב לקובץ אל המסוף."
 
 #: src/input/command.zig:389
 msgid "Copy Selection as HTML to Temporary File and Open"
@@ -734,7 +753,9 @@ msgstr "העתקת הבחירה כרצפי ANSI לקובץ זמני והעתקת
 msgid ""
 "Copy the selection contents as ANSI escape sequences to a temporary file and "
 "copy the path to the clipboard."
-msgstr "העתק/י את תוכן הבחירה כרצפי בריחה של ANSI ולאחר מכן העתק/י את הנתיב לקובץ הזמני אל לוח ההעתקה."
+msgstr ""
+"העתק/י את תוכן הבחירה כרצפי בריחה של ANSI ולאחר מכן העתק/י את הנתיב לקובץ "
+"הזמני אל לוח ההעתקה."
 
 #: src/input/command.zig:406
 msgid "Copy Selection as ANSI Sequences to Temporary File and Paste Path"
@@ -744,7 +765,9 @@ msgstr "העתקת הבחירה כרצפי ANSI לקובץ זמני והדבקת
 msgid ""
 "Copy the selection contents as ANSI escape sequences to a temporary file and "
 "paste the path to the file."
-msgstr "העתק/י את תוכן הבחירה כרצפי בריחה של ANSI לקובץ זמני ולאחר מכן הדבק/י את הנתיב לקובץ אל המסוף."
+msgstr ""
+"העתק/י את תוכן הבחירה כרצפי בריחה של ANSI לקובץ זמני ולאחר מכן הדבק/י את "
+"הנתיב לקובץ אל המסוף."
 
 #: src/input/command.zig:414
 msgid "Copy Selection as ANSI Sequences to Temporary File and Open"
@@ -754,7 +777,9 @@ msgstr "העתקת הבחירה כרצפי ANSI לקובץ זמני ופתיחת
 msgid ""
 "Copy the selection contents as ANSI escape sequences to a temporary file and "
 "open it."
-msgstr "העתק/י את תוכן הבחירה כרצפי בריחה של ANSI לקובץ זמני ולאחר מכן פתח/י את הקובץ."
+msgstr ""
+"העתק/י את תוכן הבחירה כרצפי בריחה של ANSI לקובץ זמני ולאחר מכן פתח/י את "
+"הקובץ."
 
 #: src/input/command.zig:422
 msgid "Open a new window."
@@ -968,134 +993,158 @@ msgstr "טעינת ההגדרות מחדש"
 msgid "Reload the config file."
 msgstr "טען/י מחדש את קובץ ההגדרות."
 
-#: src/input/command.zig:606
+#: src/input/command.zig:607
+msgid "Switch to Dark Appearance"
+msgstr ""
+
+#: src/input/command.zig:608
+msgid "Use a dark application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Switch to Light Appearance"
+msgstr ""
+
+#: src/input/command.zig:613
+msgid "Use a light application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Switch to System Appearance"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Use the system application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:624
 msgid "Close Terminal"
 msgstr "סגירת המסוף"
 
-#: src/input/command.zig:607
+#: src/input/command.zig:625
 msgid "Close the current terminal."
 msgstr "סגור/י את המסוף הנוכחי."
 
-#: src/input/command.zig:614
+#: src/input/command.zig:632
 msgid "Close the current tab."
 msgstr "סגור/י את הכרטיסייה הנוכחית."
 
-#: src/input/command.zig:618
+#: src/input/command.zig:636
 msgid "Close Other Tabs"
 msgstr "סגור/י כרטיסיות אחרות"
 
-#: src/input/command.zig:619
+#: src/input/command.zig:637
 msgid "Close all tabs in this window except the current one."
 msgstr "סגור/י את כל הכרטיסיות בחלון זה למעט הנוכחית."
 
-#: src/input/command.zig:623
+#: src/input/command.zig:641
 msgid "Close Tabs to the Right"
 msgstr "סגירת כרטיסיות מימין"
 
-#: src/input/command.zig:624
+#: src/input/command.zig:642
 msgid "Close all tabs to the right of the current one."
 msgstr "סגור/י את כל הכרטיסיות שנמצאות מימין לכרטיסייה הנוכחית."
 
-#: src/input/command.zig:631
+#: src/input/command.zig:649
 msgid "Close the current window."
 msgstr "סגור/י את החלון הנוכחי."
 
-#: src/input/command.zig:636
+#: src/input/command.zig:654
 msgid "Close All Windows"
 msgstr "סגירת כל החלונות"
 
-#: src/input/command.zig:637
+#: src/input/command.zig:655
 msgid "Close all windows."
 msgstr "סגור/י את כל החלונות."
 
-#: src/input/command.zig:642
+#: src/input/command.zig:660
 msgid "Toggle Maximize"
 msgstr "שינוי הגדלה למקסימום"
 
-#: src/input/command.zig:643
+#: src/input/command.zig:661
 msgid "Toggle the maximized state of the current window."
 msgstr "שנה/י את מצב ההגדלה למקסימום של החלון הנוכחי."
 
-#: src/input/command.zig:648
+#: src/input/command.zig:666
 msgid "Toggle Fullscreen"
 msgstr "הפעלה/ביטול של מסך מלא"
 
-#: src/input/command.zig:649
+#: src/input/command.zig:667
 msgid "Toggle the fullscreen state of the current window."
 msgstr "שנה/י את מצב המסך המלא של החלון הנוכחי."
 
-#: src/input/command.zig:654
+#: src/input/command.zig:672
 msgid "Toggle Window Decorations"
 msgstr "הצגה/הסתרה של עיטורי חלון"
 
-#: src/input/command.zig:655
+#: src/input/command.zig:673
 msgid "Toggle the window decorations."
 msgstr "הצג/י או הסתר/י את עיטורי החלון."
 
-#: src/input/command.zig:660
+#: src/input/command.zig:678
 msgid "Toggle Float on Top"
 msgstr "שינוי של מצב ציפה מעל"
 
-#: src/input/command.zig:661
+#: src/input/command.zig:679
 msgid "Toggle the float on top state of the current window."
 msgstr "הפעל/י או בטל/י את מצב הציפה מעל של החלון הנוכחי."
 
-#: src/input/command.zig:666
+#: src/input/command.zig:684
 msgid "Toggle Secure Input"
 msgstr "שינוי של מצב קלט מאובטח"
 
-#: src/input/command.zig:667
+#: src/input/command.zig:685
 msgid "Toggle secure input mode."
 msgstr "הפעל/י או בטל/י את מצב הקלט המאובטח."
 
-#: src/input/command.zig:672
+#: src/input/command.zig:690
 msgid "Toggle Mouse Reporting"
 msgstr "שינוי של דיווחי העכבר"
 
-#: src/input/command.zig:673
+#: src/input/command.zig:691
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr "הפעל/י או בטל/י את הדיווח של אירועי עכבר לאפליקציות מסוף."
 
-#: src/input/command.zig:678
+#: src/input/command.zig:696
 msgid "Toggle Background Opacity"
 msgstr "שינוי של אטימות הרקע"
 
-#: src/input/command.zig:679
+#: src/input/command.zig:697
 msgid "Toggle the background opacity of a window that started transparent."
 msgstr "שנה/י את אטימות הרקע של חלון שהתחיל כשקוף."
 
-#: src/input/command.zig:684
+#: src/input/command.zig:702
 msgid "Check for Updates"
 msgstr "בדיקת עדכונים"
 
-#: src/input/command.zig:685
+#: src/input/command.zig:703
 msgid "Check for updates to the application."
 msgstr "בדוק/י אם קיימים עדכונים לאפליקציה."
 
-#: src/input/command.zig:690
+#: src/input/command.zig:708
 msgid "Undo"
 msgstr "ביטול פעולה"
 
-#: src/input/command.zig:691
+#: src/input/command.zig:709
 msgid "Undo the last action."
 msgstr "בטל/י את הפעולה האחרונה."
 
-#: src/input/command.zig:696
+#: src/input/command.zig:714
 msgid "Redo"
 msgstr "ביצוע פעולה שוב"
 
-#: src/input/command.zig:697
+#: src/input/command.zig:715
 msgid "Redo the last undone action."
 msgstr "בצע/י שוב את הפעולה האחרונה שבוטלה."
 
-#: src/input/command.zig:703
+#: src/input/command.zig:721
 msgid "Quit the application."
 msgstr "צא/י מהאפליקציה."
 
-#: src/input/command.zig:708
+#: src/input/command.zig:726
 msgid "Ghostty"
 msgstr "Ghostty"
 
-#: src/input/command.zig:709
+#: src/input/command.zig:727
 msgid "Put a little Ghostty in your terminal."
 msgstr "הכנס/י קצת Ghostty למסוף שלך."

--- a/po/hr.po
+++ b/po/hr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-09-10 10:50-0400\n"
 "PO-Revision-Date: 2026-08-25 21:00+0200\n"
 "Last-Translator: Filip7 <filipm7@protonmail.com>\n"
 "Language-Team: Croatian <lokalizacija@linux.hr>\n"
@@ -50,7 +50,7 @@ msgstr "Ponovno učitaj postavke za prikaz ovog upita"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2263
+#: src/apprt/gtk/class/application.zig:2296
 msgid "Cancel"
 msgstr "Otkaži"
 
@@ -193,7 +193,7 @@ msgid "New Tab"
 msgstr "Nova kartica"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:242
-#: src/input/command.zig:613
+#: src/input/command.zig:631
 msgid "Close Tab"
 msgstr "Zatvori karticu"
 
@@ -211,7 +211,7 @@ msgid "New Window"
 msgstr "Novi prozor"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:416 src/apprt/gtk/ui/1.5/window.blp:225
-#: src/input/command.zig:630
+#: src/input/command.zig:648
 msgid "Close Window"
 msgstr "Zatvori prozor"
 
@@ -255,11 +255,11 @@ msgstr "Paleta naredbi"
 msgid "Terminal Inspector"
 msgstr "Inspektor terminala"
 
-#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1991
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1997
 msgid "About Ghostty"
 msgstr "O Ghosttyju"
 
-#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:702
+#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:720
 msgid "Quit"
 msgstr "Izađi"
 
@@ -267,27 +267,27 @@ msgstr "Izađi"
 msgid "Execute a command…"
 msgstr "Izvrši naredbu…"
 
-#: src/apprt/gtk/class/application.zig:1767
+#: src/apprt/gtk/class/application.zig:1779
 msgid "The keybind was revoked by the system."
 msgstr "Sustav je opozvao tipkovni prečac."
 
-#: src/apprt/gtk/class/application.zig:1769
+#: src/apprt/gtk/class/application.zig:1781
 msgid "The keybind was denied by the system."
 msgstr "Sustav je odbio tipkovni prečac."
 
-#: src/apprt/gtk/class/application.zig:1780
+#: src/apprt/gtk/class/application.zig:1792
 msgid "Global keybind unavailable"
 msgstr "Globalni tipkovni prečac nije dostupan"
 
-#: src/apprt/gtk/class/application.zig:2259
+#: src/apprt/gtk/class/application.zig:2292
 msgid "Export Terminal IO Events"
 msgstr "Izvezi ulazno-izlazne događaje terminala"
 
-#: src/apprt/gtk/class/application.zig:2262
+#: src/apprt/gtk/class/application.zig:2295
 msgid "Export"
 msgstr "Izvezi"
 
-#: src/apprt/gtk/class/application.zig:2783
+#: src/apprt/gtk/class/application.zig:2827
 msgid "Editing configuration file"
 msgstr "Uređivanje datoteke postavki"
 
@@ -351,16 +351,16 @@ msgstr "Sve sesije terminala u ovom prozoru će biti prekinute."
 msgid "The currently running process in this split will be terminated."
 msgstr "Pokrenuti procesi u ovoj podjeli će biti prekinuti."
 
-#: src/apprt/gtk/class/surface.zig:1181
+#: src/apprt/gtk/class/surface.zig:1194
 msgid "Command Finished"
 msgstr "Naredba je završena"
 
-#: src/apprt/gtk/class/surface.zig:1182
+#: src/apprt/gtk/class/surface.zig:1195
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Naredba je uspjela"
 
-#: src/apprt/gtk/class/surface.zig:1183
+#: src/apprt/gtk/class/surface.zig:1196
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Naredba nije uspjela"
@@ -377,19 +377,19 @@ msgstr "Promijeni naslov kartice"
 msgid "Change Window Title"
 msgstr "Promijeni naslov prozora"
 
-#: src/apprt/gtk/class/window.zig:1153
+#: src/apprt/gtk/class/window.zig:1159
 msgid "Reloaded the configuration"
 msgstr "Ponovno učitane postavke"
 
-#: src/apprt/gtk/class/window.zig:1830
+#: src/apprt/gtk/class/window.zig:1836
 msgid "Copied to clipboard"
 msgstr "Kopirano u međuspremnik"
 
-#: src/apprt/gtk/class/window.zig:1832
+#: src/apprt/gtk/class/window.zig:1838
 msgid "Cleared clipboard"
 msgstr "Očišćen međuspremnik"
 
-#: src/apprt/gtk/class/window.zig:1972
+#: src/apprt/gtk/class/window.zig:1978
 msgid "Ghostty Developers"
 msgstr "Razvijatelji Ghosttyja"
 
@@ -408,8 +408,7 @@ msgstr "Kopiraj u međuspremnik"
 #: src/input/command.zig:156
 msgid ""
 "Copy the selected text to the clipboard in both plain and styled formats."
-msgstr ""
-"Kopiraj odabrani sadržaj u međuspremnik kao običan i oblikovani tekst."
+msgstr "Kopiraj odabrani sadržaj u međuspremnik kao običan i oblikovani tekst."
 
 #: src/input/command.zig:159
 msgid "Copy Selection as Plain Text to Clipboard"
@@ -452,8 +451,8 @@ msgid ""
 "Copy the terminal title to the clipboard. If the terminal title is not set "
 "this has no effect."
 msgstr ""
-"Kopiraj naslov terminala u međuspremnik. Nema nikakvog učinka ako "
-"naslov terminala nije postavljen."
+"Kopiraj naslov terminala u međuspremnik. Nema nikakvog učinka ako naslov "
+"terminala nije postavljen."
 
 #: src/input/command.zig:185
 msgid "Paste from Clipboard"
@@ -655,7 +654,8 @@ msgstr "Kopiraj sadržaj zaslona u privremenu datoteku kao HTML i otvori je."
 
 #: src/input/command.zig:330
 msgid "Copy Screen as ANSI Sequences to Temporary File and Copy Path"
-msgstr "Kopiraj zaslon u privremenu datoteku kao ANSI nizove i kopiraj putanju."
+msgstr ""
+"Kopiraj zaslon u privremenu datoteku kao ANSI nizove i kopiraj putanju."
 
 #: src/input/command.zig:331
 msgid ""
@@ -667,7 +667,8 @@ msgstr ""
 
 #: src/input/command.zig:338
 msgid "Copy Screen as ANSI Sequences to Temporary File and Paste Path"
-msgstr "Kopiraj zaslon u privremenu datoteku kao ANSI nizove i zalijepi putanju."
+msgstr ""
+"Kopiraj zaslon u privremenu datoteku kao ANSI nizove i zalijepi putanju."
 
 #: src/input/command.zig:339
 msgid ""
@@ -710,8 +711,7 @@ msgid ""
 "Copy the selection contents to a temporary file and paste the path to the "
 "file."
 msgstr ""
-"Kopiraj sadržaj odabira u privremenu datoteku i zalijepi putanju "
-"datoteke."
+"Kopiraj sadržaj odabira u privremenu datoteku i zalijepi putanju datoteke."
 
 #: src/input/command.zig:364
 msgid "Copy Selection to Temporary File and Open"
@@ -755,7 +755,8 @@ msgstr "Kopiraj sadržaj odabira u privremenu datoteku kao HTML i otvori je."
 
 #: src/input/command.zig:398
 msgid "Copy Selection as ANSI Sequences to Temporary File and Copy Path"
-msgstr "Kopiraj odabir u privremenu datoteku kao ANSI nizove i kopiraj putanju."
+msgstr ""
+"Kopiraj odabir u privremenu datoteku kao ANSI nizove i kopiraj putanju."
 
 #: src/input/command.zig:399
 msgid ""
@@ -767,7 +768,8 @@ msgstr ""
 
 #: src/input/command.zig:406
 msgid "Copy Selection as ANSI Sequences to Temporary File and Paste Path"
-msgstr "Kopiraj odabir u privremenu datoteku kao ANSI nizove i zalijepi putanju."
+msgstr ""
+"Kopiraj odabir u privremenu datoteku kao ANSI nizove i zalijepi putanju."
 
 #: src/input/command.zig:407
 msgid ""
@@ -991,7 +993,8 @@ msgstr "Otvori postavke u novom prozoru terminala"
 
 #: src/input/command.zig:594
 msgid "Open the config file in a new window using $EDITOR or $VISUAL."
-msgstr "Otvori datoteku postavki u novom prozoru koristeći $EDITOR ili $VISUAL."
+msgstr ""
+"Otvori datoteku postavki u novom prozoru koristeći $EDITOR ili $VISUAL."
 
 #: src/input/command.zig:600
 msgid "Reload Config"
@@ -1001,134 +1004,160 @@ msgstr "Ponovno učitaj postavke"
 msgid "Reload the config file."
 msgstr "Ponovno učitaj datoteku postavki."
 
-#: src/input/command.zig:606
+#: src/input/command.zig:607
+msgid "Switch to Dark Appearance"
+msgstr ""
+
+#: src/input/command.zig:608
+msgid "Use a dark application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Switch to Light Appearance"
+msgstr ""
+
+#: src/input/command.zig:613
+msgid "Use a light application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Switch to System Appearance"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Use the system application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:624
 msgid "Close Terminal"
 msgstr "Zatvori terminal"
 
-#: src/input/command.zig:607
+#: src/input/command.zig:625
 msgid "Close the current terminal."
 msgstr "Zatvori trenutni terminal."
 
-#: src/input/command.zig:614
+#: src/input/command.zig:632
 msgid "Close the current tab."
 msgstr "Zatvori trenutnu karticu."
 
-#: src/input/command.zig:618
+#: src/input/command.zig:636
 msgid "Close Other Tabs"
 msgstr "Zatvori ostale kartice"
 
-#: src/input/command.zig:619
+#: src/input/command.zig:637
 msgid "Close all tabs in this window except the current one."
 msgstr "Zatvori sve kartice u ovom prozoru osim trenutne."
 
-#: src/input/command.zig:623
+#: src/input/command.zig:641
 msgid "Close Tabs to the Right"
 msgstr "Zatvori sve kartice na desno"
 
-#: src/input/command.zig:624
+#: src/input/command.zig:642
 msgid "Close all tabs to the right of the current one."
 msgstr "Zatvori sve kartice desno od trenutne."
 
-#: src/input/command.zig:631
+#: src/input/command.zig:649
 msgid "Close the current window."
 msgstr "Zatvori trenutni prozor."
 
-#: src/input/command.zig:636
+#: src/input/command.zig:654
 msgid "Close All Windows"
 msgstr "Zatvori sve prozore"
 
-#: src/input/command.zig:637
+#: src/input/command.zig:655
 msgid "Close all windows."
 msgstr "Zatvori sve prozore."
 
-#: src/input/command.zig:642
+#: src/input/command.zig:660
 msgid "Toggle Maximize"
 msgstr "Uključi/isključi maksimiziranje"
 
-#: src/input/command.zig:643
+#: src/input/command.zig:661
 msgid "Toggle the maximized state of the current window."
 msgstr "Uključi ili isključi maksimiziranje trenutnog prozora."
 
-#: src/input/command.zig:648
+#: src/input/command.zig:666
 msgid "Toggle Fullscreen"
 msgstr "Uključi/isključi puni zaslon"
 
-#: src/input/command.zig:649
+#: src/input/command.zig:667
 msgid "Toggle the fullscreen state of the current window."
 msgstr "Uključi ili isključi puni zaslon trenutnog prozora."
 
-#: src/input/command.zig:654
+#: src/input/command.zig:672
 msgid "Toggle Window Decorations"
 msgstr "Uključi/isključi dekoracije prozora"
 
-#: src/input/command.zig:655
+#: src/input/command.zig:673
 msgid "Toggle the window decorations."
 msgstr "Uključi ili isključi dekoracije prozora."
 
-#: src/input/command.zig:660
+#: src/input/command.zig:678
 msgid "Toggle Float on Top"
 msgstr "Uključi/isključi plutanje na vrhu"
 
-#: src/input/command.zig:661
+#: src/input/command.zig:679
 msgid "Toggle the float on top state of the current window."
 msgstr "Uključi ili isključi plutanje na vrhu trenutnog prozora."
 
-#: src/input/command.zig:666
+#: src/input/command.zig:684
 msgid "Toggle Secure Input"
 msgstr "Uključi/isključi sigurni unos"
 
-#: src/input/command.zig:667
+#: src/input/command.zig:685
 msgid "Toggle secure input mode."
 msgstr "Uključi ili isključi način sigurnog unosa."
 
-#: src/input/command.zig:672
+#: src/input/command.zig:690
 msgid "Toggle Mouse Reporting"
 msgstr "Uključi/isključi obavještavanje miša"
 
-#: src/input/command.zig:673
+#: src/input/command.zig:691
 msgid "Toggle whether mouse events are reported to terminal applications."
-msgstr "Uključi ili isključi obavještava li terminal aplikacije o događajima miša."
+msgstr ""
+"Uključi ili isključi obavještava li terminal aplikacije o događajima miša."
 
-#: src/input/command.zig:678
+#: src/input/command.zig:696
 msgid "Toggle Background Opacity"
 msgstr "Uključi/isključi prozirnost pozadine"
 
-#: src/input/command.zig:679
+#: src/input/command.zig:697
 msgid "Toggle the background opacity of a window that started transparent."
-msgstr "Uključi ili isključi prozirnost pozadine prozora koji je započeo prozirno."
+msgstr ""
+"Uključi ili isključi prozirnost pozadine prozora koji je započeo prozirno."
 
-#: src/input/command.zig:684
+#: src/input/command.zig:702
 msgid "Check for Updates"
 msgstr "Provjeri ažuriranja"
 
-#: src/input/command.zig:685
+#: src/input/command.zig:703
 msgid "Check for updates to the application."
 msgstr "Provjeri ažuriranja aplikacije."
 
-#: src/input/command.zig:690
+#: src/input/command.zig:708
 msgid "Undo"
 msgstr "Poništi"
 
-#: src/input/command.zig:691
+#: src/input/command.zig:709
 msgid "Undo the last action."
 msgstr "Poništi zadnju radnju."
 
-#: src/input/command.zig:696
+#: src/input/command.zig:714
 msgid "Redo"
 msgstr "Ponovno odradi"
 
-#: src/input/command.zig:697
+#: src/input/command.zig:715
 msgid "Redo the last undone action."
 msgstr "Ponovi zadnju poništenu radnju."
 
-#: src/input/command.zig:703
+#: src/input/command.zig:721
 msgid "Quit the application."
 msgstr "Izađi iz aplikacije."
 
-#: src/input/command.zig:708
+#: src/input/command.zig:726
 msgid "Ghostty"
 msgstr "Ghostty"
 
-#: src/input/command.zig:709
+#: src/input/command.zig:727
 msgid "Put a little Ghostty in your terminal."
 msgstr "Stavi maloga Ghosttyja u svoj terminal."

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-09-10 10:50-0400\n"
 "PO-Revision-Date: 2026-08-13 21:23+0200\n"
 "Last-Translator: Balázs Szücs <bszucs1209@gmail.com>\n"
 "Language-Team: Hungarian <translation-team-hu@lists.sourceforge.net>\n"
@@ -48,7 +48,7 @@ msgstr "Konfiguráció frissítése a kérdés újbóli megjelenítéséhez"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2263
+#: src/apprt/gtk/class/application.zig:2296
 msgid "Cancel"
 msgstr "Mégse"
 
@@ -193,7 +193,7 @@ msgid "New Tab"
 msgstr "Új fül"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:242
-#: src/input/command.zig:613
+#: src/input/command.zig:631
 msgid "Close Tab"
 msgstr "Fül bezárása"
 
@@ -211,7 +211,7 @@ msgid "New Window"
 msgstr "Új ablak"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:416 src/apprt/gtk/ui/1.5/window.blp:225
-#: src/input/command.zig:630
+#: src/input/command.zig:648
 msgid "Close Window"
 msgstr "Ablak bezárása"
 
@@ -255,11 +255,11 @@ msgstr "Parancspaletta"
 msgid "Terminal Inspector"
 msgstr "Terminálvizsgáló"
 
-#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1991
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1997
 msgid "About Ghostty"
 msgstr "A Ghostty névjegye"
 
-#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:702
+#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:720
 msgid "Quit"
 msgstr "Kilépés"
 
@@ -267,27 +267,27 @@ msgstr "Kilépés"
 msgid "Execute a command…"
 msgstr "Parancs végrehajtása…"
 
-#: src/apprt/gtk/class/application.zig:1767
+#: src/apprt/gtk/class/application.zig:1779
 msgid "The keybind was revoked by the system."
 msgstr "A billentyűparancsot a rendszer visszavonta."
 
-#: src/apprt/gtk/class/application.zig:1769
+#: src/apprt/gtk/class/application.zig:1781
 msgid "The keybind was denied by the system."
 msgstr "A billentyűparancsot a rendszer megtagadta."
 
-#: src/apprt/gtk/class/application.zig:1780
+#: src/apprt/gtk/class/application.zig:1792
 msgid "Global keybind unavailable"
 msgstr "A globális billentyűparancs nem áll rendelkezésre"
 
-#: src/apprt/gtk/class/application.zig:2259
+#: src/apprt/gtk/class/application.zig:2292
 msgid "Export Terminal IO Events"
 msgstr "Terminál I/O események exportálása"
 
-#: src/apprt/gtk/class/application.zig:2262
+#: src/apprt/gtk/class/application.zig:2295
 msgid "Export"
 msgstr "Exportálás"
 
-#: src/apprt/gtk/class/application.zig:2783
+#: src/apprt/gtk/class/application.zig:2827
 msgid "Editing configuration file"
 msgstr "Konfigurációs fájl szerkesztése"
 
@@ -351,16 +351,16 @@ msgstr "Ebben az ablakban minden terminál munkamenet lezárul."
 msgid "The currently running process in this split will be terminated."
 msgstr "Ebben a felosztásban a jelenleg futó folyamat lezárul."
 
-#: src/apprt/gtk/class/surface.zig:1181
+#: src/apprt/gtk/class/surface.zig:1194
 msgid "Command Finished"
 msgstr "Parancs befejeződött"
 
-#: src/apprt/gtk/class/surface.zig:1182
+#: src/apprt/gtk/class/surface.zig:1195
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Parancs sikeres"
 
-#: src/apprt/gtk/class/surface.zig:1183
+#: src/apprt/gtk/class/surface.zig:1196
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Parancs sikertelen"
@@ -377,19 +377,19 @@ msgstr "Fül címének módosítása"
 msgid "Change Window Title"
 msgstr "Ablak címének módosítása"
 
-#: src/apprt/gtk/class/window.zig:1153
+#: src/apprt/gtk/class/window.zig:1159
 msgid "Reloaded the configuration"
 msgstr "Konfiguráció frissítve"
 
-#: src/apprt/gtk/class/window.zig:1830
+#: src/apprt/gtk/class/window.zig:1836
 msgid "Copied to clipboard"
 msgstr "Vágólapra másolva"
 
-#: src/apprt/gtk/class/window.zig:1832
+#: src/apprt/gtk/class/window.zig:1838
 msgid "Cleared clipboard"
 msgstr "Vágólap törölve"
 
-#: src/apprt/gtk/class/window.zig:1972
+#: src/apprt/gtk/class/window.zig:1978
 msgid "Ghostty Developers"
 msgstr "Ghostty fejlesztők"
 
@@ -611,8 +611,8 @@ msgstr "Képernyő másolása ideiglenes fájlba és útvonal beillesztése"
 msgid ""
 "Copy the screen contents to a temporary file and paste the path to the file."
 msgstr ""
-"A képernyő tartalmának másolása egy ideiglenes fájlba, és a fájl "
-"útvonalának beillesztése."
+"A képernyő tartalmának másolása egy ideiglenes fájlba, és a fájl útvonalának "
+"beillesztése."
 
 #: src/input/command.zig:296
 msgid "Copy Screen to Temporary File and Open"
@@ -659,8 +659,7 @@ msgstr ""
 #: src/input/command.zig:330
 msgid "Copy Screen as ANSI Sequences to Temporary File and Copy Path"
 msgstr ""
-"Képernyő másolása ANSI szekvenciákként ideiglenes fájlba és útvonal "
-"másolása"
+"Képernyő másolása ANSI szekvenciákként ideiglenes fájlba és útvonal másolása"
 
 #: src/input/command.zig:331
 msgid ""
@@ -726,8 +725,7 @@ msgstr "Kijelölés másolása ideiglenes fájlba és megnyitás"
 
 #: src/input/command.zig:365
 msgid "Copy the selection contents to a temporary file and open it."
-msgstr ""
-"A kijelölés tartalmának másolása egy ideiglenes fájlba, és megnyitása."
+msgstr "A kijelölés tartalmának másolása egy ideiglenes fájlba, és megnyitása."
 
 #: src/input/command.zig:373
 msgid "Copy Selection as HTML to Temporary File and Copy Path"
@@ -743,16 +741,15 @@ msgstr ""
 
 #: src/input/command.zig:381
 msgid "Copy Selection as HTML to Temporary File and Paste Path"
-msgstr ""
-"Kijelölés másolása HTML-ként ideiglenes fájlba és útvonal beillesztése"
+msgstr "Kijelölés másolása HTML-ként ideiglenes fájlba és útvonal beillesztése"
 
 #: src/input/command.zig:382
 msgid ""
 "Copy the selection contents as HTML to a temporary file and paste the path "
 "to the file."
 msgstr ""
-"A kijelölés tartalmának HTML-ként másolása egy ideiglenes fájlba, és a "
-"fájl útvonalának beillesztése."
+"A kijelölés tartalmának HTML-ként másolása egy ideiglenes fájlba, és a fájl "
+"útvonalának beillesztése."
 
 #: src/input/command.zig:389
 msgid "Copy Selection as HTML to Temporary File and Open"
@@ -767,16 +764,15 @@ msgstr ""
 #: src/input/command.zig:398
 msgid "Copy Selection as ANSI Sequences to Temporary File and Copy Path"
 msgstr ""
-"Kijelölés másolása ANSI szekvenciákként ideiglenes fájlba és útvonal "
-"másolása"
+"Kijelölés másolása ANSI szekvenciákként ideiglenes fájlba és útvonal másolása"
 
 #: src/input/command.zig:399
 msgid ""
 "Copy the selection contents as ANSI escape sequences to a temporary file and "
 "copy the path to the clipboard."
 msgstr ""
-"A kijelölés tartalmának ANSI escape szekvenciákként másolása egy "
-"ideiglenes fájlba, és az útvonal vágólapra másolása."
+"A kijelölés tartalmának ANSI escape szekvenciákként másolása egy ideiglenes "
+"fájlba, és az útvonal vágólapra másolása."
 
 #: src/input/command.zig:406
 msgid "Copy Selection as ANSI Sequences to Temporary File and Paste Path"
@@ -789,21 +785,20 @@ msgid ""
 "Copy the selection contents as ANSI escape sequences to a temporary file and "
 "paste the path to the file."
 msgstr ""
-"A kijelölés tartalmának ANSI escape szekvenciákként másolása egy "
-"ideiglenes fájlba, és a fájl útvonalának beillesztése."
+"A kijelölés tartalmának ANSI escape szekvenciákként másolása egy ideiglenes "
+"fájlba, és a fájl útvonalának beillesztése."
 
 #: src/input/command.zig:414
 msgid "Copy Selection as ANSI Sequences to Temporary File and Open"
-msgstr ""
-"Kijelölés másolása ANSI szekvenciákként ideiglenes fájlba és megnyitás"
+msgstr "Kijelölés másolása ANSI szekvenciákként ideiglenes fájlba és megnyitás"
 
 #: src/input/command.zig:415
 msgid ""
 "Copy the selection contents as ANSI escape sequences to a temporary file and "
 "open it."
 msgstr ""
-"A kijelölés tartalmának ANSI escape szekvenciákként másolása egy "
-"ideiglenes fájlba, és megnyitása."
+"A kijelölés tartalmának ANSI escape szekvenciákként másolása egy ideiglenes "
+"fájlba, és megnyitása."
 
 #: src/input/command.zig:422
 msgid "Open a new window."
@@ -1021,137 +1016,159 @@ msgstr "Konfiguráció frissítése"
 msgid "Reload the config file."
 msgstr "A konfigurációs fájl frissítése."
 
-#: src/input/command.zig:606
+#: src/input/command.zig:607
+msgid "Switch to Dark Appearance"
+msgstr ""
+
+#: src/input/command.zig:608
+msgid "Use a dark application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Switch to Light Appearance"
+msgstr ""
+
+#: src/input/command.zig:613
+msgid "Use a light application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Switch to System Appearance"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Use the system application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:624
 msgid "Close Terminal"
 msgstr "Terminál bezárása"
 
-#: src/input/command.zig:607
+#: src/input/command.zig:625
 msgid "Close the current terminal."
 msgstr "A jelenlegi terminál bezárása."
 
-#: src/input/command.zig:614
+#: src/input/command.zig:632
 msgid "Close the current tab."
 msgstr "A jelenlegi fül bezárása."
 
-#: src/input/command.zig:618
+#: src/input/command.zig:636
 msgid "Close Other Tabs"
 msgstr "Egyéb fülek bezárása"
 
-#: src/input/command.zig:619
+#: src/input/command.zig:637
 msgid "Close all tabs in this window except the current one."
 msgstr "Az ebben az ablakban lévő összes fül bezárása a jelenlegi kivételével."
 
-#: src/input/command.zig:623
+#: src/input/command.zig:641
 msgid "Close Tabs to the Right"
 msgstr "Jobb oldali fülek bezárása"
 
-#: src/input/command.zig:624
+#: src/input/command.zig:642
 msgid "Close all tabs to the right of the current one."
 msgstr "A jelenlegi fültől jobbra lévő összes fül bezárása."
 
-#: src/input/command.zig:631
+#: src/input/command.zig:649
 msgid "Close the current window."
 msgstr "A jelenlegi ablak bezárása."
 
-#: src/input/command.zig:636
+#: src/input/command.zig:654
 msgid "Close All Windows"
 msgstr "Összes ablak bezárása"
 
-#: src/input/command.zig:637
+#: src/input/command.zig:655
 msgid "Close all windows."
 msgstr "Az összes ablak bezárása."
 
-#: src/input/command.zig:642
+#: src/input/command.zig:660
 msgid "Toggle Maximize"
 msgstr "Maximalizálás váltása"
 
-#: src/input/command.zig:643
+#: src/input/command.zig:661
 msgid "Toggle the maximized state of the current window."
 msgstr "A jelenlegi ablak maximalizált állapotának váltása."
 
-#: src/input/command.zig:648
+#: src/input/command.zig:666
 msgid "Toggle Fullscreen"
 msgstr "Teljes képernyő váltása"
 
-#: src/input/command.zig:649
+#: src/input/command.zig:667
 msgid "Toggle the fullscreen state of the current window."
 msgstr "A jelenlegi ablak teljes képernyős állapotának váltása."
 
-#: src/input/command.zig:654
+#: src/input/command.zig:672
 msgid "Toggle Window Decorations"
 msgstr "Ablakdíszítések váltása"
 
-#: src/input/command.zig:655
+#: src/input/command.zig:673
 msgid "Toggle the window decorations."
 msgstr "Az ablakdíszítések váltása."
 
-#: src/input/command.zig:660
+#: src/input/command.zig:678
 msgid "Toggle Float on Top"
 msgstr "Mindig felül váltása"
 
-#: src/input/command.zig:661
+#: src/input/command.zig:679
 msgid "Toggle the float on top state of the current window."
 msgstr "A jelenlegi ablak mindig felül állapotának váltása."
 
-#: src/input/command.zig:666
+#: src/input/command.zig:684
 msgid "Toggle Secure Input"
 msgstr "Biztonságos beviteli mód váltása"
 
-#: src/input/command.zig:667
+#: src/input/command.zig:685
 msgid "Toggle secure input mode."
 msgstr "A biztonságos beviteli mód váltása."
 
-#: src/input/command.zig:672
+#: src/input/command.zig:690
 msgid "Toggle Mouse Reporting"
 msgstr "Egérjelentés váltása"
 
-#: src/input/command.zig:673
+#: src/input/command.zig:691
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr ""
-"Annak váltása, hogy az egéresemények eljutnak-e a "
-"terminálalkalmazásokhoz."
+"Annak váltása, hogy az egéresemények eljutnak-e a terminálalkalmazásokhoz."
 
-#: src/input/command.zig:678
+#: src/input/command.zig:696
 msgid "Toggle Background Opacity"
 msgstr "Háttér átlátszóságának váltása"
 
-#: src/input/command.zig:679
+#: src/input/command.zig:697
 msgid "Toggle the background opacity of a window that started transparent."
-msgstr ""
-"A háttér átlátszóságának váltása egy átlátszóként indított ablaknál."
+msgstr "A háttér átlátszóságának váltása egy átlátszóként indított ablaknál."
 
-#: src/input/command.zig:684
+#: src/input/command.zig:702
 msgid "Check for Updates"
 msgstr "Frissítések keresése"
 
-#: src/input/command.zig:685
+#: src/input/command.zig:703
 msgid "Check for updates to the application."
 msgstr "Az alkalmazás frissítéseinek keresése."
 
-#: src/input/command.zig:690
+#: src/input/command.zig:708
 msgid "Undo"
 msgstr "Visszavonás"
 
-#: src/input/command.zig:691
+#: src/input/command.zig:709
 msgid "Undo the last action."
 msgstr "Az utolsó művelet visszavonása."
 
-#: src/input/command.zig:696
+#: src/input/command.zig:714
 msgid "Redo"
 msgstr "Ismétlés"
 
-#: src/input/command.zig:697
+#: src/input/command.zig:715
 msgid "Redo the last undone action."
 msgstr "Az utolsó visszavont művelet ismétlése."
 
-#: src/input/command.zig:703
+#: src/input/command.zig:721
 msgid "Quit the application."
 msgstr "Az alkalmazásból kilépés."
 
-#: src/input/command.zig:708
+#: src/input/command.zig:726
 msgid "Ghostty"
 msgstr "Ghostty"
 
-#: src/input/command.zig:709
+#: src/input/command.zig:727
 msgid "Put a little Ghostty in your terminal."
 msgstr "Egy kis Ghostty a terminálban."

--- a/po/id.po
+++ b/po/id.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-09-10 10:50-0400\n"
 "PO-Revision-Date: 2026-03-08 20:23+0700\n"
 "Last-Translator: Mikail Muzakki <mikailmmuzakki@gmail.com>\n"
 "Language-Team: Indonesian <translation-team-id@lists.sourceforge.net>\n"
@@ -49,7 +49,7 @@ msgstr "Muat ulang konfigurasi untuk menampilkan pesan ini lagi"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2263
+#: src/apprt/gtk/class/application.zig:2296
 msgid "Cancel"
 msgstr "Batal"
 
@@ -193,7 +193,7 @@ msgid "New Tab"
 msgstr "Tab baru"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:242
-#: src/input/command.zig:613
+#: src/input/command.zig:631
 msgid "Close Tab"
 msgstr "Tutup tab"
 
@@ -211,7 +211,7 @@ msgid "New Window"
 msgstr "Jendela baru"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:416 src/apprt/gtk/ui/1.5/window.blp:225
-#: src/input/command.zig:630
+#: src/input/command.zig:648
 msgid "Close Window"
 msgstr "Tutup jendela"
 
@@ -255,11 +255,11 @@ msgstr "Palet perintah"
 msgid "Terminal Inspector"
 msgstr "Inspektur terminal"
 
-#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1991
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1997
 msgid "About Ghostty"
 msgstr "Tentang Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:702
+#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:720
 msgid "Quit"
 msgstr "Keluar"
 
@@ -267,27 +267,27 @@ msgstr "Keluar"
 msgid "Execute a command…"
 msgstr "Eksekusi perintah…"
 
-#: src/apprt/gtk/class/application.zig:1767
+#: src/apprt/gtk/class/application.zig:1779
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1769
+#: src/apprt/gtk/class/application.zig:1781
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1780
+#: src/apprt/gtk/class/application.zig:1792
 msgid "Global keybind unavailable"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2259
+#: src/apprt/gtk/class/application.zig:2292
 msgid "Export Terminal IO Events"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2262
+#: src/apprt/gtk/class/application.zig:2295
 msgid "Export"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2783
+#: src/apprt/gtk/class/application.zig:2827
 msgid "Editing configuration file"
 msgstr ""
 
@@ -351,16 +351,16 @@ msgstr "Semua sesi terminal di jendela ini akan diakhiri."
 msgid "The currently running process in this split will be terminated."
 msgstr "Proses yang sedang berjalan dalam belahan ini akan diakhiri."
 
-#: src/apprt/gtk/class/surface.zig:1181
+#: src/apprt/gtk/class/surface.zig:1194
 msgid "Command Finished"
 msgstr "Perintah selesai"
 
-#: src/apprt/gtk/class/surface.zig:1182
+#: src/apprt/gtk/class/surface.zig:1195
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Perintah berhasil"
 
-#: src/apprt/gtk/class/surface.zig:1183
+#: src/apprt/gtk/class/surface.zig:1196
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Perintah gagal"
@@ -377,19 +377,19 @@ msgstr "Ubah judul tab"
 msgid "Change Window Title"
 msgstr ""
 
-#: src/apprt/gtk/class/window.zig:1153
+#: src/apprt/gtk/class/window.zig:1159
 msgid "Reloaded the configuration"
 msgstr "Memuat ulang konfigurasi"
 
-#: src/apprt/gtk/class/window.zig:1830
+#: src/apprt/gtk/class/window.zig:1836
 msgid "Copied to clipboard"
 msgstr "Disalin ke papan klip"
 
-#: src/apprt/gtk/class/window.zig:1832
+#: src/apprt/gtk/class/window.zig:1838
 msgid "Cleared clipboard"
 msgstr "Papan klip dibersihkan"
 
-#: src/apprt/gtk/class/window.zig:1972
+#: src/apprt/gtk/class/window.zig:1978
 msgid "Ghostty Developers"
 msgstr "Pengembang Ghostty"
 
@@ -971,134 +971,158 @@ msgstr ""
 msgid "Reload the config file."
 msgstr ""
 
-#: src/input/command.zig:606
-msgid "Close Terminal"
-msgstr ""
-
 #: src/input/command.zig:607
-msgid "Close the current terminal."
+msgid "Switch to Dark Appearance"
 msgstr ""
 
-#: src/input/command.zig:614
-msgid "Close the current tab."
+#: src/input/command.zig:608
+msgid "Use a dark application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Switch to Light Appearance"
+msgstr ""
+
+#: src/input/command.zig:613
+msgid "Use a light application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Switch to System Appearance"
 msgstr ""
 
 #: src/input/command.zig:618
-msgid "Close Other Tabs"
-msgstr ""
-
-#: src/input/command.zig:619
-msgid "Close all tabs in this window except the current one."
-msgstr ""
-
-#: src/input/command.zig:623
-msgid "Close Tabs to the Right"
+msgid "Use the system application appearance for this session."
 msgstr ""
 
 #: src/input/command.zig:624
-msgid "Close all tabs to the right of the current one."
+msgid "Close Terminal"
 msgstr ""
 
-#: src/input/command.zig:631
-msgid "Close the current window."
+#: src/input/command.zig:625
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:632
+msgid "Close the current tab."
 msgstr ""
 
 #: src/input/command.zig:636
-msgid "Close All Windows"
+msgid "Close Other Tabs"
 msgstr ""
 
 #: src/input/command.zig:637
-msgid "Close all windows."
+msgid "Close all tabs in this window except the current one."
+msgstr ""
+
+#: src/input/command.zig:641
+msgid "Close Tabs to the Right"
 msgstr ""
 
 #: src/input/command.zig:642
-msgid "Toggle Maximize"
-msgstr ""
-
-#: src/input/command.zig:643
-msgid "Toggle the maximized state of the current window."
-msgstr ""
-
-#: src/input/command.zig:648
-msgid "Toggle Fullscreen"
+msgid "Close all tabs to the right of the current one."
 msgstr ""
 
 #: src/input/command.zig:649
-msgid "Toggle the fullscreen state of the current window."
+msgid "Close the current window."
 msgstr ""
 
 #: src/input/command.zig:654
-msgid "Toggle Window Decorations"
+msgid "Close All Windows"
 msgstr ""
 
 #: src/input/command.zig:655
-msgid "Toggle the window decorations."
+msgid "Close all windows."
 msgstr ""
 
 #: src/input/command.zig:660
-msgid "Toggle Float on Top"
+msgid "Toggle Maximize"
 msgstr ""
 
 #: src/input/command.zig:661
-msgid "Toggle the float on top state of the current window."
+msgid "Toggle the maximized state of the current window."
 msgstr ""
 
 #: src/input/command.zig:666
-msgid "Toggle Secure Input"
+msgid "Toggle Fullscreen"
 msgstr ""
 
 #: src/input/command.zig:667
-msgid "Toggle secure input mode."
+msgid "Toggle the fullscreen state of the current window."
 msgstr ""
 
 #: src/input/command.zig:672
-msgid "Toggle Mouse Reporting"
+msgid "Toggle Window Decorations"
 msgstr ""
 
 #: src/input/command.zig:673
-msgid "Toggle whether mouse events are reported to terminal applications."
+msgid "Toggle the window decorations."
 msgstr ""
 
 #: src/input/command.zig:678
-msgid "Toggle Background Opacity"
+msgid "Toggle Float on Top"
 msgstr ""
 
 #: src/input/command.zig:679
-msgid "Toggle the background opacity of a window that started transparent."
+msgid "Toggle the float on top state of the current window."
 msgstr ""
 
 #: src/input/command.zig:684
-msgid "Check for Updates"
+msgid "Toggle Secure Input"
 msgstr ""
 
 #: src/input/command.zig:685
-msgid "Check for updates to the application."
+msgid "Toggle secure input mode."
 msgstr ""
 
 #: src/input/command.zig:690
-msgid "Undo"
+msgid "Toggle Mouse Reporting"
 msgstr ""
 
 #: src/input/command.zig:691
-msgid "Undo the last action."
+msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr ""
 
 #: src/input/command.zig:696
-msgid "Redo"
+msgid "Toggle Background Opacity"
 msgstr ""
 
 #: src/input/command.zig:697
-msgid "Redo the last undone action."
+msgid "Toggle the background opacity of a window that started transparent."
+msgstr ""
+
+#: src/input/command.zig:702
+msgid "Check for Updates"
 msgstr ""
 
 #: src/input/command.zig:703
-msgid "Quit the application."
+msgid "Check for updates to the application."
 msgstr ""
 
 #: src/input/command.zig:708
-msgid "Ghostty"
+msgid "Undo"
 msgstr ""
 
 #: src/input/command.zig:709
+msgid "Undo the last action."
+msgstr ""
+
+#: src/input/command.zig:714
+msgid "Redo"
+msgstr ""
+
+#: src/input/command.zig:715
+msgid "Redo the last undone action."
+msgstr ""
+
+#: src/input/command.zig:721
+msgid "Quit the application."
+msgstr ""
+
+#: src/input/command.zig:726
+msgid "Ghostty"
+msgstr ""
+
+#: src/input/command.zig:727
 msgid "Put a little Ghostty in your terminal."
 msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-09-10 10:50-0400\n"
 "PO-Revision-Date: 2025-09-06 19:40+0200\n"
 "Last-Translator: Giacomo Bettini <giaco.bettini@gmail.com>\n"
 "Language-Team: Italian <tp@lists.linux.it>\n"
@@ -50,7 +50,7 @@ msgstr ""
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2263
+#: src/apprt/gtk/class/application.zig:2296
 msgid "Cancel"
 msgstr "Annulla"
 
@@ -194,7 +194,7 @@ msgid "New Tab"
 msgstr "Nuova scheda"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:242
-#: src/input/command.zig:613
+#: src/input/command.zig:631
 msgid "Close Tab"
 msgstr "Chiudi scheda"
 
@@ -212,7 +212,7 @@ msgid "New Window"
 msgstr "Nuova finestra"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:416 src/apprt/gtk/ui/1.5/window.blp:225
-#: src/input/command.zig:630
+#: src/input/command.zig:648
 msgid "Close Window"
 msgstr "Chiudi finestra"
 
@@ -256,11 +256,11 @@ msgstr "Riquadro comandi"
 msgid "Terminal Inspector"
 msgstr "Ispettore del terminale"
 
-#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1991
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1997
 msgid "About Ghostty"
 msgstr "Informazioni su Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:702
+#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:720
 msgid "Quit"
 msgstr "Chiudi"
 
@@ -268,27 +268,27 @@ msgstr "Chiudi"
 msgid "Execute a command…"
 msgstr "Esegui un comando…"
 
-#: src/apprt/gtk/class/application.zig:1767
+#: src/apprt/gtk/class/application.zig:1779
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1769
+#: src/apprt/gtk/class/application.zig:1781
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1780
+#: src/apprt/gtk/class/application.zig:1792
 msgid "Global keybind unavailable"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2259
+#: src/apprt/gtk/class/application.zig:2292
 msgid "Export Terminal IO Events"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2262
+#: src/apprt/gtk/class/application.zig:2295
 msgid "Export"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2783
+#: src/apprt/gtk/class/application.zig:2827
 msgid "Editing configuration file"
 msgstr ""
 
@@ -353,16 +353,16 @@ msgid "The currently running process in this split will be terminated."
 msgstr ""
 "Il processo attualmente in esecuzione in questa divisione sarà terminato."
 
-#: src/apprt/gtk/class/surface.zig:1181
+#: src/apprt/gtk/class/surface.zig:1194
 msgid "Command Finished"
 msgstr "Comando terminato"
 
-#: src/apprt/gtk/class/surface.zig:1182
+#: src/apprt/gtk/class/surface.zig:1195
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Comando riuscito"
 
-#: src/apprt/gtk/class/surface.zig:1183
+#: src/apprt/gtk/class/surface.zig:1196
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Comando fallito"
@@ -379,19 +379,19 @@ msgstr "Cambia il titolo della scheda"
 msgid "Change Window Title"
 msgstr ""
 
-#: src/apprt/gtk/class/window.zig:1153
+#: src/apprt/gtk/class/window.zig:1159
 msgid "Reloaded the configuration"
 msgstr "Configurazione ricaricata"
 
-#: src/apprt/gtk/class/window.zig:1830
+#: src/apprt/gtk/class/window.zig:1836
 msgid "Copied to clipboard"
 msgstr "Copiato negli Appunti"
 
-#: src/apprt/gtk/class/window.zig:1832
+#: src/apprt/gtk/class/window.zig:1838
 msgid "Cleared clipboard"
 msgstr "Appunti svuotati"
 
-#: src/apprt/gtk/class/window.zig:1972
+#: src/apprt/gtk/class/window.zig:1978
 msgid "Ghostty Developers"
 msgstr "Sviluppatori di Ghostty"
 
@@ -973,134 +973,158 @@ msgstr ""
 msgid "Reload the config file."
 msgstr ""
 
-#: src/input/command.zig:606
-msgid "Close Terminal"
-msgstr ""
-
 #: src/input/command.zig:607
-msgid "Close the current terminal."
+msgid "Switch to Dark Appearance"
 msgstr ""
 
-#: src/input/command.zig:614
-msgid "Close the current tab."
+#: src/input/command.zig:608
+msgid "Use a dark application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Switch to Light Appearance"
+msgstr ""
+
+#: src/input/command.zig:613
+msgid "Use a light application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Switch to System Appearance"
 msgstr ""
 
 #: src/input/command.zig:618
-msgid "Close Other Tabs"
-msgstr ""
-
-#: src/input/command.zig:619
-msgid "Close all tabs in this window except the current one."
-msgstr ""
-
-#: src/input/command.zig:623
-msgid "Close Tabs to the Right"
+msgid "Use the system application appearance for this session."
 msgstr ""
 
 #: src/input/command.zig:624
-msgid "Close all tabs to the right of the current one."
+msgid "Close Terminal"
 msgstr ""
 
-#: src/input/command.zig:631
-msgid "Close the current window."
+#: src/input/command.zig:625
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:632
+msgid "Close the current tab."
 msgstr ""
 
 #: src/input/command.zig:636
-msgid "Close All Windows"
+msgid "Close Other Tabs"
 msgstr ""
 
 #: src/input/command.zig:637
-msgid "Close all windows."
+msgid "Close all tabs in this window except the current one."
+msgstr ""
+
+#: src/input/command.zig:641
+msgid "Close Tabs to the Right"
 msgstr ""
 
 #: src/input/command.zig:642
-msgid "Toggle Maximize"
-msgstr ""
-
-#: src/input/command.zig:643
-msgid "Toggle the maximized state of the current window."
-msgstr ""
-
-#: src/input/command.zig:648
-msgid "Toggle Fullscreen"
+msgid "Close all tabs to the right of the current one."
 msgstr ""
 
 #: src/input/command.zig:649
-msgid "Toggle the fullscreen state of the current window."
+msgid "Close the current window."
 msgstr ""
 
 #: src/input/command.zig:654
-msgid "Toggle Window Decorations"
+msgid "Close All Windows"
 msgstr ""
 
 #: src/input/command.zig:655
-msgid "Toggle the window decorations."
+msgid "Close all windows."
 msgstr ""
 
 #: src/input/command.zig:660
-msgid "Toggle Float on Top"
+msgid "Toggle Maximize"
 msgstr ""
 
 #: src/input/command.zig:661
-msgid "Toggle the float on top state of the current window."
+msgid "Toggle the maximized state of the current window."
 msgstr ""
 
 #: src/input/command.zig:666
-msgid "Toggle Secure Input"
+msgid "Toggle Fullscreen"
 msgstr ""
 
 #: src/input/command.zig:667
-msgid "Toggle secure input mode."
+msgid "Toggle the fullscreen state of the current window."
 msgstr ""
 
 #: src/input/command.zig:672
-msgid "Toggle Mouse Reporting"
+msgid "Toggle Window Decorations"
 msgstr ""
 
 #: src/input/command.zig:673
-msgid "Toggle whether mouse events are reported to terminal applications."
+msgid "Toggle the window decorations."
 msgstr ""
 
 #: src/input/command.zig:678
-msgid "Toggle Background Opacity"
+msgid "Toggle Float on Top"
 msgstr ""
 
 #: src/input/command.zig:679
-msgid "Toggle the background opacity of a window that started transparent."
+msgid "Toggle the float on top state of the current window."
 msgstr ""
 
 #: src/input/command.zig:684
-msgid "Check for Updates"
+msgid "Toggle Secure Input"
 msgstr ""
 
 #: src/input/command.zig:685
-msgid "Check for updates to the application."
+msgid "Toggle secure input mode."
 msgstr ""
 
 #: src/input/command.zig:690
-msgid "Undo"
+msgid "Toggle Mouse Reporting"
 msgstr ""
 
 #: src/input/command.zig:691
-msgid "Undo the last action."
+msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr ""
 
 #: src/input/command.zig:696
-msgid "Redo"
+msgid "Toggle Background Opacity"
 msgstr ""
 
 #: src/input/command.zig:697
-msgid "Redo the last undone action."
+msgid "Toggle the background opacity of a window that started transparent."
+msgstr ""
+
+#: src/input/command.zig:702
+msgid "Check for Updates"
 msgstr ""
 
 #: src/input/command.zig:703
-msgid "Quit the application."
+msgid "Check for updates to the application."
 msgstr ""
 
 #: src/input/command.zig:708
-msgid "Ghostty"
+msgid "Undo"
 msgstr ""
 
 #: src/input/command.zig:709
+msgid "Undo the last action."
+msgstr ""
+
+#: src/input/command.zig:714
+msgid "Redo"
+msgstr ""
+
+#: src/input/command.zig:715
+msgid "Redo the last undone action."
+msgstr ""
+
+#: src/input/command.zig:721
+msgid "Quit the application."
+msgstr ""
+
+#: src/input/command.zig:726
+msgid "Ghostty"
+msgstr ""
+
+#: src/input/command.zig:727
 msgid "Put a little Ghostty in your terminal."
 msgstr ""

--- a/po/ja.po
+++ b/po/ja.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-09-10 10:50-0400\n"
 "PO-Revision-Date: 2026-02-11 12:02+0900\n"
 "Last-Translator: Takayuki Nagatomi <tnagatomi@okweird.net>\n"
 "Language-Team: Japanese\n"
@@ -49,7 +49,7 @@ msgstr "このプロンプトを再び表示するには設定を再読み込み
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2263
+#: src/apprt/gtk/class/application.zig:2296
 msgid "Cancel"
 msgstr "キャンセル"
 
@@ -192,7 +192,7 @@ msgid "New Tab"
 msgstr "新しいタブ"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:242
-#: src/input/command.zig:613
+#: src/input/command.zig:631
 msgid "Close Tab"
 msgstr "タブを閉じる"
 
@@ -210,7 +210,7 @@ msgid "New Window"
 msgstr "新しいウィンドウ"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:416 src/apprt/gtk/ui/1.5/window.blp:225
-#: src/input/command.zig:630
+#: src/input/command.zig:648
 msgid "Close Window"
 msgstr "ウィンドウを閉じる"
 
@@ -254,11 +254,11 @@ msgstr "コマンドパレット"
 msgid "Terminal Inspector"
 msgstr "端末インスペクター"
 
-#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1991
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1997
 msgid "About Ghostty"
 msgstr "Ghostty について"
 
-#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:702
+#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:720
 msgid "Quit"
 msgstr "終了"
 
@@ -266,27 +266,27 @@ msgstr "終了"
 msgid "Execute a command…"
 msgstr "コマンドを実行…"
 
-#: src/apprt/gtk/class/application.zig:1767
+#: src/apprt/gtk/class/application.zig:1779
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1769
+#: src/apprt/gtk/class/application.zig:1781
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1780
+#: src/apprt/gtk/class/application.zig:1792
 msgid "Global keybind unavailable"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2259
+#: src/apprt/gtk/class/application.zig:2292
 msgid "Export Terminal IO Events"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2262
+#: src/apprt/gtk/class/application.zig:2295
 msgid "Export"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2783
+#: src/apprt/gtk/class/application.zig:2827
 msgid "Editing configuration file"
 msgstr ""
 
@@ -350,16 +350,16 @@ msgstr "ウィンドウ内のすべてのターミナルセッションが終了
 msgid "The currently running process in this split will be terminated."
 msgstr "分割ウィンドウ内のすべてのプロセスが終了します。"
 
-#: src/apprt/gtk/class/surface.zig:1181
+#: src/apprt/gtk/class/surface.zig:1194
 msgid "Command Finished"
 msgstr "コマンド実行終了"
 
-#: src/apprt/gtk/class/surface.zig:1182
+#: src/apprt/gtk/class/surface.zig:1195
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "コマンド実行成功"
 
-#: src/apprt/gtk/class/surface.zig:1183
+#: src/apprt/gtk/class/surface.zig:1196
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "コマンド実行失敗"
@@ -376,19 +376,19 @@ msgstr "タブのタイトルを変更する"
 msgid "Change Window Title"
 msgstr ""
 
-#: src/apprt/gtk/class/window.zig:1153
+#: src/apprt/gtk/class/window.zig:1159
 msgid "Reloaded the configuration"
 msgstr "設定を再読み込みしました"
 
-#: src/apprt/gtk/class/window.zig:1830
+#: src/apprt/gtk/class/window.zig:1836
 msgid "Copied to clipboard"
 msgstr "クリップボードにコピーしました"
 
-#: src/apprt/gtk/class/window.zig:1832
+#: src/apprt/gtk/class/window.zig:1838
 msgid "Cleared clipboard"
 msgstr "クリップボードを空にしました"
 
-#: src/apprt/gtk/class/window.zig:1972
+#: src/apprt/gtk/class/window.zig:1978
 msgid "Ghostty Developers"
 msgstr "Ghostty 開発者"
 
@@ -970,134 +970,158 @@ msgstr ""
 msgid "Reload the config file."
 msgstr ""
 
-#: src/input/command.zig:606
-msgid "Close Terminal"
-msgstr ""
-
 #: src/input/command.zig:607
-msgid "Close the current terminal."
+msgid "Switch to Dark Appearance"
 msgstr ""
 
-#: src/input/command.zig:614
-msgid "Close the current tab."
+#: src/input/command.zig:608
+msgid "Use a dark application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Switch to Light Appearance"
+msgstr ""
+
+#: src/input/command.zig:613
+msgid "Use a light application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Switch to System Appearance"
 msgstr ""
 
 #: src/input/command.zig:618
-msgid "Close Other Tabs"
-msgstr ""
-
-#: src/input/command.zig:619
-msgid "Close all tabs in this window except the current one."
-msgstr ""
-
-#: src/input/command.zig:623
-msgid "Close Tabs to the Right"
+msgid "Use the system application appearance for this session."
 msgstr ""
 
 #: src/input/command.zig:624
-msgid "Close all tabs to the right of the current one."
+msgid "Close Terminal"
 msgstr ""
 
-#: src/input/command.zig:631
-msgid "Close the current window."
+#: src/input/command.zig:625
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:632
+msgid "Close the current tab."
 msgstr ""
 
 #: src/input/command.zig:636
-msgid "Close All Windows"
+msgid "Close Other Tabs"
 msgstr ""
 
 #: src/input/command.zig:637
-msgid "Close all windows."
+msgid "Close all tabs in this window except the current one."
+msgstr ""
+
+#: src/input/command.zig:641
+msgid "Close Tabs to the Right"
 msgstr ""
 
 #: src/input/command.zig:642
-msgid "Toggle Maximize"
-msgstr ""
-
-#: src/input/command.zig:643
-msgid "Toggle the maximized state of the current window."
-msgstr ""
-
-#: src/input/command.zig:648
-msgid "Toggle Fullscreen"
+msgid "Close all tabs to the right of the current one."
 msgstr ""
 
 #: src/input/command.zig:649
-msgid "Toggle the fullscreen state of the current window."
+msgid "Close the current window."
 msgstr ""
 
 #: src/input/command.zig:654
-msgid "Toggle Window Decorations"
+msgid "Close All Windows"
 msgstr ""
 
 #: src/input/command.zig:655
-msgid "Toggle the window decorations."
+msgid "Close all windows."
 msgstr ""
 
 #: src/input/command.zig:660
-msgid "Toggle Float on Top"
+msgid "Toggle Maximize"
 msgstr ""
 
 #: src/input/command.zig:661
-msgid "Toggle the float on top state of the current window."
+msgid "Toggle the maximized state of the current window."
 msgstr ""
 
 #: src/input/command.zig:666
-msgid "Toggle Secure Input"
+msgid "Toggle Fullscreen"
 msgstr ""
 
 #: src/input/command.zig:667
-msgid "Toggle secure input mode."
+msgid "Toggle the fullscreen state of the current window."
 msgstr ""
 
 #: src/input/command.zig:672
-msgid "Toggle Mouse Reporting"
+msgid "Toggle Window Decorations"
 msgstr ""
 
 #: src/input/command.zig:673
-msgid "Toggle whether mouse events are reported to terminal applications."
+msgid "Toggle the window decorations."
 msgstr ""
 
 #: src/input/command.zig:678
-msgid "Toggle Background Opacity"
+msgid "Toggle Float on Top"
 msgstr ""
 
 #: src/input/command.zig:679
-msgid "Toggle the background opacity of a window that started transparent."
+msgid "Toggle the float on top state of the current window."
 msgstr ""
 
 #: src/input/command.zig:684
-msgid "Check for Updates"
+msgid "Toggle Secure Input"
 msgstr ""
 
 #: src/input/command.zig:685
-msgid "Check for updates to the application."
+msgid "Toggle secure input mode."
 msgstr ""
 
 #: src/input/command.zig:690
-msgid "Undo"
+msgid "Toggle Mouse Reporting"
 msgstr ""
 
 #: src/input/command.zig:691
-msgid "Undo the last action."
+msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr ""
 
 #: src/input/command.zig:696
-msgid "Redo"
+msgid "Toggle Background Opacity"
 msgstr ""
 
 #: src/input/command.zig:697
-msgid "Redo the last undone action."
+msgid "Toggle the background opacity of a window that started transparent."
+msgstr ""
+
+#: src/input/command.zig:702
+msgid "Check for Updates"
 msgstr ""
 
 #: src/input/command.zig:703
-msgid "Quit the application."
+msgid "Check for updates to the application."
 msgstr ""
 
 #: src/input/command.zig:708
-msgid "Ghostty"
+msgid "Undo"
 msgstr ""
 
 #: src/input/command.zig:709
+msgid "Undo the last action."
+msgstr ""
+
+#: src/input/command.zig:714
+msgid "Redo"
+msgstr ""
+
+#: src/input/command.zig:715
+msgid "Redo the last undone action."
+msgstr ""
+
+#: src/input/command.zig:721
+msgid "Quit the application."
+msgstr ""
+
+#: src/input/command.zig:726
+msgid "Ghostty"
+msgstr ""
+
+#: src/input/command.zig:727
 msgid "Put a little Ghostty in your terminal."
 msgstr ""

--- a/po/kk.po
+++ b/po/kk.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-09-10 10:50-0400\n"
 "PO-Revision-Date: 2026-08-13 00:00+0500\n"
 "Last-Translator: AnmiTaliDev <anmitalidev@nuros.org>\n"
 "Language-Team: Kazakh <kk_KZ@googlegroups.com>\n"
@@ -49,7 +49,7 @@ msgstr "Бұл сұрауды қайта көрсету үшін конфигу�
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2263
+#: src/apprt/gtk/class/application.zig:2296
 msgid "Cancel"
 msgstr "Бас тарту"
 
@@ -194,7 +194,7 @@ msgid "New Tab"
 msgstr "Жаңа бет"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:242
-#: src/input/command.zig:613
+#: src/input/command.zig:631
 msgid "Close Tab"
 msgstr "Бетті жабу"
 
@@ -212,7 +212,7 @@ msgid "New Window"
 msgstr "Жаңа терезе"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:416 src/apprt/gtk/ui/1.5/window.blp:225
-#: src/input/command.zig:630
+#: src/input/command.zig:648
 msgid "Close Window"
 msgstr "Терезені жабу"
 
@@ -256,11 +256,11 @@ msgstr "Командалар палитрасы"
 msgid "Terminal Inspector"
 msgstr "Терминал инспекторы"
 
-#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1991
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1997
 msgid "About Ghostty"
 msgstr "Ghostty туралы"
 
-#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:702
+#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:720
 msgid "Quit"
 msgstr "Шығу"
 
@@ -268,27 +268,27 @@ msgstr "Шығу"
 msgid "Execute a command…"
 msgstr "Команданы орындау…"
 
-#: src/apprt/gtk/class/application.zig:1767
+#: src/apprt/gtk/class/application.zig:1779
 msgid "The keybind was revoked by the system."
 msgstr "Пернелер тіркесімін жүйе қайтарып алды."
 
-#: src/apprt/gtk/class/application.zig:1769
+#: src/apprt/gtk/class/application.zig:1781
 msgid "The keybind was denied by the system."
 msgstr "Пернелер тіркесіміне жүйе тыйым салды."
 
-#: src/apprt/gtk/class/application.zig:1780
+#: src/apprt/gtk/class/application.zig:1792
 msgid "Global keybind unavailable"
 msgstr "Глобалды пернелер тіркесімі қолжетімсіз"
 
-#: src/apprt/gtk/class/application.zig:2259
+#: src/apprt/gtk/class/application.zig:2292
 msgid "Export Terminal IO Events"
 msgstr "Терминал енгізу/шығару оқиғаларын экспорттау"
 
-#: src/apprt/gtk/class/application.zig:2262
+#: src/apprt/gtk/class/application.zig:2295
 msgid "Export"
 msgstr "Экспорттау"
 
-#: src/apprt/gtk/class/application.zig:2783
+#: src/apprt/gtk/class/application.zig:2827
 msgid "Editing configuration file"
 msgstr "Конфигурация файлын түзету"
 
@@ -352,16 +352,16 @@ msgstr "Осы терезедегі барлық терминал сессиял
 msgid "The currently running process in this split will be terminated."
 msgstr "Осы бөлудегі ағымдағы орындалып жатқан процесс тоқтатылады."
 
-#: src/apprt/gtk/class/surface.zig:1181
+#: src/apprt/gtk/class/surface.zig:1194
 msgid "Command Finished"
 msgstr "Команда аяқталды"
 
-#: src/apprt/gtk/class/surface.zig:1182
+#: src/apprt/gtk/class/surface.zig:1195
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Команда сәтті орындалды"
 
-#: src/apprt/gtk/class/surface.zig:1183
+#: src/apprt/gtk/class/surface.zig:1196
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Команда сәтсіз аяқталды"
@@ -378,19 +378,19 @@ msgstr "Бет атауын өзгерту"
 msgid "Change Window Title"
 msgstr "Терезе атауын өзгерту"
 
-#: src/apprt/gtk/class/window.zig:1153
+#: src/apprt/gtk/class/window.zig:1159
 msgid "Reloaded the configuration"
 msgstr "Конфигурация қайта жүктелді"
 
-#: src/apprt/gtk/class/window.zig:1830
+#: src/apprt/gtk/class/window.zig:1836
 msgid "Copied to clipboard"
 msgstr "Алмасу буферіне көшірілді"
 
-#: src/apprt/gtk/class/window.zig:1832
+#: src/apprt/gtk/class/window.zig:1838
 msgid "Cleared clipboard"
 msgstr "Алмасу буфері тазартылды"
 
-#: src/apprt/gtk/class/window.zig:1972
+#: src/apprt/gtk/class/window.zig:1978
 msgid "Ghostty Developers"
 msgstr "Ghostty әзірлеушілері"
 
@@ -999,138 +999,162 @@ msgstr "Конфигурацияны қайта жүктеу"
 msgid "Reload the config file."
 msgstr "Конфигурация файлын қайта жүктеу."
 
-#: src/input/command.zig:606
+#: src/input/command.zig:607
+msgid "Switch to Dark Appearance"
+msgstr ""
+
+#: src/input/command.zig:608
+msgid "Use a dark application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Switch to Light Appearance"
+msgstr ""
+
+#: src/input/command.zig:613
+msgid "Use a light application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Switch to System Appearance"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Use the system application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:624
 msgid "Close Terminal"
 msgstr "Терминалды жабу"
 
-#: src/input/command.zig:607
+#: src/input/command.zig:625
 msgid "Close the current terminal."
 msgstr "Ағымдағы терминалды жабу."
 
-#: src/input/command.zig:614
+#: src/input/command.zig:632
 msgid "Close the current tab."
 msgstr "Ағымдағы бетті жабу."
 
-#: src/input/command.zig:618
+#: src/input/command.zig:636
 msgid "Close Other Tabs"
 msgstr "Басқа беттерді жабу"
 
-#: src/input/command.zig:619
+#: src/input/command.zig:637
 msgid "Close all tabs in this window except the current one."
 msgstr "Осы терезедегі ағымдағыдан басқа барлық беттерді жабу."
 
-#: src/input/command.zig:623
+#: src/input/command.zig:641
 msgid "Close Tabs to the Right"
 msgstr "Оң жақтағы беттерді жабу"
 
-#: src/input/command.zig:624
+#: src/input/command.zig:642
 msgid "Close all tabs to the right of the current one."
 msgstr "Ағымдағы беттің оң жағындағы барлық беттерді жабу."
 
-#: src/input/command.zig:631
+#: src/input/command.zig:649
 msgid "Close the current window."
 msgstr "Ағымдағы терезені жабу."
 
-#: src/input/command.zig:636
+#: src/input/command.zig:654
 msgid "Close All Windows"
 msgstr "Барлық терезелерді жабу"
 
-#: src/input/command.zig:637
+#: src/input/command.zig:655
 msgid "Close all windows."
 msgstr "Барлық терезелерді жабу."
 
-#: src/input/command.zig:642
+#: src/input/command.zig:660
 msgid "Toggle Maximize"
 msgstr "Жаюды іске қосу/сөндіру"
 
-#: src/input/command.zig:643
+#: src/input/command.zig:661
 msgid "Toggle the maximized state of the current window."
 msgstr "Ағымдағы терезенің жайылған күйін іске қосу немесе сөндіру."
 
-#: src/input/command.zig:648
+#: src/input/command.zig:666
 msgid "Toggle Fullscreen"
 msgstr "Толық экранды іске қосу/сөндіру"
 
-#: src/input/command.zig:649
+#: src/input/command.zig:667
 msgid "Toggle the fullscreen state of the current window."
 msgstr "Ағымдағы терезенің толық экран күйін іске қосу немесе сөндіру."
 
-#: src/input/command.zig:654
+#: src/input/command.zig:672
 msgid "Toggle Window Decorations"
 msgstr "Терезе безендірулерін іске қосу/сөндіру"
 
-#: src/input/command.zig:655
+#: src/input/command.zig:673
 msgid "Toggle the window decorations."
 msgstr "Терезе безендірулерін іске қосу немесе сөндіру."
 
-#: src/input/command.zig:660
+#: src/input/command.zig:678
 msgid "Toggle Float on Top"
 msgstr "Үстінде қалқып тұруды іске қосу/сөндіру"
 
-#: src/input/command.zig:661
+#: src/input/command.zig:679
 msgid "Toggle the float on top state of the current window."
 msgstr "Ағымдағы терезенің үстінде қалқып тұру күйін іске қосу немесе сөндіру."
 
-#: src/input/command.zig:666
+#: src/input/command.zig:684
 msgid "Toggle Secure Input"
 msgstr "Қауіпсіз енгізуді іске қосу/сөндіру"
 
-#: src/input/command.zig:667
+#: src/input/command.zig:685
 msgid "Toggle secure input mode."
 msgstr "Қауіпсіз енгізу режимін іске қосу немесе сөндіру."
 
-#: src/input/command.zig:672
+#: src/input/command.zig:690
 msgid "Toggle Mouse Reporting"
 msgstr "Тышқан туралы хабарлауды іске қосу/сөндіру"
 
-#: src/input/command.zig:673
+#: src/input/command.zig:691
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr ""
 "Тышқан оқиғалары терминал қолданбаларына хабарлануын іске қосу немесе "
 "сөндіру."
 
-#: src/input/command.zig:678
+#: src/input/command.zig:696
 msgid "Toggle Background Opacity"
 msgstr "Фон мөлдірсіздігін іске қосу/сөндіру"
 
-#: src/input/command.zig:679
+#: src/input/command.zig:697
 msgid "Toggle the background opacity of a window that started transparent."
 msgstr ""
 "Мөлдір күйде іске қосылған терезенің фон мөлдірсіздігін іске қосу немесе "
 "сөндіру."
 
-#: src/input/command.zig:684
+#: src/input/command.zig:702
 msgid "Check for Updates"
 msgstr "Жаңартуларды тексеру"
 
-#: src/input/command.zig:685
+#: src/input/command.zig:703
 msgid "Check for updates to the application."
 msgstr "Қолданба жаңартуларын тексеру."
 
-#: src/input/command.zig:690
+#: src/input/command.zig:708
 msgid "Undo"
 msgstr "Болдырмау"
 
-#: src/input/command.zig:691
+#: src/input/command.zig:709
 msgid "Undo the last action."
 msgstr "Соңғы әрекетті болдырмау."
 
-#: src/input/command.zig:696
+#: src/input/command.zig:714
 msgid "Redo"
 msgstr "Қайталау"
 
-#: src/input/command.zig:697
+#: src/input/command.zig:715
 msgid "Redo the last undone action."
 msgstr "Соңғы болдырылмаған әрекетті қайталау."
 
-#: src/input/command.zig:703
+#: src/input/command.zig:721
 msgid "Quit the application."
 msgstr "Қолданбадан шығу."
 
-#: src/input/command.zig:708
+#: src/input/command.zig:726
 msgid "Ghostty"
 msgstr "Ghostty"
 
-#: src/input/command.zig:709
+#: src/input/command.zig:727
 msgid "Put a little Ghostty in your terminal."
 msgstr "Терминалыңызға аздап Ghostty қосыңыз."

--- a/po/ko_KR.po
+++ b/po/ko_KR.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-09-10 10:50-0400\n"
 "PO-Revision-Date: 2026-08-14 23:43+0900\n"
 "Last-Translator: dobbylee <leekw1245@gmail.com>\n"
 "Language-Team: Korean <translation-team-ko@googlegroups.com>\n"
@@ -50,7 +50,7 @@ msgstr "이 창을 다시 보려면 설정을 다시 불러오세요"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2263
+#: src/apprt/gtk/class/application.zig:2296
 msgid "Cancel"
 msgstr "취소"
 
@@ -192,7 +192,7 @@ msgid "New Tab"
 msgstr "새 탭"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:242
-#: src/input/command.zig:613
+#: src/input/command.zig:631
 msgid "Close Tab"
 msgstr "탭 닫기"
 
@@ -210,7 +210,7 @@ msgid "New Window"
 msgstr "새 창"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:416 src/apprt/gtk/ui/1.5/window.blp:225
-#: src/input/command.zig:630
+#: src/input/command.zig:648
 msgid "Close Window"
 msgstr "창 닫기"
 
@@ -254,11 +254,11 @@ msgstr "명령 팔레트"
 msgid "Terminal Inspector"
 msgstr "터미널 인스펙터"
 
-#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1991
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1997
 msgid "About Ghostty"
 msgstr "Ghostty 정보"
 
-#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:702
+#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:720
 msgid "Quit"
 msgstr "종료"
 
@@ -266,27 +266,27 @@ msgstr "종료"
 msgid "Execute a command…"
 msgstr "명령을 실행하세요…"
 
-#: src/apprt/gtk/class/application.zig:1767
+#: src/apprt/gtk/class/application.zig:1779
 msgid "The keybind was revoked by the system."
 msgstr "시스템에서 단축키 등록을 취소했습니다."
 
-#: src/apprt/gtk/class/application.zig:1769
+#: src/apprt/gtk/class/application.zig:1781
 msgid "The keybind was denied by the system."
 msgstr "시스템에서 단축키 등록을 거부했습니다."
 
-#: src/apprt/gtk/class/application.zig:1780
+#: src/apprt/gtk/class/application.zig:1792
 msgid "Global keybind unavailable"
 msgstr "전역 단축키를 사용할 수 없음"
 
-#: src/apprt/gtk/class/application.zig:2259
+#: src/apprt/gtk/class/application.zig:2292
 msgid "Export Terminal IO Events"
 msgstr "터미널 입출력 이벤트 내보내기"
 
-#: src/apprt/gtk/class/application.zig:2262
+#: src/apprt/gtk/class/application.zig:2295
 msgid "Export"
 msgstr "내보내기"
 
-#: src/apprt/gtk/class/application.zig:2783
+#: src/apprt/gtk/class/application.zig:2827
 msgid "Editing configuration file"
 msgstr "설정 파일 편집 중"
 
@@ -350,16 +350,16 @@ msgstr "이 창의 모든 터미널 세션이 종료됩니다."
 msgid "The currently running process in this split will be terminated."
 msgstr "이 분할에서 현재 실행 중인 프로세스가 종료됩니다."
 
-#: src/apprt/gtk/class/surface.zig:1181
+#: src/apprt/gtk/class/surface.zig:1194
 msgid "Command Finished"
 msgstr "명령 완료"
 
-#: src/apprt/gtk/class/surface.zig:1182
+#: src/apprt/gtk/class/surface.zig:1195
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "명령 성공"
 
-#: src/apprt/gtk/class/surface.zig:1183
+#: src/apprt/gtk/class/surface.zig:1196
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "명령 실패"
@@ -376,19 +376,19 @@ msgstr "탭 제목 변경"
 msgid "Change Window Title"
 msgstr "창 제목 변경"
 
-#: src/apprt/gtk/class/window.zig:1153
+#: src/apprt/gtk/class/window.zig:1159
 msgid "Reloaded the configuration"
 msgstr "설정값을 다시 불러왔습니다"
 
-#: src/apprt/gtk/class/window.zig:1830
+#: src/apprt/gtk/class/window.zig:1836
 msgid "Copied to clipboard"
 msgstr "클립보드에 복사됨"
 
-#: src/apprt/gtk/class/window.zig:1832
+#: src/apprt/gtk/class/window.zig:1838
 msgid "Cleared clipboard"
 msgstr "클립보드 지워짐"
 
-#: src/apprt/gtk/class/window.zig:1972
+#: src/apprt/gtk/class/window.zig:1978
 msgid "Ghostty Developers"
 msgstr "Ghostty 개발자들"
 
@@ -408,7 +408,8 @@ msgstr "클립보드에 복사"
 msgid ""
 "Copy the selected text to the clipboard in both plain and styled formats."
 msgstr ""
-"선택한 텍스트를 일반 텍스트와 서식 있는 텍스트 형식으로 클립보드에 복사합니다."
+"선택한 텍스트를 일반 텍스트와 서식 있는 텍스트 형식으로 클립보드에 복사합니"
+"다."
 
 #: src/input/command.zig:159
 msgid "Copy Selection as Plain Text to Clipboard"
@@ -451,8 +452,8 @@ msgid ""
 "Copy the terminal title to the clipboard. If the terminal title is not set "
 "this has no effect."
 msgstr ""
-"터미널 제목을 클립보드에 복사합니다. 터미널 제목이 설정되지 않은 경우에는 "
-"아무 작업도 하지 않습니다."
+"터미널 제목을 클립보드에 복사합니다. 터미널 제목이 설정되지 않은 경우에는 아"
+"무 작업도 하지 않습니다."
 
 #: src/input/command.zig:185
 msgid "Paste from Clipboard"
@@ -625,7 +626,9 @@ msgstr "화면을 HTML 형식으로 임시 파일에 저장하고 경로 복사"
 msgid ""
 "Copy the screen contents as HTML to a temporary file and copy the path to "
 "the clipboard."
-msgstr "화면 내용을 HTML 형식으로 임시 파일에 저장하고 파일 경로를 클립보드에 복사합니다."
+msgstr ""
+"화면 내용을 HTML 형식으로 임시 파일에 저장하고 파일 경로를 클립보드에 복사합"
+"니다."
 
 #: src/input/command.zig:313
 msgid "Copy Screen as HTML to Temporary File and Paste Path"
@@ -635,7 +638,8 @@ msgstr "화면을 HTML 형식으로 임시 파일에 저장하고 경로 붙여�
 msgid ""
 "Copy the screen contents as HTML to a temporary file and paste the path to "
 "the file."
-msgstr "화면 내용을 HTML 형식으로 임시 파일에 저장하고 파일 경로를 붙여넣습니다."
+msgstr ""
+"화면 내용을 HTML 형식으로 임시 파일에 저장하고 파일 경로를 붙여넣습니다."
 
 #: src/input/command.zig:321
 msgid "Copy Screen as HTML to Temporary File and Open"
@@ -654,8 +658,8 @@ msgid ""
 "Copy the screen contents as ANSI escape sequences to a temporary file and "
 "copy the path to the clipboard."
 msgstr ""
-"화면 내용을 ANSI 이스케이프 시퀀스로 임시 파일에 저장하고 파일 경로를 "
-"클립보드에 복사합니다."
+"화면 내용을 ANSI 이스케이프 시퀀스로 임시 파일에 저장하고 파일 경로를 클립보"
+"드에 복사합니다."
 
 #: src/input/command.zig:338
 msgid "Copy Screen as ANSI Sequences to Temporary File and Paste Path"
@@ -666,8 +670,8 @@ msgid ""
 "Copy the screen contents as ANSI escape sequences to a temporary file and "
 "paste the path to the file."
 msgstr ""
-"화면 내용을 ANSI 이스케이프 시퀀스로 임시 파일에 저장하고 파일 경로를 "
-"붙여넣습니다."
+"화면 내용을 ANSI 이스케이프 시퀀스로 임시 파일에 저장하고 파일 경로를 붙여넣"
+"습니다."
 
 #: src/input/command.zig:346
 msgid "Copy Screen as ANSI Sequences to Temporary File and Open"
@@ -677,7 +681,8 @@ msgstr "화면을 ANSI 시퀀스로 임시 파일에 저장하고 열기"
 msgid ""
 "Copy the screen contents as ANSI escape sequences to a temporary file and "
 "open it."
-msgstr "화면 내용을 ANSI 이스케이프 시퀀스로 임시 파일에 저장하고 파일을 엽니다."
+msgstr ""
+"화면 내용을 ANSI 이스케이프 시퀀스로 임시 파일에 저장하고 파일을 엽니다."
 
 #: src/input/command.zig:354
 msgid "Copy Selection to Temporary File and Copy Path"
@@ -715,7 +720,9 @@ msgstr "선택 영역을 HTML 형식으로 임시 파일에 저장하고 경로 
 msgid ""
 "Copy the selection contents as HTML to a temporary file and copy the path to "
 "the clipboard."
-msgstr "선택 영역을 HTML 형식으로 임시 파일에 저장하고 파일 경로를 클립보드에 복사합니다."
+msgstr ""
+"선택 영역을 HTML 형식으로 임시 파일에 저장하고 파일 경로를 클립보드에 복사합"
+"니다."
 
 #: src/input/command.zig:381
 msgid "Copy Selection as HTML to Temporary File and Paste Path"
@@ -725,7 +732,8 @@ msgstr "선택 영역을 HTML 형식으로 임시 파일에 저장하고 경로 
 msgid ""
 "Copy the selection contents as HTML to a temporary file and paste the path "
 "to the file."
-msgstr "선택 영역을 HTML 형식으로 임시 파일에 저장하고 파일 경로를 붙여넣습니다."
+msgstr ""
+"선택 영역을 HTML 형식으로 임시 파일에 저장하고 파일 경로를 붙여넣습니다."
 
 #: src/input/command.zig:389
 msgid "Copy Selection as HTML to Temporary File and Open"
@@ -744,8 +752,8 @@ msgid ""
 "Copy the selection contents as ANSI escape sequences to a temporary file and "
 "copy the path to the clipboard."
 msgstr ""
-"선택 영역을 ANSI 이스케이프 시퀀스로 임시 파일에 저장하고 파일 경로를 "
-"클립보드에 복사합니다."
+"선택 영역을 ANSI 이스케이프 시퀀스로 임시 파일에 저장하고 파일 경로를 클립보"
+"드에 복사합니다."
 
 #: src/input/command.zig:406
 msgid "Copy Selection as ANSI Sequences to Temporary File and Paste Path"
@@ -756,8 +764,8 @@ msgid ""
 "Copy the selection contents as ANSI escape sequences to a temporary file and "
 "paste the path to the file."
 msgstr ""
-"선택 영역을 ANSI 이스케이프 시퀀스로 임시 파일에 저장하고 파일 경로를 "
-"붙여넣습니다."
+"선택 영역을 ANSI 이스케이프 시퀀스로 임시 파일에 저장하고 파일 경로를 붙여넣"
+"습니다."
 
 #: src/input/command.zig:414
 msgid "Copy Selection as ANSI Sequences to Temporary File and Open"
@@ -767,7 +775,8 @@ msgstr "선택 영역을 ANSI 시퀀스로 임시 파일에 저장하고 열기"
 msgid ""
 "Copy the selection contents as ANSI escape sequences to a temporary file and "
 "open it."
-msgstr "선택 영역을 ANSI 이스케이프 시퀀스로 임시 파일에 저장하고 파일을 엽니다."
+msgstr ""
+"선택 영역을 ANSI 이스케이프 시퀀스로 임시 파일에 저장하고 파일을 엽니다."
 
 #: src/input/command.zig:422
 msgid "Open a new window."
@@ -981,134 +990,159 @@ msgstr "설정 값 다시 불러오기"
 msgid "Reload the config file."
 msgstr "설정 파일을 다시 불러옵니다."
 
-#: src/input/command.zig:606
+#: src/input/command.zig:607
+msgid "Switch to Dark Appearance"
+msgstr ""
+
+#: src/input/command.zig:608
+msgid "Use a dark application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Switch to Light Appearance"
+msgstr ""
+
+#: src/input/command.zig:613
+msgid "Use a light application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Switch to System Appearance"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Use the system application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:624
 msgid "Close Terminal"
 msgstr "터미널 닫기"
 
-#: src/input/command.zig:607
+#: src/input/command.zig:625
 msgid "Close the current terminal."
 msgstr "현재 터미널을 닫습니다."
 
-#: src/input/command.zig:614
+#: src/input/command.zig:632
 msgid "Close the current tab."
 msgstr "현재 탭을 닫습니다."
 
-#: src/input/command.zig:618
+#: src/input/command.zig:636
 msgid "Close Other Tabs"
 msgstr "다른 탭 닫기"
 
-#: src/input/command.zig:619
+#: src/input/command.zig:637
 msgid "Close all tabs in this window except the current one."
 msgstr "이 창에서 현재 탭을 제외한 모든 탭을 닫습니다."
 
-#: src/input/command.zig:623
+#: src/input/command.zig:641
 msgid "Close Tabs to the Right"
 msgstr "오른쪽 탭 닫기"
 
-#: src/input/command.zig:624
+#: src/input/command.zig:642
 msgid "Close all tabs to the right of the current one."
 msgstr "현재 탭 오른쪽의 모든 탭을 닫습니다."
 
-#: src/input/command.zig:631
+#: src/input/command.zig:649
 msgid "Close the current window."
 msgstr "현재 창을 닫습니다."
 
-#: src/input/command.zig:636
+#: src/input/command.zig:654
 msgid "Close All Windows"
 msgstr "모든 창 닫기"
 
-#: src/input/command.zig:637
+#: src/input/command.zig:655
 msgid "Close all windows."
 msgstr "모든 창을 닫습니다."
 
-#: src/input/command.zig:642
+#: src/input/command.zig:660
 msgid "Toggle Maximize"
 msgstr "창 최대화 전환"
 
-#: src/input/command.zig:643
+#: src/input/command.zig:661
 msgid "Toggle the maximized state of the current window."
 msgstr "현재 창을 최대화하거나 원래 크기로 복원합니다."
 
-#: src/input/command.zig:648
+#: src/input/command.zig:666
 msgid "Toggle Fullscreen"
 msgstr "전체 화면 전환"
 
-#: src/input/command.zig:649
+#: src/input/command.zig:667
 msgid "Toggle the fullscreen state of the current window."
 msgstr "현재 창의 전체 화면 모드를 켜거나 끕니다."
 
-#: src/input/command.zig:654
+#: src/input/command.zig:672
 msgid "Toggle Window Decorations"
 msgstr "창 장식 표시 전환"
 
-#: src/input/command.zig:655
+#: src/input/command.zig:673
 msgid "Toggle the window decorations."
 msgstr "창 장식을 표시하거나 숨깁니다."
 
-#: src/input/command.zig:660
+#: src/input/command.zig:678
 msgid "Toggle Float on Top"
 msgstr "항상 위에 표시 전환"
 
-#: src/input/command.zig:661
+#: src/input/command.zig:679
 msgid "Toggle the float on top state of the current window."
 msgstr "현재 창의 항상 위에 표시 기능을 켜거나 끕니다."
 
-#: src/input/command.zig:666
+#: src/input/command.zig:684
 msgid "Toggle Secure Input"
 msgstr "보안 입력 전환"
 
-#: src/input/command.zig:667
+#: src/input/command.zig:685
 msgid "Toggle secure input mode."
 msgstr "보안 입력 모드를 켜거나 끕니다."
 
-#: src/input/command.zig:672
+#: src/input/command.zig:690
 msgid "Toggle Mouse Reporting"
 msgstr "마우스 이벤트 전달 전환"
 
-#: src/input/command.zig:673
+#: src/input/command.zig:691
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr "터미널 애플리케이션에 마우스 이벤트를 전달하는 기능을 켜거나 끕니다."
 
-#: src/input/command.zig:678
+#: src/input/command.zig:696
 msgid "Toggle Background Opacity"
 msgstr "배경 불투명도 전환"
 
-#: src/input/command.zig:679
+#: src/input/command.zig:697
 msgid "Toggle the background opacity of a window that started transparent."
-msgstr "투명하게 시작된 창의 배경을 불투명하게 표시하거나 원래 투명도로 되돌립니다."
+msgstr ""
+"투명하게 시작된 창의 배경을 불투명하게 표시하거나 원래 투명도로 되돌립니다."
 
-#: src/input/command.zig:684
+#: src/input/command.zig:702
 msgid "Check for Updates"
 msgstr "업데이트 확인"
 
-#: src/input/command.zig:685
+#: src/input/command.zig:703
 msgid "Check for updates to the application."
 msgstr "애플리케이션의 업데이트를 확인합니다."
 
-#: src/input/command.zig:690
+#: src/input/command.zig:708
 msgid "Undo"
 msgstr "실행 취소"
 
-#: src/input/command.zig:691
+#: src/input/command.zig:709
 msgid "Undo the last action."
 msgstr "마지막 작업을 실행 취소합니다."
 
-#: src/input/command.zig:696
+#: src/input/command.zig:714
 msgid "Redo"
 msgstr "다시 실행"
 
-#: src/input/command.zig:697
+#: src/input/command.zig:715
 msgid "Redo the last undone action."
 msgstr "마지막으로 실행 취소한 작업을 다시 실행합니다."
 
-#: src/input/command.zig:703
+#: src/input/command.zig:721
 msgid "Quit the application."
 msgstr "애플리케이션을 종료합니다."
 
-#: src/input/command.zig:708
+#: src/input/command.zig:726
 msgid "Ghostty"
 msgstr "Ghostty"
 
-#: src/input/command.zig:709
+#: src/input/command.zig:727
 msgid "Put a little Ghostty in your terminal."
 msgstr "터미널에 작은 유령 하나를 입력합니다."

--- a/po/lt.po
+++ b/po/lt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-09-10 10:50-0400\n"
 "PO-Revision-Date: 2026-02-20 12:13+0100\n"
 "Last-Translator: Tadas Lotuzas <tdslot@gmail.com>\n"
 "Language-Team: Language LT\n"
@@ -49,7 +49,7 @@ msgstr "Iš naujo įkelkite konfigūraciją, kad vėl būtų rodoma ši užuomin
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2263
+#: src/apprt/gtk/class/application.zig:2296
 msgid "Cancel"
 msgstr "Atšaukti"
 
@@ -193,7 +193,7 @@ msgid "New Tab"
 msgstr "Nauja kortelė"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:242
-#: src/input/command.zig:613
+#: src/input/command.zig:631
 msgid "Close Tab"
 msgstr "Uždaryti kortelę"
 
@@ -211,7 +211,7 @@ msgid "New Window"
 msgstr "Naujas langas"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:416 src/apprt/gtk/ui/1.5/window.blp:225
-#: src/input/command.zig:630
+#: src/input/command.zig:648
 msgid "Close Window"
 msgstr "Uždaryti langą"
 
@@ -255,11 +255,11 @@ msgstr "Komandų paletė"
 msgid "Terminal Inspector"
 msgstr "Terminalo inspektorius"
 
-#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1991
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1997
 msgid "About Ghostty"
 msgstr "Apie Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:702
+#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:720
 msgid "Quit"
 msgstr "Išeiti"
 
@@ -267,27 +267,27 @@ msgstr "Išeiti"
 msgid "Execute a command…"
 msgstr "Vykdyti komandą…"
 
-#: src/apprt/gtk/class/application.zig:1767
+#: src/apprt/gtk/class/application.zig:1779
 msgid "The keybind was revoked by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1769
+#: src/apprt/gtk/class/application.zig:1781
 msgid "The keybind was denied by the system."
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:1780
+#: src/apprt/gtk/class/application.zig:1792
 msgid "Global keybind unavailable"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2259
+#: src/apprt/gtk/class/application.zig:2292
 msgid "Export Terminal IO Events"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2262
+#: src/apprt/gtk/class/application.zig:2295
 msgid "Export"
 msgstr ""
 
-#: src/apprt/gtk/class/application.zig:2783
+#: src/apprt/gtk/class/application.zig:2827
 msgid "Editing configuration file"
 msgstr ""
 
@@ -351,16 +351,16 @@ msgstr "Visos terminalo sesijos šiame lange bus nutrauktos."
 msgid "The currently running process in this split will be terminated."
 msgstr "Šiuo metu vykdomas procesas šiame padalijime bus nutrauktas."
 
-#: src/apprt/gtk/class/surface.zig:1181
+#: src/apprt/gtk/class/surface.zig:1194
 msgid "Command Finished"
 msgstr "Komanda užbaigta"
 
-#: src/apprt/gtk/class/surface.zig:1182
+#: src/apprt/gtk/class/surface.zig:1195
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Komanda sėkminga"
 
-#: src/apprt/gtk/class/surface.zig:1183
+#: src/apprt/gtk/class/surface.zig:1196
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Komanda nepavyko"
@@ -377,19 +377,19 @@ msgstr "Keisti kortelės pavadinimą"
 msgid "Change Window Title"
 msgstr ""
 
-#: src/apprt/gtk/class/window.zig:1153
+#: src/apprt/gtk/class/window.zig:1159
 msgid "Reloaded the configuration"
 msgstr "Konfigūracija įkelta iš naujo"
 
-#: src/apprt/gtk/class/window.zig:1830
+#: src/apprt/gtk/class/window.zig:1836
 msgid "Copied to clipboard"
 msgstr "Nukopijuota į iškarpinę"
 
-#: src/apprt/gtk/class/window.zig:1832
+#: src/apprt/gtk/class/window.zig:1838
 msgid "Cleared clipboard"
 msgstr "Iškarpinė išvalyta"
 
-#: src/apprt/gtk/class/window.zig:1972
+#: src/apprt/gtk/class/window.zig:1978
 msgid "Ghostty Developers"
 msgstr "Ghostty kūrėjai"
 
@@ -971,134 +971,158 @@ msgstr ""
 msgid "Reload the config file."
 msgstr ""
 
-#: src/input/command.zig:606
-msgid "Close Terminal"
-msgstr ""
-
 #: src/input/command.zig:607
-msgid "Close the current terminal."
+msgid "Switch to Dark Appearance"
 msgstr ""
 
-#: src/input/command.zig:614
-msgid "Close the current tab."
+#: src/input/command.zig:608
+msgid "Use a dark application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Switch to Light Appearance"
+msgstr ""
+
+#: src/input/command.zig:613
+msgid "Use a light application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Switch to System Appearance"
 msgstr ""
 
 #: src/input/command.zig:618
-msgid "Close Other Tabs"
-msgstr ""
-
-#: src/input/command.zig:619
-msgid "Close all tabs in this window except the current one."
-msgstr ""
-
-#: src/input/command.zig:623
-msgid "Close Tabs to the Right"
+msgid "Use the system application appearance for this session."
 msgstr ""
 
 #: src/input/command.zig:624
-msgid "Close all tabs to the right of the current one."
+msgid "Close Terminal"
 msgstr ""
 
-#: src/input/command.zig:631
-msgid "Close the current window."
+#: src/input/command.zig:625
+msgid "Close the current terminal."
+msgstr ""
+
+#: src/input/command.zig:632
+msgid "Close the current tab."
 msgstr ""
 
 #: src/input/command.zig:636
-msgid "Close All Windows"
+msgid "Close Other Tabs"
 msgstr ""
 
 #: src/input/command.zig:637
-msgid "Close all windows."
+msgid "Close all tabs in this window except the current one."
+msgstr ""
+
+#: src/input/command.zig:641
+msgid "Close Tabs to the Right"
 msgstr ""
 
 #: src/input/command.zig:642
-msgid "Toggle Maximize"
-msgstr ""
-
-#: src/input/command.zig:643
-msgid "Toggle the maximized state of the current window."
-msgstr ""
-
-#: src/input/command.zig:648
-msgid "Toggle Fullscreen"
+msgid "Close all tabs to the right of the current one."
 msgstr ""
 
 #: src/input/command.zig:649
-msgid "Toggle the fullscreen state of the current window."
+msgid "Close the current window."
 msgstr ""
 
 #: src/input/command.zig:654
-msgid "Toggle Window Decorations"
+msgid "Close All Windows"
 msgstr ""
 
 #: src/input/command.zig:655
-msgid "Toggle the window decorations."
+msgid "Close all windows."
 msgstr ""
 
 #: src/input/command.zig:660
-msgid "Toggle Float on Top"
+msgid "Toggle Maximize"
 msgstr ""
 
 #: src/input/command.zig:661
-msgid "Toggle the float on top state of the current window."
+msgid "Toggle the maximized state of the current window."
 msgstr ""
 
 #: src/input/command.zig:666
-msgid "Toggle Secure Input"
+msgid "Toggle Fullscreen"
 msgstr ""
 
 #: src/input/command.zig:667
-msgid "Toggle secure input mode."
+msgid "Toggle the fullscreen state of the current window."
 msgstr ""
 
 #: src/input/command.zig:672
-msgid "Toggle Mouse Reporting"
+msgid "Toggle Window Decorations"
 msgstr ""
 
 #: src/input/command.zig:673
-msgid "Toggle whether mouse events are reported to terminal applications."
+msgid "Toggle the window decorations."
 msgstr ""
 
 #: src/input/command.zig:678
-msgid "Toggle Background Opacity"
+msgid "Toggle Float on Top"
 msgstr ""
 
 #: src/input/command.zig:679
-msgid "Toggle the background opacity of a window that started transparent."
+msgid "Toggle the float on top state of the current window."
 msgstr ""
 
 #: src/input/command.zig:684
-msgid "Check for Updates"
+msgid "Toggle Secure Input"
 msgstr ""
 
 #: src/input/command.zig:685
-msgid "Check for updates to the application."
+msgid "Toggle secure input mode."
 msgstr ""
 
 #: src/input/command.zig:690
-msgid "Undo"
+msgid "Toggle Mouse Reporting"
 msgstr ""
 
 #: src/input/command.zig:691
-msgid "Undo the last action."
+msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr ""
 
 #: src/input/command.zig:696
-msgid "Redo"
+msgid "Toggle Background Opacity"
 msgstr ""
 
 #: src/input/command.zig:697
-msgid "Redo the last undone action."
+msgid "Toggle the background opacity of a window that started transparent."
+msgstr ""
+
+#: src/input/command.zig:702
+msgid "Check for Updates"
 msgstr ""
 
 #: src/input/command.zig:703
-msgid "Quit the application."
+msgid "Check for updates to the application."
 msgstr ""
 
 #: src/input/command.zig:708
-msgid "Ghostty"
+msgid "Undo"
 msgstr ""
 
 #: src/input/command.zig:709
+msgid "Undo the last action."
+msgstr ""
+
+#: src/input/command.zig:714
+msgid "Redo"
+msgstr ""
+
+#: src/input/command.zig:715
+msgid "Redo the last undone action."
+msgstr ""
+
+#: src/input/command.zig:721
+msgid "Quit the application."
+msgstr ""
+
+#: src/input/command.zig:726
+msgid "Ghostty"
+msgstr ""
+
+#: src/input/command.zig:727
 msgid "Put a little Ghostty in your terminal."
 msgstr ""

--- a/po/lv.po
+++ b/po/lv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-09-10 10:50-0400\n"
 "PO-Revision-Date: 2026-08-10 17:32+0300\n"
 "Last-Translator: Ēriks Remess <eriks@remess.lv>\n"
 "Language-Team: Latvian\n"
@@ -48,7 +48,7 @@ msgstr "Lai šo uzvedni parādītu vēlreiz, pārlādējiet konfigurāciju"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2263
+#: src/apprt/gtk/class/application.zig:2296
 msgid "Cancel"
 msgstr "Atcelt"
 
@@ -190,7 +190,7 @@ msgid "New Tab"
 msgstr "Jauna cilne"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:242
-#: src/input/command.zig:613
+#: src/input/command.zig:631
 msgid "Close Tab"
 msgstr "Aizvērt cilni"
 
@@ -208,7 +208,7 @@ msgid "New Window"
 msgstr "Jauns logs"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:416 src/apprt/gtk/ui/1.5/window.blp:225
-#: src/input/command.zig:630
+#: src/input/command.zig:648
 msgid "Close Window"
 msgstr "Aizvērt logu"
 
@@ -252,11 +252,11 @@ msgstr "Komandu palete"
 msgid "Terminal Inspector"
 msgstr "Termināļa inspektors"
 
-#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1991
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1997
 msgid "About Ghostty"
 msgstr "Par Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:702
+#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:720
 msgid "Quit"
 msgstr "Iziet"
 
@@ -264,27 +264,27 @@ msgstr "Iziet"
 msgid "Execute a command…"
 msgstr "Izpildīt komandu…"
 
-#: src/apprt/gtk/class/application.zig:1767
+#: src/apprt/gtk/class/application.zig:1779
 msgid "The keybind was revoked by the system."
 msgstr "Sistēma atsauca taustiņu sasaisti."
 
-#: src/apprt/gtk/class/application.zig:1769
+#: src/apprt/gtk/class/application.zig:1781
 msgid "The keybind was denied by the system."
 msgstr "Sistēma noraidīja taustiņu sasaisti."
 
-#: src/apprt/gtk/class/application.zig:1780
+#: src/apprt/gtk/class/application.zig:1792
 msgid "Global keybind unavailable"
 msgstr "Globālā taustiņu sasaiste nav pieejama"
 
-#: src/apprt/gtk/class/application.zig:2259
+#: src/apprt/gtk/class/application.zig:2292
 msgid "Export Terminal IO Events"
 msgstr "Eksportēt termināļa ievades un izvades notikumus"
 
-#: src/apprt/gtk/class/application.zig:2262
+#: src/apprt/gtk/class/application.zig:2295
 msgid "Export"
 msgstr "Eksportēt"
 
-#: src/apprt/gtk/class/application.zig:2783
+#: src/apprt/gtk/class/application.zig:2827
 msgid "Editing configuration file"
 msgstr "Konfigurācijas faila rediģēšana:"
 
@@ -348,16 +348,16 @@ msgstr "Visas termināļa sesijas šajā logā tiks pārtrauktas."
 msgid "The currently running process in this split will be terminated."
 msgstr "Pašlaik palaistais process šajā nodalījumā tiks pārtraukts."
 
-#: src/apprt/gtk/class/surface.zig:1181
+#: src/apprt/gtk/class/surface.zig:1194
 msgid "Command Finished"
 msgstr "Komanda izpildīta"
 
-#: src/apprt/gtk/class/surface.zig:1182
+#: src/apprt/gtk/class/surface.zig:1195
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Komanda izdevās"
 
-#: src/apprt/gtk/class/surface.zig:1183
+#: src/apprt/gtk/class/surface.zig:1196
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Komanda neizdevās"
@@ -374,19 +374,19 @@ msgstr "Mainīt cilnes virsrakstu"
 msgid "Change Window Title"
 msgstr "Mainīt loga virsrakstu"
 
-#: src/apprt/gtk/class/window.zig:1153
+#: src/apprt/gtk/class/window.zig:1159
 msgid "Reloaded the configuration"
 msgstr "Konfigurācija pārlādēta"
 
-#: src/apprt/gtk/class/window.zig:1830
+#: src/apprt/gtk/class/window.zig:1836
 msgid "Copied to clipboard"
 msgstr "Nokopēts starpliktuvē"
 
-#: src/apprt/gtk/class/window.zig:1832
+#: src/apprt/gtk/class/window.zig:1838
 msgid "Cleared clipboard"
 msgstr "Starpliktuve notīrīta"
 
-#: src/apprt/gtk/class/window.zig:1972
+#: src/apprt/gtk/class/window.zig:1978
 msgid "Ghostty Developers"
 msgstr "Ghostty izstrādātāji"
 
@@ -986,136 +986,160 @@ msgstr "Pārlādēt konfigurāciju"
 msgid "Reload the config file."
 msgstr "Pārlādēt konfigurācijas failu."
 
-#: src/input/command.zig:606
+#: src/input/command.zig:607
+msgid "Switch to Dark Appearance"
+msgstr ""
+
+#: src/input/command.zig:608
+msgid "Use a dark application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Switch to Light Appearance"
+msgstr ""
+
+#: src/input/command.zig:613
+msgid "Use a light application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Switch to System Appearance"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Use the system application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:624
 msgid "Close Terminal"
 msgstr "Aizvērt termināli"
 
-#: src/input/command.zig:607
+#: src/input/command.zig:625
 msgid "Close the current terminal."
 msgstr "Aizvērt pašreizējo termināli."
 
-#: src/input/command.zig:614
+#: src/input/command.zig:632
 msgid "Close the current tab."
 msgstr "Aizvērt pašreizējo cilni."
 
-#: src/input/command.zig:618
+#: src/input/command.zig:636
 msgid "Close Other Tabs"
 msgstr "Aizvērt citas cilnes"
 
-#: src/input/command.zig:619
+#: src/input/command.zig:637
 msgid "Close all tabs in this window except the current one."
 msgstr "Aizvērt visas cilnes šajā logā, izņemot pašreizējo."
 
-#: src/input/command.zig:623
+#: src/input/command.zig:641
 msgid "Close Tabs to the Right"
 msgstr "Aizvērt cilnes pa labi"
 
-#: src/input/command.zig:624
+#: src/input/command.zig:642
 msgid "Close all tabs to the right of the current one."
 msgstr "Aizvērt visas cilnes pa labi no pašreizējās."
 
-#: src/input/command.zig:631
+#: src/input/command.zig:649
 msgid "Close the current window."
 msgstr "Aizvērt pašreizējo logu."
 
-#: src/input/command.zig:636
+#: src/input/command.zig:654
 msgid "Close All Windows"
 msgstr "Aizvērt visus logus"
 
-#: src/input/command.zig:637
+#: src/input/command.zig:655
 msgid "Close all windows."
 msgstr "Aizvērt visus logus."
 
-#: src/input/command.zig:642
+#: src/input/command.zig:660
 msgid "Toggle Maximize"
 msgstr "Maksimizēt vai atjaunot logu"
 
-#: src/input/command.zig:643
+#: src/input/command.zig:661
 msgid "Toggle the maximized state of the current window."
 msgstr "Maksimizēt pašreizējo logu vai atjaunot tā iepriekšējo izmēru."
 
-#: src/input/command.zig:648
+#: src/input/command.zig:666
 msgid "Toggle Fullscreen"
 msgstr "Ieslēgt vai izslēgt pilnekrāna režīmu"
 
-#: src/input/command.zig:649
+#: src/input/command.zig:667
 msgid "Toggle the fullscreen state of the current window."
 msgstr "Ieslēgt vai izslēgt pilnekrāna režīmu pašreizējam logam."
 
-#: src/input/command.zig:654
+#: src/input/command.zig:672
 msgid "Toggle Window Decorations"
 msgstr "Parādīt vai paslēpt loga apdari"
 
-#: src/input/command.zig:655
+#: src/input/command.zig:673
 msgid "Toggle the window decorations."
 msgstr "Parādīt vai paslēpt loga apdari."
 
-#: src/input/command.zig:660
+#: src/input/command.zig:678
 msgid "Toggle Float on Top"
 msgstr "Ieslēgt vai izslēgt rādīšanu virspusē"
 
-#: src/input/command.zig:661
+#: src/input/command.zig:679
 msgid "Toggle the float on top state of the current window."
 msgstr "Ieslēgt vai izslēgt pašreizējā loga rādīšanu virs citiem logiem."
 
-#: src/input/command.zig:666
+#: src/input/command.zig:684
 msgid "Toggle Secure Input"
 msgstr "Ieslēgt vai izslēgt drošo ievadi"
 
-#: src/input/command.zig:667
+#: src/input/command.zig:685
 msgid "Toggle secure input mode."
 msgstr "Ieslēgt vai izslēgt drošās ievades režīmu."
 
-#: src/input/command.zig:672
+#: src/input/command.zig:690
 msgid "Toggle Mouse Reporting"
 msgstr "Ieslēgt vai izslēgt peles notikumu nosūtīšanu"
 
-#: src/input/command.zig:673
+#: src/input/command.zig:691
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr "Ieslēgt vai izslēgt peles notikumu nosūtīšanu termināļa lietotnēm."
 
-#: src/input/command.zig:678
+#: src/input/command.zig:696
 msgid "Toggle Background Opacity"
 msgstr "Ieslēgt vai izslēgt fona caurspīdīgumu"
 
-#: src/input/command.zig:679
+#: src/input/command.zig:697
 msgid "Toggle the background opacity of a window that started transparent."
 msgstr ""
 "Ieslēgt vai izslēgt fona caurspīdīgumu logam, kas tika atvērts ar "
 "caurspīdīgu fonu."
 
-#: src/input/command.zig:684
+#: src/input/command.zig:702
 msgid "Check for Updates"
 msgstr "Pārbaudīt atjauninājumus"
 
-#: src/input/command.zig:685
+#: src/input/command.zig:703
 msgid "Check for updates to the application."
 msgstr "Pārbaudīt lietotnes atjauninājumus."
 
-#: src/input/command.zig:690
+#: src/input/command.zig:708
 msgid "Undo"
 msgstr "Atsaukt"
 
-#: src/input/command.zig:691
+#: src/input/command.zig:709
 msgid "Undo the last action."
 msgstr "Atsaukt pēdējo darbību."
 
-#: src/input/command.zig:696
+#: src/input/command.zig:714
 msgid "Redo"
 msgstr "Atkārtot"
 
-#: src/input/command.zig:697
+#: src/input/command.zig:715
 msgid "Redo the last undone action."
 msgstr "Atkārtot pēdējo atsaukto darbību."
 
-#: src/input/command.zig:703
+#: src/input/command.zig:721
 msgid "Quit the application."
 msgstr "Iziet no lietotnes."
 
-#: src/input/command.zig:708
+#: src/input/command.zig:726
 msgid "Ghostty"
 msgstr "Ghostty"
 
-#: src/input/command.zig:709
+#: src/input/command.zig:727
 msgid "Put a little Ghostty in your terminal."
 msgstr "Ielaid mazu Ghostty savā terminālī."

--- a/po/mk.po
+++ b/po/mk.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-09-10 10:50-0400\n"
 "PO-Revision-Date: 2026-08-30 12:23+0200\n"
 "Last-Translator: Andrej Daskalov <andrej.daskalov@gmail.com>\n"
 "Language-Team: Macedonian\n"
@@ -48,7 +48,7 @@ msgstr "Одново вчитај конфигурација за да се по
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2263
+#: src/apprt/gtk/class/application.zig:2296
 msgid "Cancel"
 msgstr "Откажи"
 
@@ -193,7 +193,7 @@ msgid "New Tab"
 msgstr "Ново јазиче"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:242
-#: src/input/command.zig:613
+#: src/input/command.zig:631
 msgid "Close Tab"
 msgstr "Затвори јазиче"
 
@@ -211,7 +211,7 @@ msgid "New Window"
 msgstr "Нов прозор"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:416 src/apprt/gtk/ui/1.5/window.blp:225
-#: src/input/command.zig:630
+#: src/input/command.zig:648
 msgid "Close Window"
 msgstr "Затвори прозор"
 
@@ -255,11 +255,11 @@ msgstr "Командна палета"
 msgid "Terminal Inspector"
 msgstr "Инспектор на терминал"
 
-#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1991
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1997
 msgid "About Ghostty"
 msgstr "За Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:702
+#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:720
 msgid "Quit"
 msgstr "Излез"
 
@@ -267,27 +267,27 @@ msgstr "Излез"
 msgid "Execute a command…"
 msgstr "Изврши команда…"
 
-#: src/apprt/gtk/class/application.zig:1767
+#: src/apprt/gtk/class/application.zig:1779
 msgid "The keybind was revoked by the system."
 msgstr "Системот ја отповика кратенката на тастатурата."
 
-#: src/apprt/gtk/class/application.zig:1769
+#: src/apprt/gtk/class/application.zig:1781
 msgid "The keybind was denied by the system."
 msgstr "Системот ја одби кратенката на тастатурата."
 
-#: src/apprt/gtk/class/application.zig:1780
+#: src/apprt/gtk/class/application.zig:1792
 msgid "Global keybind unavailable"
 msgstr "Глобалната кратенка на тастатурата е недостапна"
 
-#: src/apprt/gtk/class/application.zig:2259
+#: src/apprt/gtk/class/application.zig:2292
 msgid "Export Terminal IO Events"
 msgstr "Извези ги влезно-излезните настани на терминалот"
 
-#: src/apprt/gtk/class/application.zig:2262
+#: src/apprt/gtk/class/application.zig:2295
 msgid "Export"
 msgstr "Извези"
 
-#: src/apprt/gtk/class/application.zig:2783
+#: src/apprt/gtk/class/application.zig:2827
 msgid "Editing configuration file"
 msgstr "Уредување на конфигурациската датотека"
 
@@ -351,16 +351,16 @@ msgstr "Сите сесии во овој прозорец ќе бидат пр�
 msgid "The currently running process in this split will be terminated."
 msgstr "Процесот кој моментално се извршува во оваа поделба ќе биде прекинат."
 
-#: src/apprt/gtk/class/surface.zig:1181
+#: src/apprt/gtk/class/surface.zig:1194
 msgid "Command Finished"
 msgstr "Командата заврши"
 
-#: src/apprt/gtk/class/surface.zig:1182
+#: src/apprt/gtk/class/surface.zig:1195
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Командата успеа"
 
-#: src/apprt/gtk/class/surface.zig:1183
+#: src/apprt/gtk/class/surface.zig:1196
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Командата не успеа"
@@ -377,19 +377,19 @@ msgstr "Промени наслов на јазиче"
 msgid "Change Window Title"
 msgstr "Промени наслов на прозор"
 
-#: src/apprt/gtk/class/window.zig:1153
+#: src/apprt/gtk/class/window.zig:1159
 msgid "Reloaded the configuration"
 msgstr "Конфигурацијата е одново вчитана"
 
-#: src/apprt/gtk/class/window.zig:1830
+#: src/apprt/gtk/class/window.zig:1836
 msgid "Copied to clipboard"
 msgstr "Копирано во привремена меморија"
 
-#: src/apprt/gtk/class/window.zig:1832
+#: src/apprt/gtk/class/window.zig:1838
 msgid "Cleared clipboard"
 msgstr "Исчистена привремена меморија"
 
-#: src/apprt/gtk/class/window.zig:1972
+#: src/apprt/gtk/class/window.zig:1978
 msgid "Ghostty Developers"
 msgstr "Развивачи на Ghostty"
 
@@ -408,8 +408,9 @@ msgstr "Копирај во привремена меморија"
 #: src/input/command.zig:156
 msgid ""
 "Copy the selected text to the clipboard in both plain and styled formats."
-msgstr "Копирај го избраниот текст во привремената меморија и како обичен "
-"и како форматиран текст."
+msgstr ""
+"Копирај го избраниот текст во привремената меморија и како обичен и како "
+"форматиран текст."
 
 #: src/input/command.zig:159
 msgid "Copy Selection as Plain Text to Clipboard"
@@ -425,7 +426,9 @@ msgstr "Копирај го избраното како ANSI-секвенци в
 
 #: src/input/command.zig:164
 msgid "Copy the selected text as ANSI escape sequences to the clipboard."
-msgstr "Копирај го избраниот текст како ANSI-контролни секвенци во привремената меморија."
+msgstr ""
+"Копирај го избраниот текст како ANSI-контролни секвенци во привремената "
+"меморија."
 
 #: src/input/command.zig:167
 msgid "Copy Selection as HTML to Clipboard"
@@ -451,8 +454,9 @@ msgstr "Копирај го насловот на терминалот во пр
 msgid ""
 "Copy the terminal title to the clipboard. If the terminal title is not set "
 "this has no effect."
-msgstr "Копирај го насловот на терминалот во привремената меморија. "
-"Ако насловот не е поставен, ова нема дејство."
+msgstr ""
+"Копирај го насловот на терминалот во привремената меморија. Ако насловот не "
+"е поставен, ова нема дејство."
 
 #: src/input/command.zig:185
 msgid "Paste from Clipboard"
@@ -492,8 +496,9 @@ msgstr "Заврши пребарување"
 
 #: src/input/command.zig:210
 msgid "End the current search if any and hide any GUI elements."
-msgstr "Заврши го тековното пребарување, ако постои, и скриј ги "
-"сите елементи на графичкиот интерфејс."
+msgstr ""
+"Заврши го тековното пребарување, ако постои, и скриј ги сите елементи на "
+"графичкиот интерфејс."
 
 #: src/input/command.zig:215
 msgid "Next Search Result"
@@ -599,8 +604,9 @@ msgstr "Копирај го екранот во привремена датот�
 msgid ""
 "Copy the screen contents to a temporary file and copy the path to the "
 "clipboard."
-msgstr "Копирај ја содржината на екранот во привремена датотека и "
-"копирај ја патеката во привремената меморија."
+msgstr ""
+"Копирај ја содржината на екранот во привремена датотека и копирај ја "
+"патеката во привремената меморија."
 
 #: src/input/command.zig:291
 msgid "Copy Screen to Temporary File and Paste Path"
@@ -609,8 +615,9 @@ msgstr "Копирај го екранот во привремена датот�
 #: src/input/command.zig:292
 msgid ""
 "Copy the screen contents to a temporary file and paste the path to the file."
-msgstr "Копирај ја содржината на екранот во привремена датотека и "
-"вметни ја патеката до датотеката."
+msgstr ""
+"Копирај ја содржината на екранот во привремена датотека и вметни ја патеката "
+"до датотеката."
 
 #: src/input/command.zig:296
 msgid "Copy Screen to Temporary File and Open"
@@ -622,25 +629,29 @@ msgstr "Копирај ја содржината на екранот во при
 
 #: src/input/command.zig:305
 msgid "Copy Screen as HTML to Temporary File and Copy Path"
-msgstr "Копирај го екранот како HTML во привремена датотека и копирај ја патеката"
+msgstr ""
+"Копирај го екранот како HTML во привремена датотека и копирај ја патеката"
 
 #: src/input/command.zig:306
 msgid ""
 "Copy the screen contents as HTML to a temporary file and copy the path to "
 "the clipboard."
-msgstr "Копирај ја содржината на екранот како HTML во привремена датотека и "
-"копирај ја патеката во привремената меморија."
+msgstr ""
+"Копирај ја содржината на екранот како HTML во привремена датотека и копирај "
+"ја патеката во привремената меморија."
 
 #: src/input/command.zig:313
 msgid "Copy Screen as HTML to Temporary File and Paste Path"
-msgstr "Копирај го екранот како HTML во привремена датотека и вметни ја патеката"
+msgstr ""
+"Копирај го екранот како HTML во привремена датотека и вметни ја патеката"
 
 #: src/input/command.zig:314
 msgid ""
 "Copy the screen contents as HTML to a temporary file and paste the path to "
 "the file."
-msgstr "Копирај ја содржината на екранот како HTML во привремена датотека и "
-"вметни ја патеката до датотеката."
+msgstr ""
+"Копирај ја содржината на екранот како HTML во привремена датотека и вметни "
+"ја патеката до датотеката."
 
 #: src/input/command.zig:321
 msgid "Copy Screen as HTML to Temporary File and Open"
@@ -648,40 +659,50 @@ msgstr "Копирај го екранот како HTML во привремен
 
 #: src/input/command.zig:322
 msgid "Copy the screen contents as HTML to a temporary file and open it."
-msgstr "Копирај ја содржината на екранот како HTML во привремена датотека и отвори ја."
+msgstr ""
+"Копирај ја содржината на екранот како HTML во привремена датотека и отвори "
+"ја."
 
 #: src/input/command.zig:330
 msgid "Copy Screen as ANSI Sequences to Temporary File and Copy Path"
-msgstr "Копирај го екранот како ANSI-секвенци во привремена датотека и копирај ја патеката"
+msgstr ""
+"Копирај го екранот како ANSI-секвенци во привремена датотека и копирај ја "
+"патеката"
 
 #: src/input/command.zig:331
 msgid ""
 "Copy the screen contents as ANSI escape sequences to a temporary file and "
 "copy the path to the clipboard."
-msgstr "Копирај ја содржината на екранот како ANSI-контролни секвенци во "
-"привремена датотека и копирај ја патеката во привремената меморија."
+msgstr ""
+"Копирај ја содржината на екранот како ANSI-контролни секвенци во привремена "
+"датотека и копирај ја патеката во привремената меморија."
 
 #: src/input/command.zig:338
 msgid "Copy Screen as ANSI Sequences to Temporary File and Paste Path"
-msgstr "Копирај го екранот како ANSI-секвенци во привремена датотека и вметни ја патеката"
+msgstr ""
+"Копирај го екранот како ANSI-секвенци во привремена датотека и вметни ја "
+"патеката"
 
 #: src/input/command.zig:339
 msgid ""
 "Copy the screen contents as ANSI escape sequences to a temporary file and "
 "paste the path to the file."
-msgstr "Копирај ја содржината на екранот како ANSI-контролни секвенци во "
-"привремена датотека и вметни ја патеката до датотеката."
+msgstr ""
+"Копирај ја содржината на екранот како ANSI-контролни секвенци во привремена "
+"датотека и вметни ја патеката до датотеката."
 
 #: src/input/command.zig:346
 msgid "Copy Screen as ANSI Sequences to Temporary File and Open"
-msgstr "Копирај го екранот како ANSI-секвенци во привремена датотека и отвори ја"
+msgstr ""
+"Копирај го екранот како ANSI-секвенци во привремена датотека и отвори ја"
 
 #: src/input/command.zig:347
 msgid ""
 "Copy the screen contents as ANSI escape sequences to a temporary file and "
 "open it."
-msgstr "Копирај ја содржината на екранот како ANSI-контролни секвенци "
-"во привремена датотека и отвори ја."
+msgstr ""
+"Копирај ја содржината на екранот како ANSI-контролни секвенци во привремена "
+"датотека и отвори ја."
 
 #: src/input/command.zig:354
 msgid "Copy Selection to Temporary File and Copy Path"
@@ -691,8 +712,9 @@ msgstr "Копирај го избраното во привремена дат�
 msgid ""
 "Copy the selection contents to a temporary file and copy the path to the "
 "clipboard."
-msgstr "Копирај ја избраната содржина во привремена датотека и копирај ја "
-"патеката во привремената меморија."
+msgstr ""
+"Копирај ја избраната содржина во привремена датотека и копирај ја патеката "
+"во привремената меморија."
 
 #: src/input/command.zig:359
 msgid "Copy Selection to Temporary File and Paste Path"
@@ -702,8 +724,9 @@ msgstr "Копирај го избраното во привремена дат�
 msgid ""
 "Copy the selection contents to a temporary file and paste the path to the "
 "file."
-msgstr "Копирај ја избраната содржина во привремена датотека и вметни ја "
-"патеката до датотеката."
+msgstr ""
+"Копирај ја избраната содржина во привремена датотека и вметни ја патеката до "
+"датотеката."
 
 #: src/input/command.zig:364
 msgid "Copy Selection to Temporary File and Open"
@@ -715,25 +738,29 @@ msgstr "Копирај ја избраната содржина во привр�
 
 #: src/input/command.zig:373
 msgid "Copy Selection as HTML to Temporary File and Copy Path"
-msgstr "Копирај го избраното како HTML во привремена датотека и копирај ја патеката"
+msgstr ""
+"Копирај го избраното како HTML во привремена датотека и копирај ја патеката"
 
 #: src/input/command.zig:374
 msgid ""
 "Copy the selection contents as HTML to a temporary file and copy the path to "
 "the clipboard."
-msgstr "Копирај ја избраната содржина како HTML во привремена датотека и "
-"копирај ја патеката во привремената меморија."
+msgstr ""
+"Копирај ја избраната содржина како HTML во привремена датотека и копирај ја "
+"патеката во привремената меморија."
 
 #: src/input/command.zig:381
 msgid "Copy Selection as HTML to Temporary File and Paste Path"
-msgstr "Копирај го избраното како HTML во привремена датотека и вметни ја патеката"
+msgstr ""
+"Копирај го избраното како HTML во привремена датотека и вметни ја патеката"
 
 #: src/input/command.zig:382
 msgid ""
 "Copy the selection contents as HTML to a temporary file and paste the path "
 "to the file."
-msgstr "Копирај ја избраната содржина како HTML во привремена датотека и "
-"вметни ја патеката до датотеката."
+msgstr ""
+"Копирај ја избраната содржина како HTML во привремена датотека и вметни ја "
+"патеката до датотеката."
 
 #: src/input/command.zig:389
 msgid "Copy Selection as HTML to Temporary File and Open"
@@ -741,41 +768,48 @@ msgstr "Копирај го избраното како HTML во приврем
 
 #: src/input/command.zig:390
 msgid "Copy the selection contents as HTML to a temporary file and open it."
-msgstr "Копирај ја избраната содржина како HTML во привремена датотека и отвори ја."
+msgstr ""
+"Копирај ја избраната содржина како HTML во привремена датотека и отвори ја."
 
 #: src/input/command.zig:398
 msgid "Copy Selection as ANSI Sequences to Temporary File and Copy Path"
-msgstr "Копирај го избраното како ANSI-секвенци во привремена датотека и копирај ја патеката"
+msgstr ""
+"Копирај го избраното како ANSI-секвенци во привремена датотека и копирај ја "
+"патеката"
 
 #: src/input/command.zig:399
 msgid ""
 "Copy the selection contents as ANSI escape sequences to a temporary file and "
 "copy the path to the clipboard."
-msgstr "Копирај ја избраната содржина како ANSI-контролни секвенци во привремена "
+msgstr ""
+"Копирај ја избраната содржина како ANSI-контролни секвенци во привремена "
 "датотека и копирај ја патеката во привремената меморија."
 
 #: src/input/command.zig:406
 msgid "Copy Selection as ANSI Sequences to Temporary File and Paste Path"
-msgstr "Копирај го избраното како ANSI-секвенци во привремена датотека "
-"и вметни ја патеката"
+msgstr ""
+"Копирај го избраното како ANSI-секвенци во привремена датотека и вметни ја "
+"патеката"
 
 #: src/input/command.zig:407
 msgid ""
 "Copy the selection contents as ANSI escape sequences to a temporary file and "
 "paste the path to the file."
-msgstr "Копирај ја избраната содржина како ANSI-контролни секвенци во привремена "
+msgstr ""
+"Копирај ја избраната содржина како ANSI-контролни секвенци во привремена "
 "датотека и вметни ја патеката до датотеката."
 
 #: src/input/command.zig:414
 msgid "Copy Selection as ANSI Sequences to Temporary File and Open"
-msgstr "Копирај го избраното како ANSI-секвенци во привремена датотека "
-"и отвори ја"
+msgstr ""
+"Копирај го избраното како ANSI-секвенци во привремена датотека и отвори ја"
 
 #: src/input/command.zig:415
 msgid ""
 "Copy the selection contents as ANSI escape sequences to a temporary file and "
 "open it."
-msgstr "Копирај ја избраната содржина како ANSI-контролни секвенци во привремена "
+msgstr ""
+"Копирај ја избраната содржина како ANSI-контролни секвенци во привремена "
 "датотека и отвори ја."
 
 #: src/input/command.zig:422
@@ -972,7 +1006,9 @@ msgstr "Отвори ја конфигурацијата со уредувачо
 
 #: src/input/command.zig:589
 msgid "Open the config file with the OS's default editor."
-msgstr "Отвори ја конфигурациската датотека со стандардниот уредувач на оперативниот систем."
+msgstr ""
+"Отвори ја конфигурациската датотека со стандардниот уредувач на оперативниот "
+"систем."
 
 #: src/input/command.zig:593
 msgid "Open Config in New Terminal Window"
@@ -980,7 +1016,9 @@ msgstr "Отвори ја конфигурацијата во нов терми�
 
 #: src/input/command.zig:594
 msgid "Open the config file in a new window using $EDITOR or $VISUAL."
-msgstr "Отвори ја конфигурациската датотека во нов прозор користејќи $EDITOR или $VISUAL."
+msgstr ""
+"Отвори ја конфигурациската датотека во нов прозор користејќи $EDITOR или "
+"$VISUAL."
 
 #: src/input/command.zig:600
 msgid "Reload Config"
@@ -990,134 +1028,163 @@ msgstr "Одново вчитај ја конфигурацијата"
 msgid "Reload the config file."
 msgstr "Одново вчитај ја конфигурациската датотека."
 
-#: src/input/command.zig:606
+#: src/input/command.zig:607
+msgid "Switch to Dark Appearance"
+msgstr ""
+
+#: src/input/command.zig:608
+msgid "Use a dark application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Switch to Light Appearance"
+msgstr ""
+
+#: src/input/command.zig:613
+msgid "Use a light application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Switch to System Appearance"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Use the system application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:624
 msgid "Close Terminal"
 msgstr "Затвори терминал"
 
-#: src/input/command.zig:607
+#: src/input/command.zig:625
 msgid "Close the current terminal."
 msgstr "Затвори го тековниот терминал."
 
-#: src/input/command.zig:614
+#: src/input/command.zig:632
 msgid "Close the current tab."
 msgstr "Затвори го тековното јазиче."
 
-#: src/input/command.zig:618
+#: src/input/command.zig:636
 msgid "Close Other Tabs"
 msgstr "Затвори ги другите јазичиња"
 
-#: src/input/command.zig:619
+#: src/input/command.zig:637
 msgid "Close all tabs in this window except the current one."
 msgstr "Затвори ги сите јазичиња во овој прозор освен тековното."
 
-#: src/input/command.zig:623
+#: src/input/command.zig:641
 msgid "Close Tabs to the Right"
 msgstr "Затвори ги јазичињата надесно"
 
-#: src/input/command.zig:624
+#: src/input/command.zig:642
 msgid "Close all tabs to the right of the current one."
 msgstr "Затвори ги сите јазичиња десно од тековното."
 
-#: src/input/command.zig:631
+#: src/input/command.zig:649
 msgid "Close the current window."
 msgstr "Затвори го тековниот прозор."
 
-#: src/input/command.zig:636
+#: src/input/command.zig:654
 msgid "Close All Windows"
 msgstr "Затвори ги сите прозорци"
 
-#: src/input/command.zig:637
+#: src/input/command.zig:655
 msgid "Close all windows."
 msgstr "Затвори ги сите прозорци."
 
-#: src/input/command.zig:642
+#: src/input/command.zig:660
 msgid "Toggle Maximize"
 msgstr "Вклучи или исклучи максимизирање"
 
-#: src/input/command.zig:643
+#: src/input/command.zig:661
 msgid "Toggle the maximized state of the current window."
 msgstr "Вклучи или исклучи ја максимизираната состојба на тековниот прозор."
 
-#: src/input/command.zig:648
+#: src/input/command.zig:666
 msgid "Toggle Fullscreen"
 msgstr "Вклучи или исклучи цел екран"
 
-#: src/input/command.zig:649
+#: src/input/command.zig:667
 msgid "Toggle the fullscreen state of the current window."
 msgstr "Вклучи или исклучи го приказот на цел екран за тековниот прозор."
 
-#: src/input/command.zig:654
+#: src/input/command.zig:672
 msgid "Toggle Window Decorations"
 msgstr "Вклучи или исклучи ги декорациите на прозорецот"
 
-#: src/input/command.zig:655
+#: src/input/command.zig:673
 msgid "Toggle the window decorations."
 msgstr "Вклучи или исклучи ги декорациите на прозорецот."
 
-#: src/input/command.zig:660
+#: src/input/command.zig:678
 msgid "Toggle Float on Top"
 msgstr "Вклучи или исклучи лебдење на врвот"
 
-#: src/input/command.zig:661
+#: src/input/command.zig:679
 msgid "Toggle the float on top state of the current window."
-msgstr "Вклучи или исклучи го лебдењето на тековниот прозор над другите прозорци."
+msgstr ""
+"Вклучи или исклучи го лебдењето на тековниот прозор над другите прозорци."
 
-#: src/input/command.zig:666
+#: src/input/command.zig:684
 msgid "Toggle Secure Input"
 msgstr "Вклучи или исклучи безбеден внес"
 
-#: src/input/command.zig:667
+#: src/input/command.zig:685
 msgid "Toggle secure input mode."
 msgstr "Вклучи или исклучи го режимот за безбеден внес."
 
-#: src/input/command.zig:672
+#: src/input/command.zig:690
 msgid "Toggle Mouse Reporting"
 msgstr "Вклучи или исклучи пријавување на глувчето"
 
-#: src/input/command.zig:673
+#: src/input/command.zig:691
 msgid "Toggle whether mouse events are reported to terminal applications."
-msgstr "Вклучи или исклучи дали настаните од глувчето се пријавуваат на терминал апликациите."
+msgstr ""
+"Вклучи или исклучи дали настаните од глувчето се пријавуваат на терминал "
+"апликациите."
 
-#: src/input/command.zig:678
+#: src/input/command.zig:696
 msgid "Toggle Background Opacity"
 msgstr "Вклучи или исклучи непроѕирност на заднината"
 
-#: src/input/command.zig:679
+#: src/input/command.zig:697
 msgid "Toggle the background opacity of a window that started transparent."
-msgstr "Вклучи или исклучи ја непроѕирноста на заднината на прозорец што е отворен како проѕирен."
+msgstr ""
+"Вклучи или исклучи ја непроѕирноста на заднината на прозорец што е отворен "
+"како проѕирен."
 
-#: src/input/command.zig:684
+#: src/input/command.zig:702
 msgid "Check for Updates"
 msgstr "Провери за ажурирања"
 
-#: src/input/command.zig:685
+#: src/input/command.zig:703
 msgid "Check for updates to the application."
 msgstr "Провери дали има ажурирања за апликацијата."
 
-#: src/input/command.zig:690
+#: src/input/command.zig:708
 msgid "Undo"
 msgstr "Врати"
 
-#: src/input/command.zig:691
+#: src/input/command.zig:709
 msgid "Undo the last action."
 msgstr "Врати го последното дејство."
 
-#: src/input/command.zig:696
+#: src/input/command.zig:714
 msgid "Redo"
 msgstr "Повтори"
 
-#: src/input/command.zig:697
+#: src/input/command.zig:715
 msgid "Redo the last undone action."
 msgstr "Повтори го последното вратено дејство."
 
-#: src/input/command.zig:703
+#: src/input/command.zig:721
 msgid "Quit the application."
 msgstr "Прекини ја апликацијата."
 
-#: src/input/command.zig:708
+#: src/input/command.zig:726
 msgid "Ghostty"
 msgstr "Ghostty"
 
-#: src/input/command.zig:709
+#: src/input/command.zig:727
 msgid "Put a little Ghostty in your terminal."
 msgstr "Внеси мал Ghostty во твојот терминал."

--- a/po/nb.po
+++ b/po/nb.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-09-10 10:50-0400\n"
 "PO-Revision-Date: 2026-08-12 21:34+0200\n"
 "Last-Translator: Uzair Aftab <u@uzaaft.me>\n"
 "Language-Team: Norwegian Bokmal <l10n-no@lister.huftis.org>\n"
@@ -51,7 +51,7 @@ msgstr "Last inn konfigurasjonen på nytt for å vise denne meldingen igjen"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2263
+#: src/apprt/gtk/class/application.zig:2296
 msgid "Cancel"
 msgstr "Avbryt"
 
@@ -194,7 +194,7 @@ msgid "New Tab"
 msgstr "Ny fane"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:242
-#: src/input/command.zig:613
+#: src/input/command.zig:631
 msgid "Close Tab"
 msgstr "Lukk fane"
 
@@ -212,7 +212,7 @@ msgid "New Window"
 msgstr "Nytt vindu"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:416 src/apprt/gtk/ui/1.5/window.blp:225
-#: src/input/command.zig:630
+#: src/input/command.zig:648
 msgid "Close Window"
 msgstr "Lukk vindu"
 
@@ -256,11 +256,11 @@ msgstr "Kommandopalett"
 msgid "Terminal Inspector"
 msgstr "Terminalinspektør"
 
-#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1991
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1997
 msgid "About Ghostty"
 msgstr "Om Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:702
+#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:720
 msgid "Quit"
 msgstr "Avslutt"
 
@@ -268,27 +268,27 @@ msgstr "Avslutt"
 msgid "Execute a command…"
 msgstr "Kjør en kommando…"
 
-#: src/apprt/gtk/class/application.zig:1767
+#: src/apprt/gtk/class/application.zig:1779
 msgid "The keybind was revoked by the system."
 msgstr "Tastatursnarveien ble tilbakekalt av systemet."
 
-#: src/apprt/gtk/class/application.zig:1769
+#: src/apprt/gtk/class/application.zig:1781
 msgid "The keybind was denied by the system."
 msgstr "Tastatursnarveien ble avvist av systemet."
 
-#: src/apprt/gtk/class/application.zig:1780
+#: src/apprt/gtk/class/application.zig:1792
 msgid "Global keybind unavailable"
 msgstr "Global tastatursnarvei er utilgjengelig"
 
-#: src/apprt/gtk/class/application.zig:2259
+#: src/apprt/gtk/class/application.zig:2292
 msgid "Export Terminal IO Events"
 msgstr "Eksporter terminalens IO-hendelser"
 
-#: src/apprt/gtk/class/application.zig:2262
+#: src/apprt/gtk/class/application.zig:2295
 msgid "Export"
 msgstr "Eksporter"
 
-#: src/apprt/gtk/class/application.zig:2783
+#: src/apprt/gtk/class/application.zig:2827
 msgid "Editing configuration file"
 msgstr "Redigerer konfigurasjonsfilen"
 
@@ -352,16 +352,16 @@ msgstr "Alle terminaløkter i dette vinduet vil bli avsluttet."
 msgid "The currently running process in this split will be terminated."
 msgstr "Den kjørende prosessen for denne splitten vil bli avsluttet."
 
-#: src/apprt/gtk/class/surface.zig:1181
+#: src/apprt/gtk/class/surface.zig:1194
 msgid "Command Finished"
 msgstr "Kommandoen fullført"
 
-#: src/apprt/gtk/class/surface.zig:1182
+#: src/apprt/gtk/class/surface.zig:1195
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Kommandoen lyktes"
 
-#: src/apprt/gtk/class/surface.zig:1183
+#: src/apprt/gtk/class/surface.zig:1196
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Kommandoen mislyktes"
@@ -378,19 +378,19 @@ msgstr "Endre fanetittel"
 msgid "Change Window Title"
 msgstr "Endre vindustittel"
 
-#: src/apprt/gtk/class/window.zig:1153
+#: src/apprt/gtk/class/window.zig:1159
 msgid "Reloaded the configuration"
 msgstr "Konfigurasjonen ble lastet på nytt"
 
-#: src/apprt/gtk/class/window.zig:1830
+#: src/apprt/gtk/class/window.zig:1836
 msgid "Copied to clipboard"
 msgstr "Kopiert til utklippstavlen"
 
-#: src/apprt/gtk/class/window.zig:1832
+#: src/apprt/gtk/class/window.zig:1838
 msgid "Cleared clipboard"
 msgstr "Utklippstavle tømt"
 
-#: src/apprt/gtk/class/window.zig:1972
+#: src/apprt/gtk/class/window.zig:1978
 msgid "Ghostty Developers"
 msgstr "Ghostty-utviklere"
 
@@ -409,8 +409,7 @@ msgstr "Kopier til utklippstavlen"
 #: src/input/command.zig:156
 msgid ""
 "Copy the selected text to the clipboard in both plain and styled formats."
-msgstr ""
-"Kopier merket tekst til utklippstavlen som formatert- og ren tekst."
+msgstr "Kopier merket tekst til utklippstavlen som formatert- og ren tekst."
 
 #: src/input/command.zig:159
 msgid "Copy Selection as Plain Text to Clipboard"
@@ -426,7 +425,8 @@ msgstr "Kopier markeringen som ANSI-skiftesekvenser til utklippstavlen"
 
 #: src/input/command.zig:164
 msgid "Copy the selected text as ANSI escape sequences to the clipboard."
-msgstr "Kopier den merkede teksten som ANSI-skiftesekvenser til utklippstavlen."
+msgstr ""
+"Kopier den merkede teksten som ANSI-skiftesekvenser til utklippstavlen."
 
 #: src/input/command.zig:167
 msgid "Copy Selection as HTML to Clipboard"
@@ -600,7 +600,9 @@ msgstr "Kopier skjerminnhold til en midlertidig fil og kopier filstien"
 msgid ""
 "Copy the screen contents to a temporary file and copy the path to the "
 "clipboard."
-msgstr "Kopier skjerminnholdet til en midlertidig fil og kopier filstien til utklippstavlen."
+msgstr ""
+"Kopier skjerminnholdet til en midlertidig fil og kopier filstien til "
+"utklippstavlen."
 
 #: src/input/command.zig:291
 msgid "Copy Screen to Temporary File and Paste Path"
@@ -621,23 +623,28 @@ msgstr "Kopier skjerminnholdet til en midlertidig fil og åpne filen."
 
 #: src/input/command.zig:305
 msgid "Copy Screen as HTML to Temporary File and Copy Path"
-msgstr "Kopier skjerminnhold som HTML til en midlertidig fil og kopier filstien"
+msgstr ""
+"Kopier skjerminnhold som HTML til en midlertidig fil og kopier filstien"
 
 #: src/input/command.zig:306
 msgid ""
 "Copy the screen contents as HTML to a temporary file and copy the path to "
 "the clipboard."
-msgstr "Kopier skjerminnholdet som HTML til en midlertidig fil og kopier filstien til utklippstavlen."
+msgstr ""
+"Kopier skjerminnholdet som HTML til en midlertidig fil og kopier filstien "
+"til utklippstavlen."
 
 #: src/input/command.zig:313
 msgid "Copy Screen as HTML to Temporary File and Paste Path"
-msgstr "Kopier skjerminnhold som HTML til en midlertidig fil og lim inn filstien"
+msgstr ""
+"Kopier skjerminnhold som HTML til en midlertidig fil og lim inn filstien"
 
 #: src/input/command.zig:314
 msgid ""
 "Copy the screen contents as HTML to a temporary file and paste the path to "
 "the file."
-msgstr "Kopier skjerminnholdet som HTML til en midlertidig fil og lim inn filstien."
+msgstr ""
+"Kopier skjerminnholdet som HTML til en midlertidig fil og lim inn filstien."
 
 #: src/input/command.zig:321
 msgid "Copy Screen as HTML to Temporary File and Open"
@@ -678,8 +685,8 @@ msgstr ""
 #: src/input/command.zig:346
 msgid "Copy Screen as ANSI Sequences to Temporary File and Open"
 msgstr ""
-"Kopier skjerminnhold som ANSI-skiftesekvenser til en midlertidig fil og "
-"åpne filen"
+"Kopier skjerminnhold som ANSI-skiftesekvenser til en midlertidig fil og åpne "
+"filen"
 
 #: src/input/command.zig:347
 msgid ""
@@ -739,7 +746,8 @@ msgstr "Kopier markeringen som HTML til en midlertidig fil og lim inn filstien"
 msgid ""
 "Copy the selection contents as HTML to a temporary file and paste the path "
 "to the file."
-msgstr "Kopier markeringen som HTML til en midlertidig fil og lim inn filstien."
+msgstr ""
+"Kopier markeringen som HTML til en midlertidig fil og lim inn filstien."
 
 #: src/input/command.zig:389
 msgid "Copy Selection as HTML to Temporary File and Open"
@@ -760,14 +768,14 @@ msgid ""
 "Copy the selection contents as ANSI escape sequences to a temporary file and "
 "copy the path to the clipboard."
 msgstr ""
-"Kopier markeringen som ANSI-skiftesekvenser til en midlertidig fil og "
-"kopier filstien til utklippstavlen."
+"Kopier markeringen som ANSI-skiftesekvenser til en midlertidig fil og kopier "
+"filstien til utklippstavlen."
 
 #: src/input/command.zig:406
 msgid "Copy Selection as ANSI Sequences to Temporary File and Paste Path"
 msgstr ""
-"Kopier markeringen som ANSI-skiftesekvenser til en midlertidig fil og lim inn "
-"filstien"
+"Kopier markeringen som ANSI-skiftesekvenser til en midlertidig fil og lim "
+"inn filstien"
 
 #: src/input/command.zig:407
 msgid ""
@@ -1003,135 +1011,158 @@ msgstr "Last konfigurasjonen på nytt"
 msgid "Reload the config file."
 msgstr "Last konfigurasjonsfilen på nytt."
 
-#: src/input/command.zig:606
+#: src/input/command.zig:607
+msgid "Switch to Dark Appearance"
+msgstr ""
+
+#: src/input/command.zig:608
+msgid "Use a dark application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Switch to Light Appearance"
+msgstr ""
+
+#: src/input/command.zig:613
+msgid "Use a light application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Switch to System Appearance"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Use the system application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:624
 msgid "Close Terminal"
 msgstr "Lukk terminal"
 
-#: src/input/command.zig:607
+#: src/input/command.zig:625
 msgid "Close the current terminal."
 msgstr "Lukk den aktive terminalen."
 
-#: src/input/command.zig:614
+#: src/input/command.zig:632
 msgid "Close the current tab."
 msgstr "Lukk den aktive fanen."
 
-#: src/input/command.zig:618
+#: src/input/command.zig:636
 msgid "Close Other Tabs"
 msgstr "Lukk andre faner"
 
-#: src/input/command.zig:619
+#: src/input/command.zig:637
 msgid "Close all tabs in this window except the current one."
 msgstr "Lukk alle fanene i dette vinduet unntatt den aktive."
 
-#: src/input/command.zig:623
+#: src/input/command.zig:641
 msgid "Close Tabs to the Right"
 msgstr "Lukk faner til høyre"
 
-#: src/input/command.zig:624
+#: src/input/command.zig:642
 msgid "Close all tabs to the right of the current one."
 msgstr "Lukk alle fanene til høyre for den aktive."
 
-#: src/input/command.zig:631
+#: src/input/command.zig:649
 msgid "Close the current window."
 msgstr "Lukk det aktive vinduet."
 
-#: src/input/command.zig:636
+#: src/input/command.zig:654
 msgid "Close All Windows"
 msgstr "Lukk alle vinduer"
 
-#: src/input/command.zig:637
+#: src/input/command.zig:655
 msgid "Close all windows."
 msgstr "Lukk alle vinduer."
 
-#: src/input/command.zig:642
+#: src/input/command.zig:660
 msgid "Toggle Maximize"
 msgstr "Maksimer/gjenopprett vinduet"
 
-#: src/input/command.zig:643
+#: src/input/command.zig:661
 msgid "Toggle the maximized state of the current window."
 msgstr "Maksimer eller gjenopprett det aktive vinduet."
 
-#: src/input/command.zig:648
+#: src/input/command.zig:666
 msgid "Toggle Fullscreen"
 msgstr "Slå fullskjermmodus av/på"
 
-#: src/input/command.zig:649
+#: src/input/command.zig:667
 msgid "Toggle the fullscreen state of the current window."
 msgstr "Slå fullskjermmodus av eller på for det aktive vinduet."
 
-#: src/input/command.zig:654
+#: src/input/command.zig:672
 msgid "Toggle Window Decorations"
 msgstr "Vis/skjul vindusdekorasjoner"
 
-#: src/input/command.zig:655
+#: src/input/command.zig:673
 msgid "Toggle the window decorations."
 msgstr "Vis/skjul vindusdekorasjoner."
 
-#: src/input/command.zig:660
+#: src/input/command.zig:678
 msgid "Toggle Float on Top"
 msgstr "Slå «alltid øverst» av/på"
 
-#: src/input/command.zig:661
+#: src/input/command.zig:679
 msgid "Toggle the float on top state of the current window."
 msgstr "Slå «alltid øverst» av/på for det aktive vinduet."
 
-#: src/input/command.zig:666
+#: src/input/command.zig:684
 msgid "Toggle Secure Input"
 msgstr "Slå sikker tastaturskriving av/på"
 
-#: src/input/command.zig:667
+#: src/input/command.zig:685
 msgid "Toggle secure input mode."
 msgstr "Slå sikker tastaturskriving av/på."
 
-#: src/input/command.zig:672
+#: src/input/command.zig:690
 msgid "Toggle Mouse Reporting"
 msgstr "Aktiver/deaktiver sending av musehendelser"
 
-#: src/input/command.zig:673
+#: src/input/command.zig:691
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr "Aktiver/deaktiver sending av musehendelser til terminalprogrammer."
 
-#: src/input/command.zig:678
+#: src/input/command.zig:696
 msgid "Toggle Background Opacity"
 msgstr "Veksle bakgrunnens opasitet"
 
-#: src/input/command.zig:679
+#: src/input/command.zig:697
 msgid "Toggle the background opacity of a window that started transparent."
-msgstr ""
-"Veksle bakgrunnens opasitet for et vindu som startet gjennomsiktig."
+msgstr "Veksle bakgrunnens opasitet for et vindu som startet gjennomsiktig."
 
-#: src/input/command.zig:684
+#: src/input/command.zig:702
 msgid "Check for Updates"
 msgstr "Se etter oppdateringer"
 
-#: src/input/command.zig:685
+#: src/input/command.zig:703
 msgid "Check for updates to the application."
 msgstr "Se etter programoppdateringer."
 
-#: src/input/command.zig:690
+#: src/input/command.zig:708
 msgid "Undo"
 msgstr "Angre"
 
-#: src/input/command.zig:691
+#: src/input/command.zig:709
 msgid "Undo the last action."
 msgstr "Angre siste handling."
 
-#: src/input/command.zig:696
+#: src/input/command.zig:714
 msgid "Redo"
 msgstr "Gjør om"
 
-#: src/input/command.zig:697
+#: src/input/command.zig:715
 msgid "Redo the last undone action."
 msgstr "Gjør om den siste angrede handlingen."
 
-#: src/input/command.zig:703
+#: src/input/command.zig:721
 msgid "Quit the application."
 msgstr "Avslutt programmet."
 
-#: src/input/command.zig:708
+#: src/input/command.zig:726
 msgid "Ghostty"
 msgstr "Ghostty"
 
-#: src/input/command.zig:709
+#: src/input/command.zig:727
 msgid "Put a little Ghostty in your terminal."
 msgstr "Legg en liten Ghostty i terminalen din."

--- a/po/nl.po
+++ b/po/nl.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-09-10 10:50-0400\n"
 "PO-Revision-Date: 2026-08-14 18:30+0200\n"
 "Last-Translator: Kris van der Ven <306806+kjvdven@users.noreply.github.com>\n"
 "Language-Team: Dutch <vertaling@vrijschrift.org>\n"
@@ -50,7 +50,7 @@ msgstr "Herlaad de configuratie om deze prompt opnieuw weer te geven"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2263
+#: src/apprt/gtk/class/application.zig:2296
 msgid "Cancel"
 msgstr "Annuleren"
 
@@ -195,7 +195,7 @@ msgid "New Tab"
 msgstr "Nieuw tabblad"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:242
-#: src/input/command.zig:613
+#: src/input/command.zig:631
 msgid "Close Tab"
 msgstr "Sluit tabblad"
 
@@ -213,7 +213,7 @@ msgid "New Window"
 msgstr "Nieuw venster"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:416 src/apprt/gtk/ui/1.5/window.blp:225
-#: src/input/command.zig:630
+#: src/input/command.zig:648
 msgid "Close Window"
 msgstr "Sluit venster"
 
@@ -257,11 +257,11 @@ msgstr "Opdrachtpalet"
 msgid "Terminal Inspector"
 msgstr "Terminalinspecteur"
 
-#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1991
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1997
 msgid "About Ghostty"
 msgstr "Over Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:702
+#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:720
 msgid "Quit"
 msgstr "Afsluiten"
 
@@ -269,27 +269,27 @@ msgstr "Afsluiten"
 msgid "Execute a command…"
 msgstr "Voer een commando uit…"
 
-#: src/apprt/gtk/class/application.zig:1767
+#: src/apprt/gtk/class/application.zig:1779
 msgid "The keybind was revoked by the system."
 msgstr "De sneltoets is door het systeem ingetrokken."
 
-#: src/apprt/gtk/class/application.zig:1769
+#: src/apprt/gtk/class/application.zig:1781
 msgid "The keybind was denied by the system."
 msgstr "De sneltoets is door het systeem geweigerd."
 
-#: src/apprt/gtk/class/application.zig:1780
+#: src/apprt/gtk/class/application.zig:1792
 msgid "Global keybind unavailable"
 msgstr "Globale sneltoets niet beschikbaar"
 
-#: src/apprt/gtk/class/application.zig:2259
+#: src/apprt/gtk/class/application.zig:2292
 msgid "Export Terminal IO Events"
 msgstr "Terminal-IO-gebeurtenissen exporteren"
 
-#: src/apprt/gtk/class/application.zig:2262
+#: src/apprt/gtk/class/application.zig:2295
 msgid "Export"
 msgstr "Exporteren"
 
-#: src/apprt/gtk/class/application.zig:2783
+#: src/apprt/gtk/class/application.zig:2827
 msgid "Editing configuration file"
 msgstr "Configuratiebestand bewerken"
 
@@ -353,16 +353,16 @@ msgstr "Alle terminalsessies binnen dit venster zullen worden beëindigd."
 msgid "The currently running process in this split will be terminated."
 msgstr "Alle processen in deze splitsing zullen worden beëindigd."
 
-#: src/apprt/gtk/class/surface.zig:1181
+#: src/apprt/gtk/class/surface.zig:1194
 msgid "Command Finished"
 msgstr "Commando afgerond"
 
-#: src/apprt/gtk/class/surface.zig:1182
+#: src/apprt/gtk/class/surface.zig:1195
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Commando succesvol afgerond"
 
-#: src/apprt/gtk/class/surface.zig:1183
+#: src/apprt/gtk/class/surface.zig:1196
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Commando onsuccesvol afgerond"
@@ -379,19 +379,19 @@ msgstr "Wijzig tabbladtitel"
 msgid "Change Window Title"
 msgstr "Venstertitel wijzigen"
 
-#: src/apprt/gtk/class/window.zig:1153
+#: src/apprt/gtk/class/window.zig:1159
 msgid "Reloaded the configuration"
 msgstr "De configuratie is herladen"
 
-#: src/apprt/gtk/class/window.zig:1830
+#: src/apprt/gtk/class/window.zig:1836
 msgid "Copied to clipboard"
 msgstr "Gekopieerd naar klembord"
 
-#: src/apprt/gtk/class/window.zig:1832
+#: src/apprt/gtk/class/window.zig:1838
 msgid "Cleared clipboard"
 msgstr "Klembord geleegd"
 
-#: src/apprt/gtk/class/window.zig:1972
+#: src/apprt/gtk/class/window.zig:1978
 msgid "Ghostty Developers"
 msgstr "Ghostty-ontwikkelaars"
 
@@ -1016,138 +1016,162 @@ msgstr "Herlaad configuratie"
 msgid "Reload the config file."
 msgstr "Herlaad het configuratiebestand."
 
-#: src/input/command.zig:606
+#: src/input/command.zig:607
+msgid "Switch to Dark Appearance"
+msgstr ""
+
+#: src/input/command.zig:608
+msgid "Use a dark application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Switch to Light Appearance"
+msgstr ""
+
+#: src/input/command.zig:613
+msgid "Use a light application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Switch to System Appearance"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Use the system application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:624
 msgid "Close Terminal"
 msgstr "Sluit terminal"
 
-#: src/input/command.zig:607
+#: src/input/command.zig:625
 msgid "Close the current terminal."
 msgstr "Sluit de huidige terminal."
 
-#: src/input/command.zig:614
+#: src/input/command.zig:632
 msgid "Close the current tab."
 msgstr "Sluit het huidige tabblad."
 
-#: src/input/command.zig:618
+#: src/input/command.zig:636
 msgid "Close Other Tabs"
 msgstr "Sluit andere tabbladen"
 
-#: src/input/command.zig:619
+#: src/input/command.zig:637
 msgid "Close all tabs in this window except the current one."
 msgstr "Sluit alle tabbladen in dit venster behalve het huidige."
 
-#: src/input/command.zig:623
+#: src/input/command.zig:641
 msgid "Close Tabs to the Right"
 msgstr "Sluit tabbladen aan de rechterkant"
 
-#: src/input/command.zig:624
+#: src/input/command.zig:642
 msgid "Close all tabs to the right of the current one."
 msgstr "Sluit alle tabbladen rechts van het huidige."
 
-#: src/input/command.zig:631
+#: src/input/command.zig:649
 msgid "Close the current window."
 msgstr "Sluit het huidige venster."
 
-#: src/input/command.zig:636
+#: src/input/command.zig:654
 msgid "Close All Windows"
 msgstr "Sluit alle vensters"
 
-#: src/input/command.zig:637
+#: src/input/command.zig:655
 msgid "Close all windows."
 msgstr "Sluit alle vensters."
 
-#: src/input/command.zig:642
+#: src/input/command.zig:660
 msgid "Toggle Maximize"
 msgstr "Maximaliseren aan/uit"
 
-#: src/input/command.zig:643
+#: src/input/command.zig:661
 msgid "Toggle the maximized state of the current window."
 msgstr "Schakel het maximaliseren van het huidige venster in of uit."
 
-#: src/input/command.zig:648
+#: src/input/command.zig:666
 msgid "Toggle Fullscreen"
 msgstr "Volledig scherm aan/uit"
 
-#: src/input/command.zig:649
+#: src/input/command.zig:667
 msgid "Toggle the fullscreen state of the current window."
 msgstr "Schakel volledig scherm voor het huidige venster in of uit."
 
-#: src/input/command.zig:654
+#: src/input/command.zig:672
 msgid "Toggle Window Decorations"
 msgstr "Vensterdecoraties aan/uit"
 
-#: src/input/command.zig:655
+#: src/input/command.zig:673
 msgid "Toggle the window decorations."
 msgstr "Schakel de vensterdecoraties in of uit."
 
-#: src/input/command.zig:660
+#: src/input/command.zig:678
 msgid "Toggle Float on Top"
 msgstr "Altijd op voorgrond aan/uit"
 
-#: src/input/command.zig:661
+#: src/input/command.zig:679
 msgid "Toggle the float on top state of the current window."
 msgstr "Schakel altijd-op-voorgrond voor het huidige venster in of uit."
 
-#: src/input/command.zig:666
+#: src/input/command.zig:684
 msgid "Toggle Secure Input"
 msgstr "Veilige invoer aan/uit"
 
-#: src/input/command.zig:667
+#: src/input/command.zig:685
 msgid "Toggle secure input mode."
 msgstr "Schakel de veilige-invoermodus in of uit."
 
-#: src/input/command.zig:672
+#: src/input/command.zig:690
 msgid "Toggle Mouse Reporting"
 msgstr "Muisrapportage aan/uit"
 
-#: src/input/command.zig:673
+#: src/input/command.zig:691
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr ""
 "Schakel het doorgeven van muisgebeurtenissen aan terminalapplicaties in of "
 "uit."
 
-#: src/input/command.zig:678
+#: src/input/command.zig:696
 msgid "Toggle Background Opacity"
 msgstr "Achtergrondtransparantie aan/uit"
 
-#: src/input/command.zig:679
+#: src/input/command.zig:697
 msgid "Toggle the background opacity of a window that started transparent."
 msgstr ""
 "Schakel de achtergrondtransparantie in of uit voor een venster dat "
 "transparant is gestart."
 
-#: src/input/command.zig:684
+#: src/input/command.zig:702
 msgid "Check for Updates"
 msgstr "Controleer op updates"
 
-#: src/input/command.zig:685
+#: src/input/command.zig:703
 msgid "Check for updates to the application."
 msgstr "Controleer of er updates voor de applicatie zijn."
 
-#: src/input/command.zig:690
+#: src/input/command.zig:708
 msgid "Undo"
 msgstr "Ongedaan maken"
 
-#: src/input/command.zig:691
+#: src/input/command.zig:709
 msgid "Undo the last action."
 msgstr "Maak de laatste actie ongedaan."
 
-#: src/input/command.zig:696
+#: src/input/command.zig:714
 msgid "Redo"
 msgstr "Opnieuw uitvoeren"
 
-#: src/input/command.zig:697
+#: src/input/command.zig:715
 msgid "Redo the last undone action."
 msgstr "Voer de laatst ongedaan gemaakte actie opnieuw uit."
 
-#: src/input/command.zig:703
+#: src/input/command.zig:721
 msgid "Quit the application."
 msgstr "Sluit de applicatie af."
 
-#: src/input/command.zig:708
+#: src/input/command.zig:726
 msgid "Ghostty"
 msgstr "Ghostty"
 
-#: src/input/command.zig:709
+#: src/input/command.zig:727
 msgid "Put a little Ghostty in your terminal."
 msgstr "Een beetje Ghostty in je terminal."

--- a/po/pl.po
+++ b/po/pl.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-09-10 10:50-0400\n"
 "PO-Revision-Date: 2026-08-13 21:08+0100\n"
 "Last-Translator: trag1c <dev@jakubr.me>\n"
 "Language-Team: Polish <translation-team-pl@lists.sourceforge.net>\n"
@@ -51,7 +51,7 @@ msgstr "Przeładuj konfigurację, by ponownie wyświetlić ten komunikat"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2263
+#: src/apprt/gtk/class/application.zig:2296
 msgid "Cancel"
 msgstr "Anuluj"
 
@@ -194,7 +194,7 @@ msgid "New Tab"
 msgstr "Nowa karta"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:242
-#: src/input/command.zig:613
+#: src/input/command.zig:631
 msgid "Close Tab"
 msgstr "Zamknij kartę"
 
@@ -212,7 +212,7 @@ msgid "New Window"
 msgstr "Nowe okno"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:416 src/apprt/gtk/ui/1.5/window.blp:225
-#: src/input/command.zig:630
+#: src/input/command.zig:648
 msgid "Close Window"
 msgstr "Zamknij okno"
 
@@ -256,11 +256,11 @@ msgstr "Paleta komend"
 msgid "Terminal Inspector"
 msgstr "Inspektor terminala"
 
-#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1991
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1997
 msgid "About Ghostty"
 msgstr "O Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:702
+#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:720
 msgid "Quit"
 msgstr "Zamknij"
 
@@ -268,27 +268,27 @@ msgstr "Zamknij"
 msgid "Execute a command…"
 msgstr "Wykonaj komendę…"
 
-#: src/apprt/gtk/class/application.zig:1767
+#: src/apprt/gtk/class/application.zig:1779
 msgid "The keybind was revoked by the system."
 msgstr "Skrót klawiszowy został unieważniony przez system."
 
-#: src/apprt/gtk/class/application.zig:1769
+#: src/apprt/gtk/class/application.zig:1781
 msgid "The keybind was denied by the system."
 msgstr "Skrót klawiszowy został odrzucony przez system."
 
-#: src/apprt/gtk/class/application.zig:1780
+#: src/apprt/gtk/class/application.zig:1792
 msgid "Global keybind unavailable"
 msgstr "Globalny skrót klawiszowy jest niedostępny"
 
-#: src/apprt/gtk/class/application.zig:2259
+#: src/apprt/gtk/class/application.zig:2292
 msgid "Export Terminal IO Events"
 msgstr "Wyeksportuj zdarzenia IO terminala"
 
-#: src/apprt/gtk/class/application.zig:2262
+#: src/apprt/gtk/class/application.zig:2295
 msgid "Export"
 msgstr "Eksportuj"
 
-#: src/apprt/gtk/class/application.zig:2783
+#: src/apprt/gtk/class/application.zig:2827
 msgid "Editing configuration file"
 msgstr "Edytowanie pliku konfiguracyjnego"
 
@@ -352,16 +352,16 @@ msgstr "Wszystkie sesje terminala w obecnym oknie zostaną zakończone."
 msgid "The currently running process in this split will be terminated."
 msgstr "Wszystkie trwające procesy w obecnym podziale zostaną zakończone."
 
-#: src/apprt/gtk/class/surface.zig:1181
+#: src/apprt/gtk/class/surface.zig:1194
 msgid "Command Finished"
 msgstr "Komenda zakończona"
 
-#: src/apprt/gtk/class/surface.zig:1182
+#: src/apprt/gtk/class/surface.zig:1195
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Komenda wykonana pomyślnie"
 
-#: src/apprt/gtk/class/surface.zig:1183
+#: src/apprt/gtk/class/surface.zig:1196
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Komenda nie powiodła się"
@@ -378,19 +378,19 @@ msgstr "Zmień tytuł karty"
 msgid "Change Window Title"
 msgstr "Zmień tytuł okna"
 
-#: src/apprt/gtk/class/window.zig:1153
+#: src/apprt/gtk/class/window.zig:1159
 msgid "Reloaded the configuration"
 msgstr "Przeładowano konfigurację"
 
-#: src/apprt/gtk/class/window.zig:1830
+#: src/apprt/gtk/class/window.zig:1836
 msgid "Copied to clipboard"
 msgstr "Skopiowano do schowka"
 
-#: src/apprt/gtk/class/window.zig:1832
+#: src/apprt/gtk/class/window.zig:1838
 msgid "Cleared clipboard"
 msgstr "Wyczyszczono schowek"
 
-#: src/apprt/gtk/class/window.zig:1972
+#: src/apprt/gtk/class/window.zig:1978
 msgid "Ghostty Developers"
 msgstr "Twórcy Ghostty"
 
@@ -410,8 +410,8 @@ msgstr "Skopiuj do schowka"
 msgid ""
 "Copy the selected text to the clipboard in both plain and styled formats."
 msgstr ""
-"Skopiuj zaznaczony tekst do schowka jako zwykły tekst oraz z "
-"zachowaniem formatowania."
+"Skopiuj zaznaczony tekst do schowka jako zwykły tekst oraz z zachowaniem "
+"formatowania."
 
 #: src/input/command.zig:159
 msgid "Copy Selection as Plain Text to Clipboard"
@@ -495,7 +495,8 @@ msgstr "Zakończ wyszukiwanie"
 
 #: src/input/command.zig:210
 msgid "End the current search if any and hide any GUI elements."
-msgstr "Zakończ obecne wyszukiwanie (jeśli trwa) i ukryj wszelkie elementy GUI."
+msgstr ""
+"Zakończ obecne wyszukiwanie (jeśli trwa) i ukryj wszelkie elementy GUI."
 
 #: src/input/command.zig:215
 msgid "Next Search Result"
@@ -602,8 +603,8 @@ msgid ""
 "Copy the screen contents to a temporary file and copy the path to the "
 "clipboard."
 msgstr ""
-"Skopiuj zawartość ekranu do tymczasowego pliku i skopiuj jego ścieżkę "
-"do schowka."
+"Skopiuj zawartość ekranu do tymczasowego pliku i skopiuj jego ścieżkę do "
+"schowka."
 
 #: src/input/command.zig:291
 msgid "Copy Screen to Temporary File and Paste Path"
@@ -612,8 +613,7 @@ msgstr "Skopiuj ekran do tymczasowego pliku i wklej ścieżkę"
 #: src/input/command.zig:292
 msgid ""
 "Copy the screen contents to a temporary file and paste the path to the file."
-msgstr ""
-"Skopiuj zawartość ekranu do tymczasowego pliku i wklej jego ścieżkę."
+msgstr "Skopiuj zawartość ekranu do tymczasowego pliku i wklej jego ścieżkę."
 
 #: src/input/command.zig:296
 msgid "Copy Screen to Temporary File and Open"
@@ -644,7 +644,8 @@ msgid ""
 "Copy the screen contents as HTML to a temporary file and paste the path to "
 "the file."
 msgstr ""
-"Skopiuj zawartość ekranu jako HTML do tymczasowego pliku i wklej jego ścieżkę."
+"Skopiuj zawartość ekranu jako HTML do tymczasowego pliku i wklej jego "
+"ścieżkę."
 
 #: src/input/command.zig:321
 msgid "Copy Screen as HTML to Temporary File and Open"
@@ -663,12 +664,13 @@ msgid ""
 "Copy the screen contents as ANSI escape sequences to a temporary file and "
 "copy the path to the clipboard."
 msgstr ""
-"Skopiuj zawartość ekranu jako sekwencje ucieczki ANSI do tymczasowego pliku i "
-"wklej jego ścieżkę."
+"Skopiuj zawartość ekranu jako sekwencje ucieczki ANSI do tymczasowego pliku "
+"i wklej jego ścieżkę."
 
 #: src/input/command.zig:338
 msgid "Copy Screen as ANSI Sequences to Temporary File and Paste Path"
-msgstr "Skopiuj ekran jako sekwencje ANSI do tymczasowego pliku i wklej ścieżkę"
+msgstr ""
+"Skopiuj ekran jako sekwencje ANSI do tymczasowego pliku i wklej ścieżkę"
 
 #: src/input/command.zig:339
 msgid ""
@@ -1005,134 +1007,158 @@ msgstr "Przeładuj konfigurację"
 msgid "Reload the config file."
 msgstr "Przeładuj plik konfiguracyjny."
 
-#: src/input/command.zig:606
+#: src/input/command.zig:607
+msgid "Switch to Dark Appearance"
+msgstr ""
+
+#: src/input/command.zig:608
+msgid "Use a dark application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Switch to Light Appearance"
+msgstr ""
+
+#: src/input/command.zig:613
+msgid "Use a light application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Switch to System Appearance"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Use the system application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:624
 msgid "Close Terminal"
 msgstr "Zamknij terminal"
 
-#: src/input/command.zig:607
+#: src/input/command.zig:625
 msgid "Close the current terminal."
 msgstr "Zamknij obecny terminal."
 
-#: src/input/command.zig:614
+#: src/input/command.zig:632
 msgid "Close the current tab."
 msgstr "Zamknij obecną kartę."
 
-#: src/input/command.zig:618
+#: src/input/command.zig:636
 msgid "Close Other Tabs"
 msgstr "Zamknij inne karty"
 
-#: src/input/command.zig:619
+#: src/input/command.zig:637
 msgid "Close all tabs in this window except the current one."
 msgstr "Zamknij wszystkie karty w tym oknie poza obecną."
 
-#: src/input/command.zig:623
+#: src/input/command.zig:641
 msgid "Close Tabs to the Right"
 msgstr "Zamknij karty po prawej"
 
-#: src/input/command.zig:624
+#: src/input/command.zig:642
 msgid "Close all tabs to the right of the current one."
 msgstr "Zamknij wszystkie karty po prawej od obecnej."
 
-#: src/input/command.zig:631
+#: src/input/command.zig:649
 msgid "Close the current window."
 msgstr "Zamknij obecne okno."
 
-#: src/input/command.zig:636
+#: src/input/command.zig:654
 msgid "Close All Windows"
 msgstr "Zamknij wszystkie okna"
 
-#: src/input/command.zig:637
+#: src/input/command.zig:655
 msgid "Close all windows."
 msgstr "Zamknij wszystkie okna."
 
-#: src/input/command.zig:642
+#: src/input/command.zig:660
 msgid "Toggle Maximize"
 msgstr "Przełącz maksymalizację"
 
-#: src/input/command.zig:643
+#: src/input/command.zig:661
 msgid "Toggle the maximized state of the current window."
 msgstr "Włącz/wyłącz maksymalizację obecnego okna."
 
-#: src/input/command.zig:648
+#: src/input/command.zig:666
 msgid "Toggle Fullscreen"
 msgstr "Przełącz pełny ekran"
 
-#: src/input/command.zig:649
+#: src/input/command.zig:667
 msgid "Toggle the fullscreen state of the current window."
 msgstr "Przełącz stan pełnego ekranu obecnego okna."
 
-#: src/input/command.zig:654
+#: src/input/command.zig:672
 msgid "Toggle Window Decorations"
 msgstr "Przełącz dekoracje okna"
 
-#: src/input/command.zig:655
+#: src/input/command.zig:673
 msgid "Toggle the window decorations."
 msgstr "Przełącz dekoracje okna."
 
-#: src/input/command.zig:660
+#: src/input/command.zig:678
 msgid "Toggle Float on Top"
 msgstr "Przełącz zawsze na wierzchu"
 
-#: src/input/command.zig:661
+#: src/input/command.zig:679
 msgid "Toggle the float on top state of the current window."
 msgstr "Włącz/wyłącz wyświetlanie obecnego okna zawsze na wierzchu."
 
-#: src/input/command.zig:666
+#: src/input/command.zig:684
 msgid "Toggle Secure Input"
 msgstr "Przełącz bezpieczne wprowadzanie"
 
-#: src/input/command.zig:667
+#: src/input/command.zig:685
 msgid "Toggle secure input mode."
 msgstr "Włącz/wyłącz tryb bezpiecznego wprowadzania."
 
-#: src/input/command.zig:672
+#: src/input/command.zig:690
 msgid "Toggle Mouse Reporting"
 msgstr "Przełącz raportowanie myszy"
 
-#: src/input/command.zig:673
+#: src/input/command.zig:691
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr "Włącz/wyłącz raportowanie zdarzeń myszy do aplikacji terminalowych."
 
-#: src/input/command.zig:678
+#: src/input/command.zig:696
 msgid "Toggle Background Opacity"
 msgstr "Przełącz przezroczystość tła"
 
-#: src/input/command.zig:679
+#: src/input/command.zig:697
 msgid "Toggle the background opacity of a window that started transparent."
 msgstr "Włącz/wyłącz przezroczystość tła w oknie powstałym jako przezroczyste."
 
-#: src/input/command.zig:684
+#: src/input/command.zig:702
 msgid "Check for Updates"
 msgstr "Sprawdź aktualizacje"
 
-#: src/input/command.zig:685
+#: src/input/command.zig:703
 msgid "Check for updates to the application."
 msgstr "Sprawdź dostępność aktualizacji dla aplikacji."
 
-#: src/input/command.zig:690
+#: src/input/command.zig:708
 msgid "Undo"
 msgstr "Cofnij"
 
-#: src/input/command.zig:691
+#: src/input/command.zig:709
 msgid "Undo the last action."
 msgstr "Cofnij ostatnią akcję."
 
-#: src/input/command.zig:696
+#: src/input/command.zig:714
 msgid "Redo"
 msgstr "Powtórz"
 
-#: src/input/command.zig:697
+#: src/input/command.zig:715
 msgid "Redo the last undone action."
 msgstr "Powtórz ostatnią cofniętą akcję."
 
-#: src/input/command.zig:703
+#: src/input/command.zig:721
 msgid "Quit the application."
 msgstr "Wyjdź z aplikacji."
 
-#: src/input/command.zig:708
+#: src/input/command.zig:726
 msgid "Ghostty"
 msgstr "Ghostty"
 
-#: src/input/command.zig:709
+#: src/input/command.zig:727
 msgid "Put a little Ghostty in your terminal."
 msgstr "Umieść małe Ghostty w twoim terminalu."

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-09-10 10:50-0400\n"
 "PO-Revision-Date: 2026-08-17 11:57-0500\n"
 "Last-Translator: Guilherme Tiscoski <github@guilhermetiscoski.com>\n"
 "Language-Team: Brazilian Portuguese <ldpbr-"
@@ -52,7 +52,7 @@ msgstr "Recarregue a configuração para mostrar este aviso novamente"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2263
+#: src/apprt/gtk/class/application.zig:2296
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -196,7 +196,7 @@ msgid "New Tab"
 msgstr "Nova aba"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:242
-#: src/input/command.zig:613
+#: src/input/command.zig:631
 msgid "Close Tab"
 msgstr "Fechar aba"
 
@@ -214,7 +214,7 @@ msgid "New Window"
 msgstr "Nova janela"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:416 src/apprt/gtk/ui/1.5/window.blp:225
-#: src/input/command.zig:630
+#: src/input/command.zig:648
 msgid "Close Window"
 msgstr "Fechar janela"
 
@@ -258,11 +258,11 @@ msgstr "Paleta de comandos"
 msgid "Terminal Inspector"
 msgstr "Inspetor de terminal"
 
-#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1991
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1997
 msgid "About Ghostty"
 msgstr "Sobre o Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:702
+#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:720
 msgid "Quit"
 msgstr "Sair"
 
@@ -270,27 +270,27 @@ msgstr "Sair"
 msgid "Execute a command…"
 msgstr "Executar um comando…"
 
-#: src/apprt/gtk/class/application.zig:1767
+#: src/apprt/gtk/class/application.zig:1779
 msgid "The keybind was revoked by the system."
 msgstr "O atalho de teclado foi revogado pelo sistema."
 
-#: src/apprt/gtk/class/application.zig:1769
+#: src/apprt/gtk/class/application.zig:1781
 msgid "The keybind was denied by the system."
 msgstr "O atalho de teclado foi negado pelo sistema."
 
-#: src/apprt/gtk/class/application.zig:1780
+#: src/apprt/gtk/class/application.zig:1792
 msgid "Global keybind unavailable"
 msgstr "Atalho de teclado global indisponível"
 
-#: src/apprt/gtk/class/application.zig:2259
+#: src/apprt/gtk/class/application.zig:2292
 msgid "Export Terminal IO Events"
 msgstr "Exportar eventos de E/S do terminal"
 
-#: src/apprt/gtk/class/application.zig:2262
+#: src/apprt/gtk/class/application.zig:2295
 msgid "Export"
 msgstr "Exportar"
 
-#: src/apprt/gtk/class/application.zig:2783
+#: src/apprt/gtk/class/application.zig:2827
 msgid "Editing configuration file"
 msgstr "Editando arquivo de configuração"
 
@@ -354,16 +354,16 @@ msgstr "Todas as sessões de terminal nessa janela serão finalizadas."
 msgid "The currently running process in this split will be terminated."
 msgstr "O processo atual rodando nessa divisão será finalizado."
 
-#: src/apprt/gtk/class/surface.zig:1181
+#: src/apprt/gtk/class/surface.zig:1194
 msgid "Command Finished"
 msgstr "Comando finalizado"
 
-#: src/apprt/gtk/class/surface.zig:1182
+#: src/apprt/gtk/class/surface.zig:1195
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Comando bem-sucedido"
 
-#: src/apprt/gtk/class/surface.zig:1183
+#: src/apprt/gtk/class/surface.zig:1196
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Comando falhou"
@@ -380,19 +380,19 @@ msgstr "Mudar título da aba"
 msgid "Change Window Title"
 msgstr "Mudar título da janela"
 
-#: src/apprt/gtk/class/window.zig:1153
+#: src/apprt/gtk/class/window.zig:1159
 msgid "Reloaded the configuration"
 msgstr "Configuração recarregada"
 
-#: src/apprt/gtk/class/window.zig:1830
+#: src/apprt/gtk/class/window.zig:1836
 msgid "Copied to clipboard"
 msgstr "Copiado para a área de transferência"
 
-#: src/apprt/gtk/class/window.zig:1832
+#: src/apprt/gtk/class/window.zig:1838
 msgid "Cleared clipboard"
 msgstr "Área de transferência limpa"
 
-#: src/apprt/gtk/class/window.zig:1972
+#: src/apprt/gtk/class/window.zig:1978
 msgid "Ghostty Developers"
 msgstr "Desenvolvedores do Ghostty"
 
@@ -1019,136 +1019,160 @@ msgstr "Recarregar configuração"
 msgid "Reload the config file."
 msgstr "Recarregar o arquivo de configuração."
 
-#: src/input/command.zig:606
+#: src/input/command.zig:607
+msgid "Switch to Dark Appearance"
+msgstr ""
+
+#: src/input/command.zig:608
+msgid "Use a dark application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Switch to Light Appearance"
+msgstr ""
+
+#: src/input/command.zig:613
+msgid "Use a light application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Switch to System Appearance"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Use the system application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:624
 msgid "Close Terminal"
 msgstr "Fechar terminal"
 
-#: src/input/command.zig:607
+#: src/input/command.zig:625
 msgid "Close the current terminal."
 msgstr "Fechar o terminal atual."
 
-#: src/input/command.zig:614
+#: src/input/command.zig:632
 msgid "Close the current tab."
 msgstr "Fechar a aba atual."
 
-#: src/input/command.zig:618
+#: src/input/command.zig:636
 msgid "Close Other Tabs"
 msgstr "Fechar outras abas"
 
-#: src/input/command.zig:619
+#: src/input/command.zig:637
 msgid "Close all tabs in this window except the current one."
 msgstr "Fechar todas as abas desta janela, exceto a atual."
 
-#: src/input/command.zig:623
+#: src/input/command.zig:641
 msgid "Close Tabs to the Right"
 msgstr "Fechar abas à direita"
 
-#: src/input/command.zig:624
+#: src/input/command.zig:642
 msgid "Close all tabs to the right of the current one."
 msgstr "Fechar todas as abas à direita da atual."
 
-#: src/input/command.zig:631
+#: src/input/command.zig:649
 msgid "Close the current window."
 msgstr "Fechar a janela atual."
 
-#: src/input/command.zig:636
+#: src/input/command.zig:654
 msgid "Close All Windows"
 msgstr "Fechar todas as janelas"
 
-#: src/input/command.zig:637
+#: src/input/command.zig:655
 msgid "Close all windows."
 msgstr "Fechar todas as janelas."
 
-#: src/input/command.zig:642
+#: src/input/command.zig:660
 msgid "Toggle Maximize"
 msgstr "Alternar maximização"
 
-#: src/input/command.zig:643
+#: src/input/command.zig:661
 msgid "Toggle the maximized state of the current window."
 msgstr "Alternar o estado maximizado da janela atual."
 
-#: src/input/command.zig:648
+#: src/input/command.zig:666
 msgid "Toggle Fullscreen"
 msgstr "Alternar tela cheia"
 
-#: src/input/command.zig:649
+#: src/input/command.zig:667
 msgid "Toggle the fullscreen state of the current window."
 msgstr "Alternar o estado de tela cheia da janela atual."
 
-#: src/input/command.zig:654
+#: src/input/command.zig:672
 msgid "Toggle Window Decorations"
 msgstr "Alternar decorações da janela"
 
-#: src/input/command.zig:655
+#: src/input/command.zig:673
 msgid "Toggle the window decorations."
 msgstr "Alternar as decorações da janela."
 
-#: src/input/command.zig:660
+#: src/input/command.zig:678
 msgid "Toggle Float on Top"
 msgstr "Alternar janela sempre no topo"
 
-#: src/input/command.zig:661
+#: src/input/command.zig:679
 msgid "Toggle the float on top state of the current window."
 msgstr "Alternar se a janela atual deve permanecer sempre no topo."
 
-#: src/input/command.zig:666
+#: src/input/command.zig:684
 msgid "Toggle Secure Input"
 msgstr "Alternar entrada segura"
 
-#: src/input/command.zig:667
+#: src/input/command.zig:685
 msgid "Toggle secure input mode."
 msgstr "Alternar o modo de entrada segura."
 
-#: src/input/command.zig:672
+#: src/input/command.zig:690
 msgid "Toggle Mouse Reporting"
 msgstr "Alternar envio de eventos do mouse"
 
-#: src/input/command.zig:673
+#: src/input/command.zig:691
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr "Alternar o envio de eventos do mouse aos aplicativos do terminal."
 
-#: src/input/command.zig:678
+#: src/input/command.zig:696
 msgid "Toggle Background Opacity"
 msgstr "Alternar opacidade do plano de fundo"
 
-#: src/input/command.zig:679
+#: src/input/command.zig:697
 msgid "Toggle the background opacity of a window that started transparent."
 msgstr ""
 "Alternar a opacidade do plano de fundo de uma janela iniciada com "
 "transparência."
 
-#: src/input/command.zig:684
+#: src/input/command.zig:702
 msgid "Check for Updates"
 msgstr "Verificar atualizações"
 
-#: src/input/command.zig:685
+#: src/input/command.zig:703
 msgid "Check for updates to the application."
 msgstr "Verificar se há atualizações para o aplicativo."
 
-#: src/input/command.zig:690
+#: src/input/command.zig:708
 msgid "Undo"
 msgstr "Desfazer"
 
-#: src/input/command.zig:691
+#: src/input/command.zig:709
 msgid "Undo the last action."
 msgstr "Desfazer a última ação."
 
-#: src/input/command.zig:696
+#: src/input/command.zig:714
 msgid "Redo"
 msgstr "Refazer"
 
-#: src/input/command.zig:697
+#: src/input/command.zig:715
 msgid "Redo the last undone action."
 msgstr "Refazer a última ação desfeita."
 
-#: src/input/command.zig:703
+#: src/input/command.zig:721
 msgid "Quit the application."
 msgstr "Sair do aplicativo."
 
-#: src/input/command.zig:708
+#: src/input/command.zig:726
 msgid "Ghostty"
 msgstr "Ghostty"
 
-#: src/input/command.zig:709
+#: src/input/command.zig:727
 msgid "Put a little Ghostty in your terminal."
 msgstr "Colocar um pouco de Ghostty no seu terminal."

--- a/po/ru.po
+++ b/po/ru.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-09-10 10:50-0400\n"
 "PO-Revision-Date: 2026-08-23 12:00+0200\n"
 "Last-Translator: derVedro <dervedro@googlemail.com>\n"
 "Language-Team: Russian\n"
@@ -18,7 +18,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 #: dist/linux/ghostty_nautilus.py:53
 msgid "Open in Ghostty"
@@ -51,7 +52,7 @@ msgstr "Перезагрузите конфигурацию, чтобы снов
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2263
+#: src/apprt/gtk/class/application.zig:2296
 msgid "Cancel"
 msgstr "Отмена"
 
@@ -196,7 +197,7 @@ msgid "New Tab"
 msgstr "Новая вкладка"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:242
-#: src/input/command.zig:613
+#: src/input/command.zig:631
 msgid "Close Tab"
 msgstr "Закрыть вкладку"
 
@@ -214,7 +215,7 @@ msgid "New Window"
 msgstr "Новое окно"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:416 src/apprt/gtk/ui/1.5/window.blp:225
-#: src/input/command.zig:630
+#: src/input/command.zig:648
 msgid "Close Window"
 msgstr "Закрыть окно"
 
@@ -258,11 +259,11 @@ msgstr "Палитра команд"
 msgid "Terminal Inspector"
 msgstr "Инспектор терминала"
 
-#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1991
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1997
 msgid "About Ghostty"
 msgstr "О Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:702
+#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:720
 msgid "Quit"
 msgstr "Выход"
 
@@ -270,27 +271,27 @@ msgstr "Выход"
 msgid "Execute a command…"
 msgstr "Выполнить команду…"
 
-#: src/apprt/gtk/class/application.zig:1767
+#: src/apprt/gtk/class/application.zig:1779
 msgid "The keybind was revoked by the system."
 msgstr "Сочетание клавиш было отозвано системой."
 
-#: src/apprt/gtk/class/application.zig:1769
+#: src/apprt/gtk/class/application.zig:1781
 msgid "The keybind was denied by the system."
 msgstr "Сочетание клавиш было отклонено системой."
 
-#: src/apprt/gtk/class/application.zig:1780
+#: src/apprt/gtk/class/application.zig:1792
 msgid "Global keybind unavailable"
 msgstr "Глобальное сочетание клавиш недоступно"
 
-#: src/apprt/gtk/class/application.zig:2259
+#: src/apprt/gtk/class/application.zig:2292
 msgid "Export Terminal IO Events"
 msgstr "Экспортировать события ввода-вывода терминала"
 
-#: src/apprt/gtk/class/application.zig:2262
+#: src/apprt/gtk/class/application.zig:2295
 msgid "Export"
 msgstr "Экспортировать"
 
-#: src/apprt/gtk/class/application.zig:2783
+#: src/apprt/gtk/class/application.zig:2827
 msgid "Editing configuration file"
 msgstr "Редактирование файла конфигурации"
 
@@ -354,16 +355,16 @@ msgstr "Все сессии терминала в этом окне будут �
 msgid "The currently running process in this split will be terminated."
 msgstr "Процесс, работающий в этой области, будет остановлен."
 
-#: src/apprt/gtk/class/surface.zig:1181
+#: src/apprt/gtk/class/surface.zig:1194
 msgid "Command Finished"
 msgstr "Команда завершилась"
 
-#: src/apprt/gtk/class/surface.zig:1182
+#: src/apprt/gtk/class/surface.zig:1195
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Команда выполнена успешно"
 
-#: src/apprt/gtk/class/surface.zig:1183
+#: src/apprt/gtk/class/surface.zig:1196
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Команда завершилась с ошибкой"
@@ -380,19 +381,19 @@ msgstr "Переименовать вкладку"
 msgid "Change Window Title"
 msgstr "Переименовать окно"
 
-#: src/apprt/gtk/class/window.zig:1153
+#: src/apprt/gtk/class/window.zig:1159
 msgid "Reloaded the configuration"
 msgstr "Конфигурация перезагружена"
 
-#: src/apprt/gtk/class/window.zig:1830
+#: src/apprt/gtk/class/window.zig:1836
 msgid "Copied to clipboard"
 msgstr "Скопировано в буфер обмена"
 
-#: src/apprt/gtk/class/window.zig:1832
+#: src/apprt/gtk/class/window.zig:1838
 msgid "Cleared clipboard"
 msgstr "Буфер обмена очищен"
 
-#: src/apprt/gtk/class/window.zig:1972
+#: src/apprt/gtk/class/window.zig:1978
 msgid "Ghostty Developers"
 msgstr "Разработчики Ghostty"
 
@@ -430,8 +431,8 @@ msgstr "Скопировать выделение как ANSI в буфер об
 #: src/input/command.zig:164
 msgid "Copy the selected text as ANSI escape sequences to the clipboard."
 msgstr ""
-"Скопировать выделенный текст как управляющие последовательности ANSI в "
-"буфер обмена."
+"Скопировать выделенный текст как управляющие последовательности ANSI в буфер "
+"обмена."
 
 #: src/input/command.zig:167
 msgid "Copy Selection as HTML to Clipboard"
@@ -646,7 +647,8 @@ msgstr "Скопировать вывод как HTML во временный ф
 msgid ""
 "Copy the screen contents as HTML to a temporary file and paste the path to "
 "the file."
-msgstr "Скопировать весь вывод как HTML во временный файл и вставить путь к файлу."
+msgstr ""
+"Скопировать весь вывод как HTML во временный файл и вставить путь к файлу."
 
 #: src/input/command.zig:321
 msgid "Copy Screen as HTML to Temporary File and Open"
@@ -701,7 +703,8 @@ msgid ""
 "Copy the selection contents to a temporary file and copy the path to the "
 "clipboard."
 msgstr ""
-"Скопировать выделение во временный файл и скопировать путь к нему в буфер обмена."
+"Скопировать выделение во временный файл и скопировать путь к нему в буфер "
+"обмена."
 
 #: src/input/command.zig:359
 msgid "Copy Selection to Temporary File and Paste Path"
@@ -730,8 +733,8 @@ msgid ""
 "Copy the selection contents as HTML to a temporary file and copy the path to "
 "the clipboard."
 msgstr ""
-"Скопировать выделение как HTML во временный файл и скопировать путь к нему "
-"в буфер обмена."
+"Скопировать выделение как HTML во временный файл и скопировать путь к нему в "
+"буфер обмена."
 
 #: src/input/command.zig:381
 msgid "Copy Selection as HTML to Temporary File and Paste Path"
@@ -1000,134 +1003,159 @@ msgstr "Перезагрузить конфигурацию"
 msgid "Reload the config file."
 msgstr "Перезагрузить файл конфигурации."
 
-#: src/input/command.zig:606
+#: src/input/command.zig:607
+msgid "Switch to Dark Appearance"
+msgstr ""
+
+#: src/input/command.zig:608
+msgid "Use a dark application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Switch to Light Appearance"
+msgstr ""
+
+#: src/input/command.zig:613
+msgid "Use a light application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Switch to System Appearance"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Use the system application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:624
 msgid "Close Terminal"
 msgstr "Закрыть терминал"
 
-#: src/input/command.zig:607
+#: src/input/command.zig:625
 msgid "Close the current terminal."
 msgstr "Закрыть текущий терминал."
 
-#: src/input/command.zig:614
+#: src/input/command.zig:632
 msgid "Close the current tab."
 msgstr "Закрыть текущую вкладку."
 
-#: src/input/command.zig:618
+#: src/input/command.zig:636
 msgid "Close Other Tabs"
 msgstr "Закрыть другие вкладки"
 
-#: src/input/command.zig:619
+#: src/input/command.zig:637
 msgid "Close all tabs in this window except the current one."
 msgstr "Закрыть все остальные вкладки в этом окне."
 
-#: src/input/command.zig:623
+#: src/input/command.zig:641
 msgid "Close Tabs to the Right"
 msgstr "Закрыть вкладки справа"
 
-#: src/input/command.zig:624
+#: src/input/command.zig:642
 msgid "Close all tabs to the right of the current one."
 msgstr "Закрыть все вкладки справа от текущей."
 
-#: src/input/command.zig:631
+#: src/input/command.zig:649
 msgid "Close the current window."
 msgstr "Закрыть текущее окно."
 
-#: src/input/command.zig:636
+#: src/input/command.zig:654
 msgid "Close All Windows"
 msgstr "Закрыть все окна"
 
-#: src/input/command.zig:637
+#: src/input/command.zig:655
 msgid "Close all windows."
 msgstr "Закрыть все окна."
 
-#: src/input/command.zig:642
+#: src/input/command.zig:660
 msgid "Toggle Maximize"
 msgstr "Переключить развёрнутый режим окна"
 
-#: src/input/command.zig:643
+#: src/input/command.zig:661
 msgid "Toggle the maximized state of the current window."
 msgstr "Развернуть текущее окно или вернуть прежний размер."
 
-#: src/input/command.zig:648
+#: src/input/command.zig:666
 msgid "Toggle Fullscreen"
 msgstr "Переключить полноэкранный режим"
 
-#: src/input/command.zig:649
+#: src/input/command.zig:667
 msgid "Toggle the fullscreen state of the current window."
 msgstr "Показать текущее окно во весь экран или вернуть прежний размер."
 
-#: src/input/command.zig:654
+#: src/input/command.zig:672
 msgid "Toggle Window Decorations"
 msgstr "Переключить оформление окна"
 
-#: src/input/command.zig:655
+#: src/input/command.zig:673
 msgid "Toggle the window decorations."
 msgstr "Показать или скрыть оформление окна."
 
-#: src/input/command.zig:660
+#: src/input/command.zig:678
 msgid "Toggle Float on Top"
 msgstr "Переключить режим поверх всех окон"
 
-#: src/input/command.zig:661
+#: src/input/command.zig:679
 msgid "Toggle the float on top state of the current window."
 msgstr "Закрепить окно поверх остальных или снять закрепление."
 
-#: src/input/command.zig:666
+#: src/input/command.zig:684
 msgid "Toggle Secure Input"
 msgstr "Переключить защищённый ввод"
 
-#: src/input/command.zig:667
+#: src/input/command.zig:685
 msgid "Toggle secure input mode."
 msgstr "Включить или отключить режим защищённого ввода."
 
-#: src/input/command.zig:672
+#: src/input/command.zig:690
 msgid "Toggle Mouse Reporting"
 msgstr "Переключить передачу событий мыши"
 
-#: src/input/command.zig:673
+#: src/input/command.zig:691
 msgid "Toggle whether mouse events are reported to terminal applications."
-msgstr "Разрешить или запретить передачу событий мыши терминальным приложениям."
+msgstr ""
+"Разрешить или запретить передачу событий мыши терминальным приложениям."
 
-#: src/input/command.zig:678
+#: src/input/command.zig:696
 msgid "Toggle Background Opacity"
 msgstr "Переключить прозрачность фона"
 
-#: src/input/command.zig:679
+#: src/input/command.zig:697
 msgid "Toggle the background opacity of a window that started transparent."
 msgstr "Изменить прозрачность у изначально прозрачного окна."
 
-#: src/input/command.zig:684
+#: src/input/command.zig:702
 msgid "Check for Updates"
 msgstr "Проверить обновления"
 
-#: src/input/command.zig:685
+#: src/input/command.zig:703
 msgid "Check for updates to the application."
 msgstr "Проверить наличие обновлений приложения."
 
-#: src/input/command.zig:690
+#: src/input/command.zig:708
 msgid "Undo"
 msgstr "Отменить"
 
-#: src/input/command.zig:691
+#: src/input/command.zig:709
 msgid "Undo the last action."
 msgstr "Отменить последнее действие."
 
-#: src/input/command.zig:696
+#: src/input/command.zig:714
 msgid "Redo"
 msgstr "Повторить"
 
-#: src/input/command.zig:697
+#: src/input/command.zig:715
 msgid "Redo the last undone action."
 msgstr "Повторить последнее отменённое действие."
 
-#: src/input/command.zig:703
+#: src/input/command.zig:721
 msgid "Quit the application."
 msgstr "Выйти из приложения."
 
-#: src/input/command.zig:708
+#: src/input/command.zig:726
 msgid "Ghostty"
 msgstr "Ghostty"
 
-#: src/input/command.zig:709
+#: src/input/command.zig:727
 msgid "Put a little Ghostty in your terminal."
 msgstr "Вставить в терминал маленького Ghostty."

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-09-10 10:50-0400\n"
 "PO-Revision-Date: 2026-08-31 21:45+0200\n"
 "Last-Translator: Марко Костић <marko.m.kostic@gmail.com>\n"
 "Language-Team: Language SR\n"
@@ -45,12 +45,14 @@ msgstr "Запамти избор за ову разделу"
 msgid "Reload configuration to show this prompt again"
 msgstr "Поново учитај подешавања да би се овај упит поново приказао"
 
-#: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7 src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2263
+#: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
+#: src/apprt/gtk/ui/1.5/title-dialog.blp:8
+#: src/apprt/gtk/class/application.zig:2296
 msgid "Cancel"
 msgstr "Откажи"
 
-#: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:8 src/apprt/gtk/ui/1.2/search-overlay.blp:90
+#: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:8
+#: src/apprt/gtk/ui/1.2/search-overlay.blp:90
 #: src/apprt/gtk/ui/1.3/surface-child-exited.blp:17
 msgid "Close"
 msgstr "Затвори"
@@ -61,24 +63,27 @@ msgstr "Грешке у подешавањима"
 
 #: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:8
 msgid ""
-"One or more configuration errors were found. Please review the errors below, and either reload your "
-"configuration or ignore these errors."
+"One or more configuration errors were found. Please review the errors below, "
+"and either reload your configuration or ignore these errors."
 msgstr ""
-"Пронађена је једна или више грешака у подешавањима. Прегледај грешке испод, и поново учитај своја "
-"подешавања или занемари ове грешке."
+"Пронађена је једна или више грешака у подешавањима. Прегледај грешке испод, "
+"и поново учитај своја подешавања или занемари ове грешке."
 
 #: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:12
 msgid "Ignore"
 msgstr "Занемари"
 
-#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:13 src/apprt/gtk/ui/1.2/surface.blp:439
-#: src/apprt/gtk/ui/1.5/window.blp:318
+#: src/apprt/gtk/ui/1.2/config-errors-dialog.blp:13
+#: src/apprt/gtk/ui/1.2/surface.blp:439 src/apprt/gtk/ui/1.5/window.blp:318
 msgid "Reload Configuration"
 msgstr "Поново учитај подешавања"
 
-#: src/apprt/gtk/ui/1.2/debug-warning.blp:7 src/apprt/gtk/ui/1.3/debug-warning.blp:6
-msgid "⚠️ You're running a debug build of Ghostty! Performance will be degraded."
-msgstr "⚠️ Покрећеш издање Ghostty-ја за отклањање грешака! Перформансе биће смањене."
+#: src/apprt/gtk/ui/1.2/debug-warning.blp:7
+#: src/apprt/gtk/ui/1.3/debug-warning.blp:6
+msgid ""
+"⚠️ You're running a debug build of Ghostty! Performance will be degraded."
+msgstr ""
+"⚠️ Покрећеш издање Ghostty-ја за отклањање грешака! Перформансе биће смањене."
 
 #: src/apprt/gtk/ui/1.5/inspector-window.blp:5
 msgid "Ghostty: Terminal Inspector"
@@ -106,11 +111,12 @@ msgstr "Није било могуће обезбедити OpenGL контек�
 
 #: src/apprt/gtk/ui/1.2/surface.blp:101
 msgid ""
-"This terminal is in read-only mode. You can still view, select, and scroll through the content, but no "
-"input events will be sent to the running application."
+"This terminal is in read-only mode. You can still view, select, and scroll "
+"through the content, but no input events will be sent to the running "
+"application."
 msgstr ""
-"Овај терминал је у режиму само за читање. И даље можеш прегледати, бирати и помицати садржај, али "
-"догађаји уноса неће бити послати покренутом програму."
+"Овај терминал је у режиму само за читање. И даље можеш прегледати, бирати и "
+"помицати садржај, али догађаји уноса неће бити послати покренутом програму."
 
 #: src/apprt/gtk/ui/1.2/surface.blp:112
 msgid "Read-only"
@@ -178,11 +184,13 @@ msgid "Change Tab Title…"
 msgstr "Промени наслов језичка…"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:391 src/apprt/gtk/ui/1.5/window.blp:60
-#: src/apprt/gtk/ui/1.5/window.blp:110 src/apprt/gtk/ui/1.5/window.blp:237 src/input/command.zig:427
+#: src/apprt/gtk/ui/1.5/window.blp:110 src/apprt/gtk/ui/1.5/window.blp:237
+#: src/input/command.zig:427
 msgid "New Tab"
 msgstr "Нови језичак"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:242 src/input/command.zig:613
+#: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:242
+#: src/input/command.zig:631
 msgid "Close Tab"
 msgstr "Затвори језичак"
 
@@ -194,11 +202,13 @@ msgstr "Прозор"
 msgid "Change Window Title…"
 msgstr "Промени наслов прозора…"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:411 src/apprt/gtk/ui/1.5/window.blp:220 src/input/command.zig:421
+#: src/apprt/gtk/ui/1.2/surface.blp:411 src/apprt/gtk/ui/1.5/window.blp:220
+#: src/input/command.zig:421
 msgid "New Window"
 msgstr "Нови прозор"
 
-#: src/apprt/gtk/ui/1.2/surface.blp:416 src/apprt/gtk/ui/1.5/window.blp:225 src/input/command.zig:630
+#: src/apprt/gtk/ui/1.2/surface.blp:416 src/apprt/gtk/ui/1.5/window.blp:225
+#: src/input/command.zig:648
 msgid "Close Window"
 msgstr "Затвори прозор"
 
@@ -242,11 +252,11 @@ msgstr "Палета наредби"
 msgid "Terminal Inspector"
 msgstr "Инспектор терминала"
 
-#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1991
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1997
 msgid "About Ghostty"
 msgstr "О програму Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:702
+#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:720
 msgid "Quit"
 msgstr "Изађи"
 
@@ -254,47 +264,56 @@ msgstr "Изађи"
 msgid "Execute a command…"
 msgstr "Изврши наредбу…"
 
-#: src/apprt/gtk/class/application.zig:1767
+#: src/apprt/gtk/class/application.zig:1779
 msgid "The keybind was revoked by the system."
 msgstr "Систем је опозвао пречицу."
 
-#: src/apprt/gtk/class/application.zig:1769
+#: src/apprt/gtk/class/application.zig:1781
 msgid "The keybind was denied by the system."
 msgstr "Систем је одбио пречицу."
 
-#: src/apprt/gtk/class/application.zig:1780
+#: src/apprt/gtk/class/application.zig:1792
 msgid "Global keybind unavailable"
 msgstr "Глобална пречица није доступна"
 
-#: src/apprt/gtk/class/application.zig:2259
+#: src/apprt/gtk/class/application.zig:2292
 msgid "Export Terminal IO Events"
 msgstr "Извези догађаје улаза/излаза терминала"
 
-#: src/apprt/gtk/class/application.zig:2262
+#: src/apprt/gtk/class/application.zig:2295
 msgid "Export"
 msgstr "Извези"
 
-#: src/apprt/gtk/class/application.zig:2783
+#: src/apprt/gtk/class/application.zig:2827
 msgid "Editing configuration file"
 msgstr "Уређивање датотеке са подешавањима"
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:198
 msgid ""
-"An application is attempting to write to the clipboard. The current clipboard contents are shown below."
-msgstr "Програм покушава да пише у оставу. Тренутни садржај оставе је приказан испод."
+"An application is attempting to write to the clipboard. The current "
+"clipboard contents are shown below."
+msgstr ""
+"Програм покушава да пише у оставу. Тренутни садржај оставе је приказан испод."
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:202
 msgid ""
-"An application is attempting to read from the clipboard. The current clipboard contents are shown below."
-msgstr "Програм покушава да чита из оставе. Тренутни садржај оставе је приказан испод."
+"An application is attempting to read from the clipboard. The current "
+"clipboard contents are shown below."
+msgstr ""
+"Програм покушава да чита из оставе. Тренутни садржај оставе је приказан "
+"испод."
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:205
 msgid "Warning: Potentially Unsafe Paste"
 msgstr "Упозорење: потенцијално небезбедно убацивање"
 
 #: src/apprt/gtk/class/clipboard_confirmation_dialog.zig:206
-msgid "Pasting this text into the terminal may be dangerous as it looks like some commands may be executed."
-msgstr "Убацивање овог текста у терминал може бити опасно јер изгледа као да се неке наредбе могу извршити."
+msgid ""
+"Pasting this text into the terminal may be dangerous as it looks like some "
+"commands may be executed."
+msgstr ""
+"Убацивање овог текста у терминал може бити опасно јер изгледа као да се неке "
+"наредбе могу извршити."
 
 #: src/apprt/gtk/class/close_confirmation_dialog.zig:184
 msgid "Quit Ghostty?"
@@ -328,15 +347,17 @@ msgstr "Све сесије терминала у овом прозору бић
 msgid "The currently running process in this split will be terminated."
 msgstr "Тренутно покренут процес у овој раздели биће прекинут."
 
-#: src/apprt/gtk/class/surface.zig:1181
+#: src/apprt/gtk/class/surface.zig:1194
 msgid "Command Finished"
 msgstr "Наредба је завршена"
 
-#: src/apprt/gtk/class/surface.zig:1182 src/apprt/gtk/class/surface_child_exited.zig:109
+#: src/apprt/gtk/class/surface.zig:1195
+#: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Наредба је успешно извршена"
 
-#: src/apprt/gtk/class/surface.zig:1183 src/apprt/gtk/class/surface_child_exited.zig:113
+#: src/apprt/gtk/class/surface.zig:1196
+#: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Наредба није успела"
 
@@ -352,19 +373,19 @@ msgstr "Промени наслов језичка"
 msgid "Change Window Title"
 msgstr "Промени наслов прозора"
 
-#: src/apprt/gtk/class/window.zig:1153
+#: src/apprt/gtk/class/window.zig:1159
 msgid "Reloaded the configuration"
 msgstr "Поново учитана подешавања"
 
-#: src/apprt/gtk/class/window.zig:1830
+#: src/apprt/gtk/class/window.zig:1836
 msgid "Copied to clipboard"
 msgstr "Копирано у оставу"
 
-#: src/apprt/gtk/class/window.zig:1832
+#: src/apprt/gtk/class/window.zig:1838
 msgid "Cleared clipboard"
 msgstr "Остава очишћена"
 
-#: src/apprt/gtk/class/window.zig:1972
+#: src/apprt/gtk/class/window.zig:1978
 msgid "Ghostty Developers"
 msgstr "Програмери Ghostty-ја"
 
@@ -381,7 +402,8 @@ msgid "Copy to Clipboard"
 msgstr "Копирај у оставу"
 
 #: src/input/command.zig:156
-msgid "Copy the selected text to the clipboard in both plain and styled formats."
+msgid ""
+"Copy the selected text to the clipboard in both plain and styled formats."
 msgstr "Копирај изабрани текст у оставу у обичном и обликованом формату."
 
 #: src/input/command.zig:159
@@ -421,8 +443,12 @@ msgid "Copy Terminal Title to Clipboard"
 msgstr "Копирај наслов терминала у оставу"
 
 #: src/input/command.zig:180
-msgid "Copy the terminal title to the clipboard. If the terminal title is not set this has no effect."
-msgstr "Копирај наслов терминала у оставу. Ако наслов терминала није постављен, ово неће имати дејства."
+msgid ""
+"Copy the terminal title to the clipboard. If the terminal title is not set "
+"this has no effect."
+msgstr ""
+"Копирај наслов терминала у оставу. Ако наслов терминала није постављен, ово "
+"неће имати дејства."
 
 #: src/input/command.zig:185
 msgid "Paste from Clipboard"
@@ -565,16 +591,21 @@ msgid "Copy Screen to Temporary File and Copy Path"
 msgstr "Копирај екран у привремену датотеку и копирај путању"
 
 #: src/input/command.zig:287
-msgid "Copy the screen contents to a temporary file and copy the path to the clipboard."
-msgstr "Копирај садржај екрана у привремену датотеку и копирај путању у оставу."
+msgid ""
+"Copy the screen contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+"Копирај садржај екрана у привремену датотеку и копирај путању у оставу."
 
 #: src/input/command.zig:291
 msgid "Copy Screen to Temporary File and Paste Path"
 msgstr "Копирај екран у привремену датотеку и убаци путању"
 
 #: src/input/command.zig:292
-msgid "Copy the screen contents to a temporary file and paste the path to the file."
-msgstr "Копирај садржај екрана у привремену датотеку и убаци путању до те датотеке."
+msgid ""
+"Copy the screen contents to a temporary file and paste the path to the file."
+msgstr ""
+"Копирај садржај екрана у привремену датотеку и убаци путању до те датотеке."
 
 #: src/input/command.zig:296
 msgid "Copy Screen to Temporary File and Open"
@@ -589,16 +620,24 @@ msgid "Copy Screen as HTML to Temporary File and Copy Path"
 msgstr "Копирај екран као HTML у привремену датотеку и копирај путању"
 
 #: src/input/command.zig:306
-msgid "Copy the screen contents as HTML to a temporary file and copy the path to the clipboard."
-msgstr "Копирај садржај екрана као HTML у привремену датотеку и копирај путању у оставу."
+msgid ""
+"Copy the screen contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+"Копирај садржај екрана као HTML у привремену датотеку и копирај путању у "
+"оставу."
 
 #: src/input/command.zig:313
 msgid "Copy Screen as HTML to Temporary File and Paste Path"
 msgstr "Копирај екран као HTML у привремену датотеку и убаци путању"
 
 #: src/input/command.zig:314
-msgid "Copy the screen contents as HTML to a temporary file and paste the path to the file."
-msgstr "Копирај садржај екрана као HTML у привремену датотеку и убаци путању до те датотеке."
+msgid ""
+"Copy the screen contents as HTML to a temporary file and paste the path to "
+"the file."
+msgstr ""
+"Копирај садржај екрана као HTML у привремену датотеку и убаци путању до те "
+"датотеке."
 
 #: src/input/command.zig:321
 msgid "Copy Screen as HTML to Temporary File and Open"
@@ -614,8 +653,11 @@ msgstr "Копирај екран као ANSI секвенце у приврем
 
 #: src/input/command.zig:331
 msgid ""
-"Copy the screen contents as ANSI escape sequences to a temporary file and copy the path to the clipboard."
-msgstr "Копирај садржај екрана као излазне ANSI секвенце у привремену датотеку и копирај путању у оставу."
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+"Копирај садржај екрана као излазне ANSI секвенце у привремену датотеку и "
+"копирај путању у оставу."
 
 #: src/input/command.zig:338
 msgid "Copy Screen as ANSI Sequences to Temporary File and Paste Path"
@@ -623,32 +665,45 @@ msgstr "Копирај екран као ANSI секвенце у приврем
 
 #: src/input/command.zig:339
 msgid ""
-"Copy the screen contents as ANSI escape sequences to a temporary file and paste the path to the file."
-msgstr "Копирај садржај екрана као излазне ANSI секвенце у привремену датотеку и убаци путању до датотеке."
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+"Копирај садржај екрана као излазне ANSI секвенце у привремену датотеку и "
+"убаци путању до датотеке."
 
 #: src/input/command.zig:346
 msgid "Copy Screen as ANSI Sequences to Temporary File and Open"
 msgstr "Копирај екран као ANSI секвенце у привремену датотеку и отвори"
 
 #: src/input/command.zig:347
-msgid "Copy the screen contents as ANSI escape sequences to a temporary file and open it."
-msgstr "Копирај садржај екрана као излазне ANSI секвенце у привремену датотеку и отвори је."
+msgid ""
+"Copy the screen contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+"Копирај садржај екрана као излазне ANSI секвенце у привремену датотеку и "
+"отвори је."
 
 #: src/input/command.zig:354
 msgid "Copy Selection to Temporary File and Copy Path"
 msgstr "Копирај изабрано у привремену датотеку и копирај путању"
 
 #: src/input/command.zig:355
-msgid "Copy the selection contents to a temporary file and copy the path to the clipboard."
-msgstr "Копирај садржај изабраног у привремену датотеку и копирај путању у оставу."
+msgid ""
+"Copy the selection contents to a temporary file and copy the path to the "
+"clipboard."
+msgstr ""
+"Копирај садржај изабраног у привремену датотеку и копирај путању у оставу."
 
 #: src/input/command.zig:359
 msgid "Copy Selection to Temporary File and Paste Path"
 msgstr "Копирај изабрано у привремену датотеку и убаци путању"
 
 #: src/input/command.zig:360
-msgid "Copy the selection contents to a temporary file and paste the path to the file."
-msgstr "Копирај садржај изабраног у привремену датотеку и убаци путању до датотеке."
+msgid ""
+"Copy the selection contents to a temporary file and paste the path to the "
+"file."
+msgstr ""
+"Копирај садржај изабраног у привремену датотеку и убаци путању до датотеке."
 
 #: src/input/command.zig:364
 msgid "Copy Selection to Temporary File and Open"
@@ -663,16 +718,24 @@ msgid "Copy Selection as HTML to Temporary File and Copy Path"
 msgstr "Копирај изабрано као HTML у привремену датотеку и копирај путању"
 
 #: src/input/command.zig:374
-msgid "Copy the selection contents as HTML to a temporary file and copy the path to the clipboard."
-msgstr "Копирај садржај изабраног као HTML у привремену датотеку и копирај путању у оставу."
+msgid ""
+"Copy the selection contents as HTML to a temporary file and copy the path to "
+"the clipboard."
+msgstr ""
+"Копирај садржај изабраног као HTML у привремену датотеку и копирај путању у "
+"оставу."
 
 #: src/input/command.zig:381
 msgid "Copy Selection as HTML to Temporary File and Paste Path"
 msgstr "Копирај изабрано као HTML у привремену датотеку и убаци путању"
 
 #: src/input/command.zig:382
-msgid "Copy the selection contents as HTML to a temporary file and paste the path to the file."
-msgstr "Копирај садржај изабраног као HTML у привремену датотеку и убаци путању до датотеке."
+msgid ""
+"Copy the selection contents as HTML to a temporary file and paste the path "
+"to the file."
+msgstr ""
+"Копирај садржај изабраног као HTML у привремену датотеку и убаци путању до "
+"датотеке."
 
 #: src/input/command.zig:389
 msgid "Copy Selection as HTML to Temporary File and Open"
@@ -684,30 +747,41 @@ msgstr "Копирај садржај изабраног као HTML у прив
 
 #: src/input/command.zig:398
 msgid "Copy Selection as ANSI Sequences to Temporary File and Copy Path"
-msgstr "Копирај изабрано као ANSI секвенце у привремену датотеку и копирај путању"
+msgstr ""
+"Копирај изабрано као ANSI секвенце у привремену датотеку и копирај путању"
 
 #: src/input/command.zig:399
 msgid ""
-"Copy the selection contents as ANSI escape sequences to a temporary file and copy the path to the "
-"clipboard."
-msgstr "Копирај садржај избора као излазне ANSI секвенце у привремену датотеку и копирај путању у оставу."
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"copy the path to the clipboard."
+msgstr ""
+"Копирај садржај избора као излазне ANSI секвенце у привремену датотеку и "
+"копирај путању у оставу."
 
 #: src/input/command.zig:406
 msgid "Copy Selection as ANSI Sequences to Temporary File and Paste Path"
-msgstr "Копирај изабрано као ANSI секвенце у привремену датотеку и убаци путању"
+msgstr ""
+"Копирај изабрано као ANSI секвенце у привремену датотеку и убаци путању"
 
 #: src/input/command.zig:407
 msgid ""
-"Copy the selection contents as ANSI escape sequences to a temporary file and paste the path to the file."
-msgstr "Копирај садржај избора као излазне ANSI секвенце у привремену датотеку и убаци путању до те датотеке."
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"paste the path to the file."
+msgstr ""
+"Копирај садржај избора као излазне ANSI секвенце у привремену датотеку и "
+"убаци путању до те датотеке."
 
 #: src/input/command.zig:414
 msgid "Copy Selection as ANSI Sequences to Temporary File and Open"
 msgstr "Копирај изабрано као ANSI секвенце у привремену датотеку и отвори"
 
 #: src/input/command.zig:415
-msgid "Copy the selection contents as ANSI escape sequences to a temporary file and open it."
-msgstr "Копирај садржај избора као излазне ANSI секвенце у привремену датотеку и отвори је."
+msgid ""
+"Copy the selection contents as ANSI escape sequences to a temporary file and "
+"open it."
+msgstr ""
+"Копирај садржај избора као излазне ANSI секвенце у привремену датотеку и "
+"отвори је."
 
 #: src/input/command.zig:422
 msgid "Open a new window."
@@ -921,134 +995,158 @@ msgstr "Поново учитај подешавања"
 msgid "Reload the config file."
 msgstr "Поново учитај датотеку подешавања."
 
-#: src/input/command.zig:606
+#: src/input/command.zig:607
+msgid "Switch to Dark Appearance"
+msgstr ""
+
+#: src/input/command.zig:608
+msgid "Use a dark application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Switch to Light Appearance"
+msgstr ""
+
+#: src/input/command.zig:613
+msgid "Use a light application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Switch to System Appearance"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Use the system application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:624
 msgid "Close Terminal"
 msgstr "Затвори терминал"
 
-#: src/input/command.zig:607
+#: src/input/command.zig:625
 msgid "Close the current terminal."
 msgstr "Затвори тренутни терминал."
 
-#: src/input/command.zig:614
+#: src/input/command.zig:632
 msgid "Close the current tab."
 msgstr "Затвори тренутни језичак."
 
-#: src/input/command.zig:618
+#: src/input/command.zig:636
 msgid "Close Other Tabs"
 msgstr "Затвори друге језичке"
 
-#: src/input/command.zig:619
+#: src/input/command.zig:637
 msgid "Close all tabs in this window except the current one."
 msgstr "Затвори све језичке у овом прозору изузев тренутног."
 
-#: src/input/command.zig:623
+#: src/input/command.zig:641
 msgid "Close Tabs to the Right"
 msgstr "Затвори језичке удесно"
 
-#: src/input/command.zig:624
+#: src/input/command.zig:642
 msgid "Close all tabs to the right of the current one."
 msgstr "Затвори све језичке десно од тренутног."
 
-#: src/input/command.zig:631
+#: src/input/command.zig:649
 msgid "Close the current window."
 msgstr "Затвори тренутни прозор."
 
-#: src/input/command.zig:636
+#: src/input/command.zig:654
 msgid "Close All Windows"
 msgstr "Затвори све прозоре"
 
-#: src/input/command.zig:637
+#: src/input/command.zig:655
 msgid "Close all windows."
 msgstr "Затвори све прозоре."
 
-#: src/input/command.zig:642
+#: src/input/command.zig:660
 msgid "Toggle Maximize"
 msgstr "Окини увећање"
 
-#: src/input/command.zig:643
+#: src/input/command.zig:661
 msgid "Toggle the maximized state of the current window."
 msgstr "Промени стање увећања тренутног прозора."
 
-#: src/input/command.zig:648
+#: src/input/command.zig:666
 msgid "Toggle Fullscreen"
 msgstr "Пребаци преко целог екрана"
 
-#: src/input/command.zig:649
+#: src/input/command.zig:667
 msgid "Toggle the fullscreen state of the current window."
 msgstr "Промени стање приказивања тренутног прозора преко целог екрана."
 
-#: src/input/command.zig:654
+#: src/input/command.zig:672
 msgid "Toggle Window Decorations"
 msgstr "Окини декорације прозора"
 
-#: src/input/command.zig:655
+#: src/input/command.zig:673
 msgid "Toggle the window decorations."
 msgstr "Промени стање декорације прозора."
 
-#: src/input/command.zig:660
+#: src/input/command.zig:678
 msgid "Toggle Float on Top"
 msgstr "Окини плутајуће на врху"
 
-#: src/input/command.zig:661
+#: src/input/command.zig:679
 msgid "Toggle the float on top state of the current window."
 msgstr "Промени стање плутања на врху тренутног прозора."
 
-#: src/input/command.zig:666
+#: src/input/command.zig:684
 msgid "Toggle Secure Input"
 msgstr "Окини безбедан унос"
 
-#: src/input/command.zig:667
+#: src/input/command.zig:685
 msgid "Toggle secure input mode."
 msgstr "Промени режим безбедног уноса."
 
-#: src/input/command.zig:672
+#: src/input/command.zig:690
 msgid "Toggle Mouse Reporting"
 msgstr "Окини прослеђивање догађаја миша"
 
-#: src/input/command.zig:673
+#: src/input/command.zig:691
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr "Пребаци да ли се догађаји миша пријављују терминалним програмима."
 
-#: src/input/command.zig:678
+#: src/input/command.zig:696
 msgid "Toggle Background Opacity"
 msgstr "Окини непровидност позадине"
 
-#: src/input/command.zig:679
+#: src/input/command.zig:697
 msgid "Toggle the background opacity of a window that started transparent."
 msgstr "Пребаци непровидност позадине прозора који је првобитно био провидан."
 
-#: src/input/command.zig:684
+#: src/input/command.zig:702
 msgid "Check for Updates"
 msgstr "Провери ажурирања"
 
-#: src/input/command.zig:685
+#: src/input/command.zig:703
 msgid "Check for updates to the application."
 msgstr "Провери ажурирања за програм."
 
-#: src/input/command.zig:690
+#: src/input/command.zig:708
 msgid "Undo"
 msgstr "Опозови"
 
-#: src/input/command.zig:691
+#: src/input/command.zig:709
 msgid "Undo the last action."
 msgstr "Опозови последњу радњу."
 
-#: src/input/command.zig:696
+#: src/input/command.zig:714
 msgid "Redo"
 msgstr "Понови"
 
-#: src/input/command.zig:697
+#: src/input/command.zig:715
 msgid "Redo the last undone action."
 msgstr "Понови последњу опозвану радњу."
 
-#: src/input/command.zig:703
+#: src/input/command.zig:721
 msgid "Quit the application."
 msgstr "Изађи из програма."
 
-#: src/input/command.zig:708
+#: src/input/command.zig:726
 msgid "Ghostty"
 msgstr "Ghostty"
 
-#: src/input/command.zig:709
+#: src/input/command.zig:727
 msgid "Put a little Ghostty in your terminal."
 msgstr "Убаци мало Ghostty-ја у свој терминал."

--- a/po/sr@latin.po
+++ b/po/sr@latin.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-09-10 10:50-0400\n"
 "PO-Revision-Date: 2026-08-31 21:45+0200\n"
 "Last-Translator: Marko Kostić <marko.m.kostic@gmail.com>\n"
 "Language-Team: Language SR\n"
@@ -51,7 +51,7 @@ msgstr "Ponovo učitaj podešavanja da bi se ovaj upit ponovo prikazao"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2263
+#: src/apprt/gtk/class/application.zig:2296
 msgid "Cancel"
 msgstr "Otkaži"
 
@@ -195,7 +195,7 @@ msgid "New Tab"
 msgstr "Novi jezičak"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:242
-#: src/input/command.zig:613
+#: src/input/command.zig:631
 msgid "Close Tab"
 msgstr "Zatvori jezičak"
 
@@ -213,7 +213,7 @@ msgid "New Window"
 msgstr "Novi prozor"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:416 src/apprt/gtk/ui/1.5/window.blp:225
-#: src/input/command.zig:630
+#: src/input/command.zig:648
 msgid "Close Window"
 msgstr "Zatvori prozor"
 
@@ -257,11 +257,11 @@ msgstr "Paleta naredbi"
 msgid "Terminal Inspector"
 msgstr "Inspektor terminala"
 
-#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1991
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1997
 msgid "About Ghostty"
 msgstr "O programu Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:702
+#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:720
 msgid "Quit"
 msgstr "Izađi"
 
@@ -269,27 +269,27 @@ msgstr "Izađi"
 msgid "Execute a command…"
 msgstr "Izvrši naredbu…"
 
-#: src/apprt/gtk/class/application.zig:1767
+#: src/apprt/gtk/class/application.zig:1779
 msgid "The keybind was revoked by the system."
 msgstr "Sistem je opozvao prečicu."
 
-#: src/apprt/gtk/class/application.zig:1769
+#: src/apprt/gtk/class/application.zig:1781
 msgid "The keybind was denied by the system."
 msgstr "Sistem je odbio prečicu."
 
-#: src/apprt/gtk/class/application.zig:1780
+#: src/apprt/gtk/class/application.zig:1792
 msgid "Global keybind unavailable"
 msgstr "Globalna prečica nije dostupna"
 
-#: src/apprt/gtk/class/application.zig:2259
+#: src/apprt/gtk/class/application.zig:2292
 msgid "Export Terminal IO Events"
 msgstr "Izvezi događaje ulaza/izlaza terminala"
 
-#: src/apprt/gtk/class/application.zig:2262
+#: src/apprt/gtk/class/application.zig:2295
 msgid "Export"
 msgstr "Izvezi"
 
-#: src/apprt/gtk/class/application.zig:2783
+#: src/apprt/gtk/class/application.zig:2827
 msgid "Editing configuration file"
 msgstr "Uređivanje datoteke sa podešavanjima"
 
@@ -352,16 +352,16 @@ msgstr "Sve sesije terminala u ovom prozoru biće prekinute."
 msgid "The currently running process in this split will be terminated."
 msgstr "Trenutno pokrenut proces u ovoj razdeli biće prekinut."
 
-#: src/apprt/gtk/class/surface.zig:1181
+#: src/apprt/gtk/class/surface.zig:1194
 msgid "Command Finished"
 msgstr "Naredba je završena"
 
-#: src/apprt/gtk/class/surface.zig:1182
+#: src/apprt/gtk/class/surface.zig:1195
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Naredba je uspešno izvršena"
 
-#: src/apprt/gtk/class/surface.zig:1183
+#: src/apprt/gtk/class/surface.zig:1196
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Naredba nije uspela"
@@ -378,19 +378,19 @@ msgstr "Promeni naslov jezička"
 msgid "Change Window Title"
 msgstr "Promeni naslov prozora"
 
-#: src/apprt/gtk/class/window.zig:1153
+#: src/apprt/gtk/class/window.zig:1159
 msgid "Reloaded the configuration"
 msgstr "Ponovo učitana podešavanja"
 
-#: src/apprt/gtk/class/window.zig:1830
+#: src/apprt/gtk/class/window.zig:1836
 msgid "Copied to clipboard"
 msgstr "Kopirano u ostavu"
 
-#: src/apprt/gtk/class/window.zig:1832
+#: src/apprt/gtk/class/window.zig:1838
 msgid "Cleared clipboard"
 msgstr "Ostava očišćena"
 
-#: src/apprt/gtk/class/window.zig:1972
+#: src/apprt/gtk/class/window.zig:1978
 msgid "Ghostty Developers"
 msgstr "Programeri Ghostty-ja"
 
@@ -1002,134 +1002,158 @@ msgstr "Ponovo učitaj podešavanja"
 msgid "Reload the config file."
 msgstr "Ponovo učitaj datoteku podešavanja."
 
-#: src/input/command.zig:606
+#: src/input/command.zig:607
+msgid "Switch to Dark Appearance"
+msgstr ""
+
+#: src/input/command.zig:608
+msgid "Use a dark application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Switch to Light Appearance"
+msgstr ""
+
+#: src/input/command.zig:613
+msgid "Use a light application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Switch to System Appearance"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Use the system application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:624
 msgid "Close Terminal"
 msgstr "Zatvori terminal"
 
-#: src/input/command.zig:607
+#: src/input/command.zig:625
 msgid "Close the current terminal."
 msgstr "Zatvori trenutni terminal."
 
-#: src/input/command.zig:614
+#: src/input/command.zig:632
 msgid "Close the current tab."
 msgstr "Zatvori trenutni jezičak."
 
-#: src/input/command.zig:618
+#: src/input/command.zig:636
 msgid "Close Other Tabs"
 msgstr "Zatvori druge jezičke"
 
-#: src/input/command.zig:619
+#: src/input/command.zig:637
 msgid "Close all tabs in this window except the current one."
 msgstr "Zatvori sve jezičke u ovom prozoru izuzev trenutnog."
 
-#: src/input/command.zig:623
+#: src/input/command.zig:641
 msgid "Close Tabs to the Right"
 msgstr "Zatvori jezičke udesno"
 
-#: src/input/command.zig:624
+#: src/input/command.zig:642
 msgid "Close all tabs to the right of the current one."
 msgstr "Zatvori sve jezičke desno od trenutnog."
 
-#: src/input/command.zig:631
+#: src/input/command.zig:649
 msgid "Close the current window."
 msgstr "Zatvori trenutni prozor."
 
-#: src/input/command.zig:636
+#: src/input/command.zig:654
 msgid "Close All Windows"
 msgstr "Zatvori sve prozore"
 
-#: src/input/command.zig:637
+#: src/input/command.zig:655
 msgid "Close all windows."
 msgstr "Zatvori sve prozore."
 
-#: src/input/command.zig:642
+#: src/input/command.zig:660
 msgid "Toggle Maximize"
 msgstr "Okini uvećanje"
 
-#: src/input/command.zig:643
+#: src/input/command.zig:661
 msgid "Toggle the maximized state of the current window."
 msgstr "Promeni stanje uvećanja trenutnog prozora."
 
-#: src/input/command.zig:648
+#: src/input/command.zig:666
 msgid "Toggle Fullscreen"
 msgstr "Prebaci preko celog ekrana"
 
-#: src/input/command.zig:649
+#: src/input/command.zig:667
 msgid "Toggle the fullscreen state of the current window."
 msgstr "Promeni stanje prikazivanja trenutnog prozora preko celog ekrana."
 
-#: src/input/command.zig:654
+#: src/input/command.zig:672
 msgid "Toggle Window Decorations"
 msgstr "Okini dekoracije prozora"
 
-#: src/input/command.zig:655
+#: src/input/command.zig:673
 msgid "Toggle the window decorations."
 msgstr "Promeni stanje dekoracije prozora."
 
-#: src/input/command.zig:660
+#: src/input/command.zig:678
 msgid "Toggle Float on Top"
 msgstr "Okini plutajuće na vrhu"
 
-#: src/input/command.zig:661
+#: src/input/command.zig:679
 msgid "Toggle the float on top state of the current window."
 msgstr "Promeni stanje plutanja na vrhu trenutnog prozora."
 
-#: src/input/command.zig:666
+#: src/input/command.zig:684
 msgid "Toggle Secure Input"
 msgstr "Okini bezbedan unos"
 
-#: src/input/command.zig:667
+#: src/input/command.zig:685
 msgid "Toggle secure input mode."
 msgstr "Promeni režim bezbednog unosa."
 
-#: src/input/command.zig:672
+#: src/input/command.zig:690
 msgid "Toggle Mouse Reporting"
 msgstr "Okini prosleđivanje događaja miša"
 
-#: src/input/command.zig:673
+#: src/input/command.zig:691
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr "Prebaci da li se događaji miša prijavljuju terminalnim programima."
 
-#: src/input/command.zig:678
+#: src/input/command.zig:696
 msgid "Toggle Background Opacity"
 msgstr "Okini neprovidnost pozadine"
 
-#: src/input/command.zig:679
+#: src/input/command.zig:697
 msgid "Toggle the background opacity of a window that started transparent."
 msgstr "Prebaci neprovidnost pozadine prozora koji je prvobitno bio providan."
 
-#: src/input/command.zig:684
+#: src/input/command.zig:702
 msgid "Check for Updates"
 msgstr "Proveri ažuriranja"
 
-#: src/input/command.zig:685
+#: src/input/command.zig:703
 msgid "Check for updates to the application."
 msgstr "Proveri ažuriranja za program."
 
-#: src/input/command.zig:690
+#: src/input/command.zig:708
 msgid "Undo"
 msgstr "Opozovi"
 
-#: src/input/command.zig:691
+#: src/input/command.zig:709
 msgid "Undo the last action."
 msgstr "Opozovi poslednju radnju."
 
-#: src/input/command.zig:696
+#: src/input/command.zig:714
 msgid "Redo"
 msgstr "Ponovi"
 
-#: src/input/command.zig:697
+#: src/input/command.zig:715
 msgid "Redo the last undone action."
 msgstr "Ponovi poslednju opozvanu radnju."
 
-#: src/input/command.zig:703
+#: src/input/command.zig:721
 msgid "Quit the application."
 msgstr "Izađi iz programa."
 
-#: src/input/command.zig:708
+#: src/input/command.zig:726
 msgid "Ghostty"
 msgstr "Ghostty"
 
-#: src/input/command.zig:709
+#: src/input/command.zig:727
 msgid "Put a little Ghostty in your terminal."
 msgstr "Ubaci malo Ghostty-ja u svoj terminal."

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-09-10 10:50-0400\n"
 "PO-Revision-Date: 2026-08-13 20:33+0300\n"
 "Last-Translator: Emir SARI <emir_sari@icloud.com>\n"
 "Language-Team: Turkish\n"
@@ -48,7 +48,7 @@ msgstr "Bu istemi tekrar göstermek için yapılandırmayı yeniden yükle"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2263
+#: src/apprt/gtk/class/application.zig:2296
 msgid "Cancel"
 msgstr "İptal"
 
@@ -194,7 +194,7 @@ msgid "New Tab"
 msgstr "Yeni Sekme"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:242
-#: src/input/command.zig:613
+#: src/input/command.zig:631
 msgid "Close Tab"
 msgstr "Sekmeyi Kapat"
 
@@ -212,7 +212,7 @@ msgid "New Window"
 msgstr "Yeni Pencere"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:416 src/apprt/gtk/ui/1.5/window.blp:225
-#: src/input/command.zig:630
+#: src/input/command.zig:648
 msgid "Close Window"
 msgstr "Pencereyi Kapat"
 
@@ -256,11 +256,11 @@ msgstr "Komut Paleti"
 msgid "Terminal Inspector"
 msgstr "Uçbirim Denetçisi"
 
-#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1991
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1997
 msgid "About Ghostty"
 msgstr "Ghostty Hakkında"
 
-#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:702
+#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:720
 msgid "Quit"
 msgstr "Çık"
 
@@ -268,27 +268,27 @@ msgstr "Çık"
 msgid "Execute a command…"
 msgstr "Bir komut çalıştır…"
 
-#: src/apprt/gtk/class/application.zig:1767
+#: src/apprt/gtk/class/application.zig:1779
 msgid "The keybind was revoked by the system."
 msgstr "Tuş atama, sistem tarafından yürürlükten kaldırıldı."
 
-#: src/apprt/gtk/class/application.zig:1769
+#: src/apprt/gtk/class/application.zig:1781
 msgid "The keybind was denied by the system."
 msgstr "Tuş atama, sistem tarafından reddedildi."
 
-#: src/apprt/gtk/class/application.zig:1780
+#: src/apprt/gtk/class/application.zig:1792
 msgid "Global keybind unavailable"
 msgstr "Global tuş atama kullanılamıyor"
 
-#: src/apprt/gtk/class/application.zig:2259
+#: src/apprt/gtk/class/application.zig:2292
 msgid "Export Terminal IO Events"
 msgstr "Uçbirim G–Ç Olaylarını Dışa Aktar"
 
-#: src/apprt/gtk/class/application.zig:2262
+#: src/apprt/gtk/class/application.zig:2295
 msgid "Export"
 msgstr "Dışa Aktar"
 
-#: src/apprt/gtk/class/application.zig:2783
+#: src/apprt/gtk/class/application.zig:2827
 msgid "Editing configuration file"
 msgstr "Yapılandırma dosyası düzenleniyor"
 
@@ -352,16 +352,16 @@ msgstr "Bu penceredeki tüm uçbirim oturumları sonlandırılacaktır."
 msgid "The currently running process in this split will be terminated."
 msgstr "Bu bölmedeki şu anda çalışan süreç sonlandırılacaktır."
 
-#: src/apprt/gtk/class/surface.zig:1181
+#: src/apprt/gtk/class/surface.zig:1194
 msgid "Command Finished"
 msgstr "Komut Bitti"
 
-#: src/apprt/gtk/class/surface.zig:1182
+#: src/apprt/gtk/class/surface.zig:1195
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Komut Başarılı"
 
-#: src/apprt/gtk/class/surface.zig:1183
+#: src/apprt/gtk/class/surface.zig:1196
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Komut Başarısız"
@@ -378,19 +378,19 @@ msgstr "Sekme Başlığını Değiştir"
 msgid "Change Window Title"
 msgstr "Pencere Başlığını Değiştir"
 
-#: src/apprt/gtk/class/window.zig:1153
+#: src/apprt/gtk/class/window.zig:1159
 msgid "Reloaded the configuration"
 msgstr "Yapılandırma yeniden yüklendi"
 
-#: src/apprt/gtk/class/window.zig:1830
+#: src/apprt/gtk/class/window.zig:1836
 msgid "Copied to clipboard"
 msgstr "Panoya kopyalandı"
 
-#: src/apprt/gtk/class/window.zig:1832
+#: src/apprt/gtk/class/window.zig:1838
 msgid "Cleared clipboard"
 msgstr "Pano temizlendi"
 
-#: src/apprt/gtk/class/window.zig:1972
+#: src/apprt/gtk/class/window.zig:1978
 msgid "Ghostty Developers"
 msgstr "Ghostty Geliştiricileri"
 
@@ -1002,136 +1002,160 @@ msgstr "Yapılandırmayı Yeniden Yükle"
 msgid "Reload the config file."
 msgstr "Yapılandırma dosyasını yeniden yükleyin."
 
-#: src/input/command.zig:606
+#: src/input/command.zig:607
+msgid "Switch to Dark Appearance"
+msgstr ""
+
+#: src/input/command.zig:608
+msgid "Use a dark application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Switch to Light Appearance"
+msgstr ""
+
+#: src/input/command.zig:613
+msgid "Use a light application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Switch to System Appearance"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Use the system application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:624
 msgid "Close Terminal"
 msgstr "Uçbirimi Kapat"
 
-#: src/input/command.zig:607
+#: src/input/command.zig:625
 msgid "Close the current terminal."
 msgstr "Geçerli uçbirimi kapatın."
 
-#: src/input/command.zig:614
+#: src/input/command.zig:632
 msgid "Close the current tab."
 msgstr "Geçerli sekmeyi kapatın."
 
-#: src/input/command.zig:618
+#: src/input/command.zig:636
 msgid "Close Other Tabs"
 msgstr "Diğer Sekmeleri Kapat"
 
-#: src/input/command.zig:619
+#: src/input/command.zig:637
 msgid "Close all tabs in this window except the current one."
 msgstr "Geçerli sekme dışında, bu penceredeki tüm sekmeleri kapatın."
 
-#: src/input/command.zig:623
+#: src/input/command.zig:641
 msgid "Close Tabs to the Right"
 msgstr "Sağdaki Sekmeleri Kapat"
 
-#: src/input/command.zig:624
+#: src/input/command.zig:642
 msgid "Close all tabs to the right of the current one."
 msgstr "Geçerli sekmenin sağındaki tüm sekmeleri kapatın."
 
-#: src/input/command.zig:631
+#: src/input/command.zig:649
 msgid "Close the current window."
 msgstr "Geçerli pencereyi kapatın."
 
-#: src/input/command.zig:636
+#: src/input/command.zig:654
 msgid "Close All Windows"
 msgstr "Tüm Pencereleri Kapat"
 
-#: src/input/command.zig:637
+#: src/input/command.zig:655
 msgid "Close all windows."
 msgstr "Tüm pencereleri kapatın."
 
-#: src/input/command.zig:642
+#: src/input/command.zig:660
 msgid "Toggle Maximize"
 msgstr "Ekranı Kapla/Küçült"
 
-#: src/input/command.zig:643
+#: src/input/command.zig:661
 msgid "Toggle the maximized state of the current window."
 msgstr ""
 "Geçerli pencereyi ekranı kaplayacak şekilde büyütün veya eski hâline geri "
 "alın."
 
-#: src/input/command.zig:648
+#: src/input/command.zig:666
 msgid "Toggle Fullscreen"
 msgstr "Tam Ekranı Aç/Kapat"
 
-#: src/input/command.zig:649
+#: src/input/command.zig:667
 msgid "Toggle the fullscreen state of the current window."
 msgstr "Geçerli pencereyi tam ekran yapın veya eski hâline geri alın."
 
-#: src/input/command.zig:654
+#: src/input/command.zig:672
 msgid "Toggle Window Decorations"
 msgstr "Pencere Dekorasyonlarını Aç/Kapat"
 
-#: src/input/command.zig:655
+#: src/input/command.zig:673
 msgid "Toggle the window decorations."
 msgstr "Pencere dekorasyonlarını açın/kapatın."
 
-#: src/input/command.zig:660
+#: src/input/command.zig:678
 msgid "Toggle Float on Top"
 msgstr "Pencereyi Yüzer Yap"
 
-#: src/input/command.zig:661
+#: src/input/command.zig:679
 msgid "Toggle the float on top state of the current window."
 msgstr "Geçerli pencerenin en üstte kalma durumunu açın/kapatın."
 
-#: src/input/command.zig:666
+#: src/input/command.zig:684
 msgid "Toggle Secure Input"
 msgstr "Güvenli Girişi Aç/Kapat"
 
-#: src/input/command.zig:667
+#: src/input/command.zig:685
 msgid "Toggle secure input mode."
 msgstr "Güvenli giriş kipini açın/kapatın."
 
-#: src/input/command.zig:672
+#: src/input/command.zig:690
 msgid "Toggle Mouse Reporting"
 msgstr "Fare Bildirmeyi Aç/Kapat"
 
-#: src/input/command.zig:673
+#: src/input/command.zig:691
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr "Fare olaylarını uçbirim uygulamalarına bildirmeyi açın/kapatın."
 
-#: src/input/command.zig:678
+#: src/input/command.zig:696
 msgid "Toggle Background Opacity"
 msgstr "Arka Plan Matlığını Aç/Kapat"
 
-#: src/input/command.zig:679
+#: src/input/command.zig:697
 msgid "Toggle the background opacity of a window that started transparent."
 msgstr "Saydam olarak açılmış bir pencerenin arka plan matlığını açın/kapatın."
 
-#: src/input/command.zig:684
+#: src/input/command.zig:702
 msgid "Check for Updates"
 msgstr "Güncellemeleri Denetle"
 
-#: src/input/command.zig:685
+#: src/input/command.zig:703
 msgid "Check for updates to the application."
 msgstr "Uygulamaya olan güncellemeleri denetleyin."
 
-#: src/input/command.zig:690
+#: src/input/command.zig:708
 msgid "Undo"
 msgstr "Geri Al"
 
-#: src/input/command.zig:691
+#: src/input/command.zig:709
 msgid "Undo the last action."
 msgstr "Son eylemi geri alın."
 
-#: src/input/command.zig:696
+#: src/input/command.zig:714
 msgid "Redo"
 msgstr "Yinele"
 
-#: src/input/command.zig:697
+#: src/input/command.zig:715
 msgid "Redo the last undone action."
 msgstr "Son geri alınmış eylemi yineleyin."
 
-#: src/input/command.zig:703
+#: src/input/command.zig:721
 msgid "Quit the application."
 msgstr "Uygulamadan çıkın."
 
-#: src/input/command.zig:708
+#: src/input/command.zig:726
 msgid "Ghostty"
 msgstr "Ghostty"
 
-#: src/input/command.zig:709
+#: src/input/command.zig:727
 msgid "Put a little Ghostty in your terminal."
 msgstr "Uçbiriminize minik bir Ghostty koyun."

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-09-10 10:50-0400\n"
 "PO-Revision-Date: 2026-08-19 19:34+0100\n"
 "Last-Translator: Volodymyr Chernetskyi "
 "<19735328+chernetskyi@users.noreply.github.com>\n"
@@ -50,7 +50,7 @@ msgstr "Перезавантажте налаштування, щоб показ
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2263
+#: src/apprt/gtk/class/application.zig:2296
 msgid "Cancel"
 msgstr "Скасувати"
 
@@ -194,7 +194,7 @@ msgid "New Tab"
 msgstr "Нова вкладка"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:242
-#: src/input/command.zig:613
+#: src/input/command.zig:631
 msgid "Close Tab"
 msgstr "Закрити вкладку"
 
@@ -212,7 +212,7 @@ msgid "New Window"
 msgstr "Нове вікно"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:416 src/apprt/gtk/ui/1.5/window.blp:225
-#: src/input/command.zig:630
+#: src/input/command.zig:648
 msgid "Close Window"
 msgstr "Закрити вікно"
 
@@ -256,11 +256,11 @@ msgstr "Палітра команд"
 msgid "Terminal Inspector"
 msgstr "Інспектор терміналу"
 
-#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1991
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1997
 msgid "About Ghostty"
 msgstr "Про Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:702
+#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:720
 msgid "Quit"
 msgstr "Вийти"
 
@@ -268,27 +268,27 @@ msgstr "Вийти"
 msgid "Execute a command…"
 msgstr "Виконати команду…"
 
-#: src/apprt/gtk/class/application.zig:1767
+#: src/apprt/gtk/class/application.zig:1779
 msgid "The keybind was revoked by the system."
 msgstr "Дана привʼязка клавіш відкликана системою."
 
-#: src/apprt/gtk/class/application.zig:1769
+#: src/apprt/gtk/class/application.zig:1781
 msgid "The keybind was denied by the system."
 msgstr "Дана привʼязка клавіш відхилена системою."
 
-#: src/apprt/gtk/class/application.zig:1780
+#: src/apprt/gtk/class/application.zig:1792
 msgid "Global keybind unavailable"
 msgstr "Глобальна привʼязка клавіш недоступна"
 
-#: src/apprt/gtk/class/application.zig:2259
+#: src/apprt/gtk/class/application.zig:2292
 msgid "Export Terminal IO Events"
 msgstr "Експортувати події введення/виведення терміналу"
 
-#: src/apprt/gtk/class/application.zig:2262
+#: src/apprt/gtk/class/application.zig:2295
 msgid "Export"
 msgstr "Експортувати"
 
-#: src/apprt/gtk/class/application.zig:2783
+#: src/apprt/gtk/class/application.zig:2827
 msgid "Editing configuration file"
 msgstr "Редагування файлу налаштувань"
 
@@ -352,16 +352,16 @@ msgstr "Всі сесії терміналу в цьому вікні будут
 msgid "The currently running process in this split will be terminated."
 msgstr "Процес, що виконується в цій панелі, буде завершено."
 
-#: src/apprt/gtk/class/surface.zig:1181
+#: src/apprt/gtk/class/surface.zig:1194
 msgid "Command Finished"
 msgstr "Команда завершилась"
 
-#: src/apprt/gtk/class/surface.zig:1182
+#: src/apprt/gtk/class/surface.zig:1195
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Команда завершилась успішно"
 
-#: src/apprt/gtk/class/surface.zig:1183
+#: src/apprt/gtk/class/surface.zig:1196
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Команда завершилась з помилкою"
@@ -378,19 +378,19 @@ msgstr "Змінити заголовок вкладки"
 msgid "Change Window Title"
 msgstr "Змінити заголовок вікна"
 
-#: src/apprt/gtk/class/window.zig:1153
+#: src/apprt/gtk/class/window.zig:1159
 msgid "Reloaded the configuration"
 msgstr "Налаштування перезавантажено"
 
-#: src/apprt/gtk/class/window.zig:1830
+#: src/apprt/gtk/class/window.zig:1836
 msgid "Copied to clipboard"
 msgstr "Скопійовано до буфера обміну"
 
-#: src/apprt/gtk/class/window.zig:1832
+#: src/apprt/gtk/class/window.zig:1838
 msgid "Cleared clipboard"
 msgstr "Буфер обміну очищено"
 
-#: src/apprt/gtk/class/window.zig:1972
+#: src/apprt/gtk/class/window.zig:1978
 msgid "Ghostty Developers"
 msgstr "Розробники Ghostty"
 
@@ -612,8 +612,7 @@ msgstr "Зберегти екран до файлу і вставити шлях
 #: src/input/command.zig:292
 msgid ""
 "Copy the screen contents to a temporary file and paste the path to the file."
-msgstr ""
-"Зберегти вміст екрана до тимчасового файлу і вставити шлях до файлу."
+msgstr "Зберегти вміст екрана до тимчасового файлу і вставити шлях до файлу."
 
 #: src/input/command.zig:296
 msgid "Copy Screen to Temporary File and Open"
@@ -1002,135 +1001,158 @@ msgstr "Перезавантажити налаштування"
 msgid "Reload the config file."
 msgstr "Перезавантажити файл налаштувань."
 
-#: src/input/command.zig:606
+#: src/input/command.zig:607
+msgid "Switch to Dark Appearance"
+msgstr ""
+
+#: src/input/command.zig:608
+msgid "Use a dark application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Switch to Light Appearance"
+msgstr ""
+
+#: src/input/command.zig:613
+msgid "Use a light application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Switch to System Appearance"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Use the system application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:624
 msgid "Close Terminal"
 msgstr "Закрити термінал"
 
-#: src/input/command.zig:607
+#: src/input/command.zig:625
 msgid "Close the current terminal."
 msgstr "Закрити поточний термінал."
 
-#: src/input/command.zig:614
+#: src/input/command.zig:632
 msgid "Close the current tab."
 msgstr "Закрити поточну вкладку."
 
-#: src/input/command.zig:618
+#: src/input/command.zig:636
 msgid "Close Other Tabs"
 msgstr "Закрити інші вкладки"
 
-#: src/input/command.zig:619
+#: src/input/command.zig:637
 msgid "Close all tabs in this window except the current one."
 msgstr "Закрити всі вкладки в цьому вікні, окрім поточної."
 
-#: src/input/command.zig:623
+#: src/input/command.zig:641
 msgid "Close Tabs to the Right"
 msgstr "Закрити вкладки праворуч"
 
-#: src/input/command.zig:624
+#: src/input/command.zig:642
 msgid "Close all tabs to the right of the current one."
 msgstr "Закрити всі вкладки праворуч поточної."
 
-#: src/input/command.zig:631
+#: src/input/command.zig:649
 msgid "Close the current window."
 msgstr "Закрити поточне вікно."
 
-#: src/input/command.zig:636
+#: src/input/command.zig:654
 msgid "Close All Windows"
 msgstr "Закрити всі вікна"
 
-#: src/input/command.zig:637
+#: src/input/command.zig:655
 msgid "Close all windows."
 msgstr "Закрити всі вікна."
 
-#: src/input/command.zig:642
+#: src/input/command.zig:660
 msgid "Toggle Maximize"
 msgstr "Перемкнути розгортання"
 
-#: src/input/command.zig:643
+#: src/input/command.zig:661
 msgid "Toggle the maximized state of the current window."
 msgstr "Перемкнути розгортання поточного вікна."
 
-#: src/input/command.zig:648
+#: src/input/command.zig:666
 msgid "Toggle Fullscreen"
 msgstr "Перемкнути повноекранний режим"
 
-#: src/input/command.zig:649
+#: src/input/command.zig:667
 msgid "Toggle the fullscreen state of the current window."
 msgstr "Перемкнути повноекранний режим поточного вікна."
 
-#: src/input/command.zig:654
+#: src/input/command.zig:672
 msgid "Toggle Window Decorations"
 msgstr "Перемкнути оформлення вікон"
 
-#: src/input/command.zig:655
+#: src/input/command.zig:673
 msgid "Toggle the window decorations."
 msgstr "Перемкнути оформлення вікон."
 
-#: src/input/command.zig:660
+#: src/input/command.zig:678
 msgid "Toggle Float on Top"
 msgstr "Перемкнути режим «поверх інших вікон»"
 
-#: src/input/command.zig:661
+#: src/input/command.zig:679
 msgid "Toggle the float on top state of the current window."
 msgstr "Перемкнути режим «поверх інших вікон» для поточного вікна."
 
-#: src/input/command.zig:666
+#: src/input/command.zig:684
 msgid "Toggle Secure Input"
 msgstr "Перемкнути безпечне введення"
 
-#: src/input/command.zig:667
+#: src/input/command.zig:685
 msgid "Toggle secure input mode."
 msgstr "Перемкнути режим безпечного введення."
 
-#: src/input/command.zig:672
+#: src/input/command.zig:690
 msgid "Toggle Mouse Reporting"
 msgstr "Перемкнути передавання подій миші"
 
-#: src/input/command.zig:673
+#: src/input/command.zig:691
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr "Перемкнути передавання подій миші до термінальних застосунків."
 
-#: src/input/command.zig:678
+#: src/input/command.zig:696
 msgid "Toggle Background Opacity"
 msgstr "Перемкнути непрозорість фону"
 
-#: src/input/command.zig:679
+#: src/input/command.zig:697
 msgid "Toggle the background opacity of a window that started transparent."
-msgstr ""
-"Перемкнути непрозорість фону вікна, фон якого спочатку був прозорим."
+msgstr "Перемкнути непрозорість фону вікна, фон якого спочатку був прозорим."
 
-#: src/input/command.zig:684
+#: src/input/command.zig:702
 msgid "Check for Updates"
 msgstr "Перевірити наявність оновлень"
 
-#: src/input/command.zig:685
+#: src/input/command.zig:703
 msgid "Check for updates to the application."
 msgstr "Перевірити наявність оновлень застосунку."
 
-#: src/input/command.zig:690
+#: src/input/command.zig:708
 msgid "Undo"
 msgstr "Скасувати"
 
-#: src/input/command.zig:691
+#: src/input/command.zig:709
 msgid "Undo the last action."
 msgstr "Скасувати останню дію."
 
-#: src/input/command.zig:696
+#: src/input/command.zig:714
 msgid "Redo"
 msgstr "Повторити"
 
-#: src/input/command.zig:697
+#: src/input/command.zig:715
 msgid "Redo the last undone action."
 msgstr "Повторити останню скасовану дію."
 
-#: src/input/command.zig:703
+#: src/input/command.zig:721
 msgid "Quit the application."
 msgstr "Вийти із застосунку."
 
-#: src/input/command.zig:708
+#: src/input/command.zig:726
 msgid "Ghostty"
 msgstr "Привид Ghostty"
 
-#: src/input/command.zig:709
+#: src/input/command.zig:727
 msgid "Put a little Ghostty in your terminal."
 msgstr "Вставити маленького Ghostty у ваш термінал."

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-09-10 10:50-0400\n"
 "PO-Revision-Date: 2026-08-13 21:30+0700\n"
 "Last-Translator: Anh Thang <buianhthang89@gmail.com>\n"
 "Language-Team: Vietnamese <translation-team-vi@lists.sourceforge.net>\n"
@@ -48,7 +48,7 @@ msgstr "Tải lại cấu hình để hiển thị lại thông báo này"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2263
+#: src/apprt/gtk/class/application.zig:2296
 msgid "Cancel"
 msgstr "Hủy"
 
@@ -192,7 +192,7 @@ msgid "New Tab"
 msgstr "Tab mới"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:242
-#: src/input/command.zig:613
+#: src/input/command.zig:631
 msgid "Close Tab"
 msgstr "Đóng Tab"
 
@@ -210,7 +210,7 @@ msgid "New Window"
 msgstr "Cửa sổ mới"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:416 src/apprt/gtk/ui/1.5/window.blp:225
-#: src/input/command.zig:630
+#: src/input/command.zig:648
 msgid "Close Window"
 msgstr "Đóng cửa sổ"
 
@@ -254,11 +254,11 @@ msgstr "Bảng lệnh"
 msgid "Terminal Inspector"
 msgstr "Bộ kiểm tra Terminal"
 
-#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1991
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1997
 msgid "About Ghostty"
 msgstr "Về Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:702
+#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:720
 msgid "Quit"
 msgstr "Thoát"
 
@@ -266,27 +266,27 @@ msgstr "Thoát"
 msgid "Execute a command…"
 msgstr "Thực thi lệnh…"
 
-#: src/apprt/gtk/class/application.zig:1767
+#: src/apprt/gtk/class/application.zig:1779
 msgid "The keybind was revoked by the system."
 msgstr "Tổ hợp phím đã bị hệ thống thu hồi."
 
-#: src/apprt/gtk/class/application.zig:1769
+#: src/apprt/gtk/class/application.zig:1781
 msgid "The keybind was denied by the system."
 msgstr "Tổ hợp phím đã bị hệ thống từ chối."
 
-#: src/apprt/gtk/class/application.zig:1780
+#: src/apprt/gtk/class/application.zig:1792
 msgid "Global keybind unavailable"
 msgstr "Tổ hợp phím toàn cục không khả dụng"
 
-#: src/apprt/gtk/class/application.zig:2259
+#: src/apprt/gtk/class/application.zig:2292
 msgid "Export Terminal IO Events"
 msgstr "Xuất các sự kiện I/O của terminal"
 
-#: src/apprt/gtk/class/application.zig:2262
+#: src/apprt/gtk/class/application.zig:2295
 msgid "Export"
 msgstr "Xuất"
 
-#: src/apprt/gtk/class/application.zig:2783
+#: src/apprt/gtk/class/application.zig:2827
 msgid "Editing configuration file"
 msgstr "Đang chỉnh sửa tệp cấu hình"
 
@@ -350,16 +350,16 @@ msgstr "Tất cả các phiên làm việc terminal trong cửa sổ này sẽ b
 msgid "The currently running process in this split will be terminated."
 msgstr "Tiến trình đang chạy trong phần chia này sẽ bị chấm dứt."
 
-#: src/apprt/gtk/class/surface.zig:1181
+#: src/apprt/gtk/class/surface.zig:1194
 msgid "Command Finished"
 msgstr "Lệnh đã kết thúc"
 
-#: src/apprt/gtk/class/surface.zig:1182
+#: src/apprt/gtk/class/surface.zig:1195
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "Lệnh đã thực thi thành công"
 
-#: src/apprt/gtk/class/surface.zig:1183
+#: src/apprt/gtk/class/surface.zig:1196
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "Lệnh thực thi thất bại"
@@ -376,19 +376,19 @@ msgstr "Đổi tiêu đề Tab"
 msgid "Change Window Title"
 msgstr "Đổi tiêu đề cửa sổ"
 
-#: src/apprt/gtk/class/window.zig:1153
+#: src/apprt/gtk/class/window.zig:1159
 msgid "Reloaded the configuration"
 msgstr "Đã tải lại cấu hình"
 
-#: src/apprt/gtk/class/window.zig:1830
+#: src/apprt/gtk/class/window.zig:1836
 msgid "Copied to clipboard"
 msgstr "Đã sao chép vào bảng tạm"
 
-#: src/apprt/gtk/class/window.zig:1832
+#: src/apprt/gtk/class/window.zig:1838
 msgid "Cleared clipboard"
 msgstr "Đã xóa sạch bảng tạm"
 
-#: src/apprt/gtk/class/window.zig:1972
+#: src/apprt/gtk/class/window.zig:1978
 msgid "Ghostty Developers"
 msgstr "Các nhà phát triển Ghostty"
 
@@ -407,8 +407,7 @@ msgstr "Sao chép vào bảng tạm"
 #: src/input/command.zig:156
 msgid ""
 "Copy the selected text to the clipboard in both plain and styled formats."
-msgstr ""
-"Sao chép văn bản đã chọn vào bảng tạm dưới dạng thuần và có định dạng."
+msgstr "Sao chép văn bản đã chọn vào bảng tạm dưới dạng thuần và có định dạng."
 
 #: src/input/command.zig:159
 msgid "Copy Selection as Plain Text to Clipboard"
@@ -451,8 +450,8 @@ msgid ""
 "Copy the terminal title to the clipboard. If the terminal title is not set "
 "this has no effect."
 msgstr ""
-"Sao chép tiêu đề terminal vào bảng tạm. Nếu tiêu đề chưa được đặt, "
-"lệnh này không có hiệu lực."
+"Sao chép tiêu đề terminal vào bảng tạm. Nếu tiêu đề chưa được đặt, lệnh này "
+"không có hiệu lực."
 
 #: src/input/command.zig:185
 msgid "Paste from Clipboard"
@@ -599,8 +598,8 @@ msgid ""
 "Copy the screen contents to a temporary file and copy the path to the "
 "clipboard."
 msgstr ""
-"Sao chép nội dung màn hình vào một tệp tạm và sao chép đường dẫn tệp "
-"vào bảng tạm."
+"Sao chép nội dung màn hình vào một tệp tạm và sao chép đường dẫn tệp vào "
+"bảng tạm."
 
 #: src/input/command.zig:291
 msgid "Copy Screen to Temporary File and Paste Path"
@@ -609,8 +608,7 @@ msgstr "Sao chép màn hình vào tệp tạm và dán đường dẫn"
 #: src/input/command.zig:292
 msgid ""
 "Copy the screen contents to a temporary file and paste the path to the file."
-msgstr ""
-"Sao chép nội dung màn hình vào một tệp tạm và dán đường dẫn tệp đó."
+msgstr "Sao chép nội dung màn hình vào một tệp tạm và dán đường dẫn tệp đó."
 
 #: src/input/command.zig:296
 msgid "Copy Screen to Temporary File and Open"
@@ -641,7 +639,8 @@ msgid ""
 "Copy the screen contents as HTML to a temporary file and paste the path to "
 "the file."
 msgstr ""
-"Sao chép nội dung màn hình dưới dạng HTML vào tệp tạm và dán đường dẫn tệp đó."
+"Sao chép nội dung màn hình dưới dạng HTML vào tệp tạm và dán đường dẫn tệp "
+"đó."
 
 #: src/input/command.zig:321
 msgid "Copy Screen as HTML to Temporary File and Open"
@@ -653,15 +652,16 @@ msgstr "Sao chép nội dung màn hình dưới dạng HTML vào tệp tạm và
 
 #: src/input/command.zig:330
 msgid "Copy Screen as ANSI Sequences to Temporary File and Copy Path"
-msgstr "Sao chép màn hình dưới dạng chuỗi ANSI vào tệp tạm và sao chép đường dẫn"
+msgstr ""
+"Sao chép màn hình dưới dạng chuỗi ANSI vào tệp tạm và sao chép đường dẫn"
 
 #: src/input/command.zig:331
 msgid ""
 "Copy the screen contents as ANSI escape sequences to a temporary file and "
 "copy the path to the clipboard."
 msgstr ""
-"Sao chép nội dung màn hình dưới dạng chuỗi thoát ANSI vào tệp tạm "
-"và sao chép đường dẫn vào bảng tạm."
+"Sao chép nội dung màn hình dưới dạng chuỗi thoát ANSI vào tệp tạm và sao "
+"chép đường dẫn vào bảng tạm."
 
 #: src/input/command.zig:338
 msgid "Copy Screen as ANSI Sequences to Temporary File and Paste Path"
@@ -672,8 +672,8 @@ msgid ""
 "Copy the screen contents as ANSI escape sequences to a temporary file and "
 "paste the path to the file."
 msgstr ""
-"Sao chép nội dung màn hình dưới dạng chuỗi thoát ANSI vào tệp tạm "
-"và dán đường dẫn tệp đó."
+"Sao chép nội dung màn hình dưới dạng chuỗi thoát ANSI vào tệp tạm và dán "
+"đường dẫn tệp đó."
 
 #: src/input/command.zig:346
 msgid "Copy Screen as ANSI Sequences to Temporary File and Open"
@@ -684,7 +684,8 @@ msgid ""
 "Copy the screen contents as ANSI escape sequences to a temporary file and "
 "open it."
 msgstr ""
-"Sao chép nội dung màn hình dưới dạng chuỗi thoát ANSI vào tệp tạm và mở tệp đó."
+"Sao chép nội dung màn hình dưới dạng chuỗi thoát ANSI vào tệp tạm và mở tệp "
+"đó."
 
 #: src/input/command.zig:354
 msgid "Copy Selection to Temporary File and Copy Path"
@@ -705,8 +706,7 @@ msgstr "Sao chép vùng chọn vào tệp tạm và dán đường dẫn"
 msgid ""
 "Copy the selection contents to a temporary file and paste the path to the "
 "file."
-msgstr ""
-"Sao chép nội dung vùng chọn vào tệp tạm và dán đường dẫn tệp đó."
+msgstr "Sao chép nội dung vùng chọn vào tệp tạm và dán đường dẫn tệp đó."
 
 #: src/input/command.zig:364
 msgid "Copy Selection to Temporary File and Open"
@@ -737,8 +737,8 @@ msgid ""
 "Copy the selection contents as HTML to a temporary file and paste the path "
 "to the file."
 msgstr ""
-"Sao chép nội dung vùng chọn dưới dạng HTML vào tệp tạm "
-"và dán đường dẫn tệp đó."
+"Sao chép nội dung vùng chọn dưới dạng HTML vào tệp tạm và dán đường dẫn tệp "
+"đó."
 
 #: src/input/command.zig:389
 msgid "Copy Selection as HTML to Temporary File and Open"
@@ -750,15 +750,16 @@ msgstr "Sao chép nội dung vùng chọn dưới dạng HTML vào tệp tạm v
 
 #: src/input/command.zig:398
 msgid "Copy Selection as ANSI Sequences to Temporary File and Copy Path"
-msgstr "Sao chép vùng chọn dưới dạng chuỗi ANSI vào tệp tạm và sao chép đường dẫn"
+msgstr ""
+"Sao chép vùng chọn dưới dạng chuỗi ANSI vào tệp tạm và sao chép đường dẫn"
 
 #: src/input/command.zig:399
 msgid ""
 "Copy the selection contents as ANSI escape sequences to a temporary file and "
 "copy the path to the clipboard."
 msgstr ""
-"Sao chép nội dung vùng chọn dưới dạng chuỗi thoát ANSI vào tệp tạm "
-"và sao chép đường dẫn vào bảng tạm."
+"Sao chép nội dung vùng chọn dưới dạng chuỗi thoát ANSI vào tệp tạm và sao "
+"chép đường dẫn vào bảng tạm."
 
 #: src/input/command.zig:406
 msgid "Copy Selection as ANSI Sequences to Temporary File and Paste Path"
@@ -769,8 +770,8 @@ msgid ""
 "Copy the selection contents as ANSI escape sequences to a temporary file and "
 "paste the path to the file."
 msgstr ""
-"Sao chép nội dung vùng chọn dưới dạng chuỗi thoát ANSI vào tệp tạm "
-"và dán đường dẫn tệp đó."
+"Sao chép nội dung vùng chọn dưới dạng chuỗi thoát ANSI vào tệp tạm và dán "
+"đường dẫn tệp đó."
 
 #: src/input/command.zig:414
 msgid "Copy Selection as ANSI Sequences to Temporary File and Open"
@@ -781,7 +782,8 @@ msgid ""
 "Copy the selection contents as ANSI escape sequences to a temporary file and "
 "open it."
 msgstr ""
-"Sao chép nội dung vùng chọn dưới dạng chuỗi thoát ANSI vào tệp tạm và mở tệp đó."
+"Sao chép nội dung vùng chọn dưới dạng chuỗi thoát ANSI vào tệp tạm và mở tệp "
+"đó."
 
 #: src/input/command.zig:422
 msgid "Open a new window."
@@ -995,134 +997,160 @@ msgstr "Tải lại cấu hình"
 msgid "Reload the config file."
 msgstr "Tải lại tệp cấu hình."
 
-#: src/input/command.zig:606
+#: src/input/command.zig:607
+msgid "Switch to Dark Appearance"
+msgstr ""
+
+#: src/input/command.zig:608
+msgid "Use a dark application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Switch to Light Appearance"
+msgstr ""
+
+#: src/input/command.zig:613
+msgid "Use a light application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Switch to System Appearance"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Use the system application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:624
 msgid "Close Terminal"
 msgstr "Đóng Terminal"
 
-#: src/input/command.zig:607
+#: src/input/command.zig:625
 msgid "Close the current terminal."
 msgstr "Đóng terminal hiện tại."
 
-#: src/input/command.zig:614
+#: src/input/command.zig:632
 msgid "Close the current tab."
 msgstr "Đóng tab hiện tại."
 
-#: src/input/command.zig:618
+#: src/input/command.zig:636
 msgid "Close Other Tabs"
 msgstr "Đóng các Tab khác"
 
-#: src/input/command.zig:619
+#: src/input/command.zig:637
 msgid "Close all tabs in this window except the current one."
 msgstr "Đóng tất cả các tab trong cửa sổ này ngoại trừ tab hiện tại."
 
-#: src/input/command.zig:623
+#: src/input/command.zig:641
 msgid "Close Tabs to the Right"
 msgstr "Đóng các Tab bên phải"
 
-#: src/input/command.zig:624
+#: src/input/command.zig:642
 msgid "Close all tabs to the right of the current one."
 msgstr "Đóng tất cả các tab ở phía bên phải tab hiện tại."
 
-#: src/input/command.zig:631
+#: src/input/command.zig:649
 msgid "Close the current window."
 msgstr "Đóng cửa sổ hiện tại."
 
-#: src/input/command.zig:636
+#: src/input/command.zig:654
 msgid "Close All Windows"
 msgstr "Đóng tất cả cửa sổ"
 
-#: src/input/command.zig:637
+#: src/input/command.zig:655
 msgid "Close all windows."
 msgstr "Đóng tất cả các cửa sổ đang mở."
 
-#: src/input/command.zig:642
+#: src/input/command.zig:660
 msgid "Toggle Maximize"
 msgstr "Bật/Tắt phóng to cửa sổ"
 
-#: src/input/command.zig:643
+#: src/input/command.zig:661
 msgid "Toggle the maximized state of the current window."
 msgstr "Bật hoặc tắt chế độ phóng to của cửa sổ hiện tại."
 
-#: src/input/command.zig:648
+#: src/input/command.zig:666
 msgid "Toggle Fullscreen"
 msgstr "Bật/Tắt toàn màn hình"
 
-#: src/input/command.zig:649
+#: src/input/command.zig:667
 msgid "Toggle the fullscreen state of the current window."
 msgstr "Bật hoặc tắt chế độ toàn màn hình của cửa sổ hiện tại."
 
-#: src/input/command.zig:654
+#: src/input/command.zig:672
 msgid "Toggle Window Decorations"
 msgstr "Bật/Tắt trang trí cửa sổ"
 
-#: src/input/command.zig:655
+#: src/input/command.zig:673
 msgid "Toggle the window decorations."
 msgstr "Ẩn hoặc hiện viền và thanh tiêu đề của cửa sổ."
 
-#: src/input/command.zig:660
+#: src/input/command.zig:678
 msgid "Toggle Float on Top"
 msgstr "Bật/Tắt ghim trên cùng"
 
-#: src/input/command.zig:661
+#: src/input/command.zig:679
 msgid "Toggle the float on top state of the current window."
 msgstr "Bật hoặc tắt chế độ luôn hiển thị trên cùng của cửa sổ."
 
-#: src/input/command.zig:666
+#: src/input/command.zig:684
 msgid "Toggle Secure Input"
 msgstr "Bật/Tắt nhập liệu an toàn"
 
-#: src/input/command.zig:667
+#: src/input/command.zig:685
 msgid "Toggle secure input mode."
 msgstr "Bật hoặc tắt chế độ nhập liệu an toàn."
 
-#: src/input/command.zig:672
+#: src/input/command.zig:690
 msgid "Toggle Mouse Reporting"
 msgstr "Bật/Tắt báo cáo chuột"
 
-#: src/input/command.zig:673
+#: src/input/command.zig:691
 msgid "Toggle whether mouse events are reported to terminal applications."
-msgstr "Bật hoặc tắt việc gửi sự kiện thao tác chuột tới các ứng dụng chạy trong terminal."
+msgstr ""
+"Bật hoặc tắt việc gửi sự kiện thao tác chuột tới các ứng dụng chạy trong "
+"terminal."
 
-#: src/input/command.zig:678
+#: src/input/command.zig:696
 msgid "Toggle Background Opacity"
 msgstr "Bật/Tắt độ mờ nền"
 
-#: src/input/command.zig:679
+#: src/input/command.zig:697
 msgid "Toggle the background opacity of a window that started transparent."
 msgstr "Bật hoặc tắt độ mờ (độ trong suốt) của nền cửa sổ ban đầu."
 
-#: src/input/command.zig:684
+#: src/input/command.zig:702
 msgid "Check for Updates"
 msgstr "Kiểm tra bản cập nhật"
 
-#: src/input/command.zig:685
+#: src/input/command.zig:703
 msgid "Check for updates to the application."
 msgstr "Kiểm tra xem có bản cập nhật mới cho ứng dụng hay không."
 
-#: src/input/command.zig:690
+#: src/input/command.zig:708
 msgid "Undo"
 msgstr "Hoàn tác"
 
-#: src/input/command.zig:691
+#: src/input/command.zig:709
 msgid "Undo the last action."
 msgstr "Hoàn tác hành động gần nhất."
 
-#: src/input/command.zig:696
+#: src/input/command.zig:714
 msgid "Redo"
 msgstr "Làm lại"
 
-#: src/input/command.zig:697
+#: src/input/command.zig:715
 msgid "Redo the last undone action."
 msgstr "Làm lại hành động vừa hoàn tác."
 
-#: src/input/command.zig:703
+#: src/input/command.zig:721
 msgid "Quit the application."
 msgstr "Thoát ứng dụng."
 
-#: src/input/command.zig:708
+#: src/input/command.zig:726
 msgid "Ghostty"
 msgstr "Ghostty"
 
-#: src/input/command.zig:709
+#: src/input/command.zig:727
 msgid "Put a little Ghostty in your terminal."
 msgstr "Mang một chút Ghostty vào terminal của bạn."

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-09-10 10:50-0400\n"
 "PO-Revision-Date: 2026-02-12 01:56+0800\n"
 "Last-Translator: Leah <hi@pluie.me>\n"
 "Language-Team: Chinese (simplified) <i18n-zh@googlegroups.com>\n"
@@ -49,7 +49,7 @@ msgstr "本提示将在重载配置后再次出现"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2263
+#: src/apprt/gtk/class/application.zig:2296
 msgid "Cancel"
 msgstr "取消"
 
@@ -190,7 +190,7 @@ msgid "New Tab"
 msgstr "新建标签页"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:242
-#: src/input/command.zig:613
+#: src/input/command.zig:631
 msgid "Close Tab"
 msgstr "关闭标签页"
 
@@ -208,7 +208,7 @@ msgid "New Window"
 msgstr "新建窗口"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:416 src/apprt/gtk/ui/1.5/window.blp:225
-#: src/input/command.zig:630
+#: src/input/command.zig:648
 msgid "Close Window"
 msgstr "关闭窗口"
 
@@ -252,11 +252,11 @@ msgstr "命令面板"
 msgid "Terminal Inspector"
 msgstr "终端调试器"
 
-#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1991
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1997
 msgid "About Ghostty"
 msgstr "关于 Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:702
+#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:720
 msgid "Quit"
 msgstr "退出"
 
@@ -264,27 +264,27 @@ msgstr "退出"
 msgid "Execute a command…"
 msgstr "选择要执行的命令…"
 
-#: src/apprt/gtk/class/application.zig:1767
+#: src/apprt/gtk/class/application.zig:1779
 msgid "The keybind was revoked by the system."
 msgstr "系统撤销了该快捷键。"
 
-#: src/apprt/gtk/class/application.zig:1769
+#: src/apprt/gtk/class/application.zig:1781
 msgid "The keybind was denied by the system."
 msgstr "系统拒绝绑定该快捷键。"
 
-#: src/apprt/gtk/class/application.zig:1780
+#: src/apprt/gtk/class/application.zig:1792
 msgid "Global keybind unavailable"
 msgstr "全局快捷键不可用"
 
-#: src/apprt/gtk/class/application.zig:2259
+#: src/apprt/gtk/class/application.zig:2292
 msgid "Export Terminal IO Events"
 msgstr "导出终端输入输出事件"
 
-#: src/apprt/gtk/class/application.zig:2262
+#: src/apprt/gtk/class/application.zig:2295
 msgid "Export"
 msgstr "导出"
 
-#: src/apprt/gtk/class/application.zig:2783
+#: src/apprt/gtk/class/application.zig:2827
 msgid "Editing configuration file"
 msgstr ""
 
@@ -342,16 +342,16 @@ msgstr "窗口内所有运行中的进程将被终止。"
 msgid "The currently running process in this split will be terminated."
 msgstr "分屏内正在运行中的进程将被终止。"
 
-#: src/apprt/gtk/class/surface.zig:1181
+#: src/apprt/gtk/class/surface.zig:1194
 msgid "Command Finished"
 msgstr "命令已完成"
 
-#: src/apprt/gtk/class/surface.zig:1182
+#: src/apprt/gtk/class/surface.zig:1195
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "命令执行成功"
 
-#: src/apprt/gtk/class/surface.zig:1183
+#: src/apprt/gtk/class/surface.zig:1196
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "命令执行失败"
@@ -368,19 +368,19 @@ msgstr "更改标签页标题"
 msgid "Change Window Title"
 msgstr ""
 
-#: src/apprt/gtk/class/window.zig:1153
+#: src/apprt/gtk/class/window.zig:1159
 msgid "Reloaded the configuration"
 msgstr "已重新加载配置"
 
-#: src/apprt/gtk/class/window.zig:1830
+#: src/apprt/gtk/class/window.zig:1836
 msgid "Copied to clipboard"
 msgstr "已复制至剪贴板"
 
-#: src/apprt/gtk/class/window.zig:1832
+#: src/apprt/gtk/class/window.zig:1838
 msgid "Cleared clipboard"
 msgstr "已清空剪贴板"
 
-#: src/apprt/gtk/class/window.zig:1972
+#: src/apprt/gtk/class/window.zig:1978
 msgid "Ghostty Developers"
 msgstr "Ghostty 开发团队"
 
@@ -642,7 +642,8 @@ msgstr "以 ANSI 序列格式复制屏幕内容到临时文件并复制路径"
 msgid ""
 "Copy the screen contents as ANSI escape sequences to a temporary file and "
 "copy the path to the clipboard."
-msgstr "将屏幕内容以 ANSI 转义序列格式复制到一个临时文件，并将其路径复制到剪贴板。"
+msgstr ""
+"将屏幕内容以 ANSI 转义序列格式复制到一个临时文件，并将其路径复制到剪贴板。"
 
 #: src/input/command.zig:338
 msgid "Copy Screen as ANSI Sequences to Temporary File and Paste Path"
@@ -652,7 +653,8 @@ msgstr "以 ANSI 序列格式复制屏幕内容到临时文件并粘贴路径"
 msgid ""
 "Copy the screen contents as ANSI escape sequences to a temporary file and "
 "paste the path to the file."
-msgstr "将屏幕内容以 ANSI 转义序列格式复制到一个临时文件，并将其路径粘贴进终端。"
+msgstr ""
+"将屏幕内容以 ANSI 转义序列格式复制到一个临时文件，并将其路径粘贴进终端。"
 
 #: src/input/command.zig:346
 msgid "Copy Screen as ANSI Sequences to Temporary File and Open"
@@ -962,135 +964,159 @@ msgstr "重新加载配置"
 msgid "Reload the config file."
 msgstr "重新加载配置文件。"
 
-#: src/input/command.zig:606
+#: src/input/command.zig:607
+msgid "Switch to Dark Appearance"
+msgstr ""
+
+#: src/input/command.zig:608
+msgid "Use a dark application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Switch to Light Appearance"
+msgstr ""
+
+#: src/input/command.zig:613
+msgid "Use a light application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Switch to System Appearance"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Use the system application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:624
 msgid "Close Terminal"
 msgstr "关闭终端"
 
-#: src/input/command.zig:607
+#: src/input/command.zig:625
 msgid "Close the current terminal."
 msgstr "关闭当前终端。"
 
-#: src/input/command.zig:614
+#: src/input/command.zig:632
 msgid "Close the current tab."
 msgstr "关闭当前标签页。"
 
-#: src/input/command.zig:618
+#: src/input/command.zig:636
 msgid "Close Other Tabs"
 msgstr "关闭其他标签页"
 
-#: src/input/command.zig:619
+#: src/input/command.zig:637
 msgid "Close all tabs in this window except the current one."
 msgstr "关闭当前窗口内除了当前标签页以外的所有标签页。"
 
-#: src/input/command.zig:623
+#: src/input/command.zig:641
 msgid "Close Tabs to the Right"
 msgstr "关闭右侧标签页"
 
-#: src/input/command.zig:624
+#: src/input/command.zig:642
 msgid "Close all tabs to the right of the current one."
 msgstr "关闭当前标签页右侧的所有标签页。"
 
-#: src/input/command.zig:631
+#: src/input/command.zig:649
 msgid "Close the current window."
 msgstr "关闭当前窗口。"
 
-#: src/input/command.zig:636
+#: src/input/command.zig:654
 msgid "Close All Windows"
 msgstr "关闭所有窗口"
 
-#: src/input/command.zig:637
+#: src/input/command.zig:655
 msgid "Close all windows."
 msgstr "关闭所有窗口。"
 
-#: src/input/command.zig:642
+#: src/input/command.zig:660
 msgid "Toggle Maximize"
 msgstr "切换最大化"
 
-#: src/input/command.zig:643
+#: src/input/command.zig:661
 msgid "Toggle the maximized state of the current window."
 msgstr "切换当前窗口的最大化状态。"
 
-#: src/input/command.zig:648
+#: src/input/command.zig:666
 msgid "Toggle Fullscreen"
 msgstr "切换全屏"
 
-#: src/input/command.zig:649
+#: src/input/command.zig:667
 msgid "Toggle the fullscreen state of the current window."
 msgstr "切换当前窗口的全屏状态。"
 
-#: src/input/command.zig:654
+#: src/input/command.zig:672
 msgid "Toggle Window Decorations"
 msgstr "切换窗口装饰"
 
-#: src/input/command.zig:655
+#: src/input/command.zig:673
 msgid "Toggle the window decorations."
 msgstr "切换是否显示窗口装饰，如标题栏、边框等。"
 
-#: src/input/command.zig:660
+#: src/input/command.zig:678
 msgid "Toggle Float on Top"
 msgstr "切换窗口置顶"
 
-#: src/input/command.zig:661
+#: src/input/command.zig:679
 msgid "Toggle the float on top state of the current window."
 msgstr "切换当前窗口的置顶状态。"
 
-#: src/input/command.zig:666
+#: src/input/command.zig:684
 msgid "Toggle Secure Input"
 msgstr "切换安全输入"
 
-#: src/input/command.zig:667
+#: src/input/command.zig:685
 msgid "Toggle secure input mode."
 msgstr "切换安全输入模式。"
 
-#: src/input/command.zig:672
+#: src/input/command.zig:690
 msgid "Toggle Mouse Reporting"
 msgstr "切换鼠标事件上报"
 
-#: src/input/command.zig:673
+#: src/input/command.zig:691
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr "切换是否向终端应用上报鼠标事件。"
 
-#: src/input/command.zig:678
 # Opacity 实际指不透明度，但是这样表述太拗口了
+#: src/input/command.zig:696
 msgid "Toggle Background Opacity"
 msgstr "切换背景透明度"
 
-#: src/input/command.zig:679
+#: src/input/command.zig:697
 msgid "Toggle the background opacity of a window that started transparent."
 msgstr "切换最初透明的窗口的背景透明度。"
 
-#: src/input/command.zig:684
+#: src/input/command.zig:702
 msgid "Check for Updates"
 msgstr "检查更新"
 
-#: src/input/command.zig:685
+#: src/input/command.zig:703
 msgid "Check for updates to the application."
 msgstr "检查应用是否有版本更新。"
 
-#: src/input/command.zig:690
+#: src/input/command.zig:708
 msgid "Undo"
 msgstr "撤销"
 
-#: src/input/command.zig:691
+#: src/input/command.zig:709
 msgid "Undo the last action."
 msgstr "撤销上一个操作。"
 
-#: src/input/command.zig:696
+#: src/input/command.zig:714
 msgid "Redo"
 msgstr "重做"
 
-#: src/input/command.zig:697
+#: src/input/command.zig:715
 msgid "Redo the last undone action."
 msgstr "重做上一个撤销的操作。"
 
-#: src/input/command.zig:703
+#: src/input/command.zig:721
 msgid "Quit the application."
 msgstr "退出应用。"
 
-#: src/input/command.zig:708
+#: src/input/command.zig:726
 msgid "Ghostty"
 msgstr "Ghostty"
 
-#: src/input/command.zig:709
+#: src/input/command.zig:727
 msgid "Put a little Ghostty in your terminal."
 msgstr "把一只小 Ghostty 塞进终端里。"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.mitchellh.ghostty\n"
 "Report-Msgid-Bugs-To: m@mitchellh.com\n"
-"POT-Creation-Date: 2026-08-10 10:06-0500\n"
+"POT-Creation-Date: 2026-09-10 10:50-0400\n"
 "PO-Revision-Date: 2026-08-14 10:59+0800\n"
 "Last-Translator: Alang Hsu <alang.hsu@gmail.com>\n"
 "Language-Team: Chinese (traditional)\n"
@@ -50,7 +50,7 @@ msgstr "重新載入設定以再次顯示此提示"
 
 #: src/apprt/gtk/ui/1.2/close-confirmation-dialog.blp:7
 #: src/apprt/gtk/ui/1.5/title-dialog.blp:8
-#: src/apprt/gtk/class/application.zig:2263
+#: src/apprt/gtk/class/application.zig:2296
 msgid "Cancel"
 msgstr "取消"
 
@@ -190,7 +190,7 @@ msgid "New Tab"
 msgstr "開新分頁"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:396 src/apprt/gtk/ui/1.5/window.blp:242
-#: src/input/command.zig:613
+#: src/input/command.zig:631
 msgid "Close Tab"
 msgstr "關閉分頁"
 
@@ -208,7 +208,7 @@ msgid "New Window"
 msgstr "開新視窗"
 
 #: src/apprt/gtk/ui/1.2/surface.blp:416 src/apprt/gtk/ui/1.5/window.blp:225
-#: src/input/command.zig:630
+#: src/input/command.zig:648
 msgid "Close Window"
 msgstr "關閉視窗"
 
@@ -252,11 +252,11 @@ msgstr "命令面板"
 msgid "Terminal Inspector"
 msgstr "終端機檢查工具"
 
-#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1991
+#: src/apprt/gtk/ui/1.5/window.blp:326 src/apprt/gtk/class/window.zig:1997
 msgid "About Ghostty"
 msgstr "關於 Ghostty"
 
-#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:702
+#: src/apprt/gtk/ui/1.5/window.blp:331 src/input/command.zig:720
 msgid "Quit"
 msgstr "結束"
 
@@ -264,27 +264,27 @@ msgstr "結束"
 msgid "Execute a command…"
 msgstr "執行命令…"
 
-#: src/apprt/gtk/class/application.zig:1767
+#: src/apprt/gtk/class/application.zig:1779
 msgid "The keybind was revoked by the system."
 msgstr "系統已撤銷此按鍵綁定。"
 
-#: src/apprt/gtk/class/application.zig:1769
+#: src/apprt/gtk/class/application.zig:1781
 msgid "The keybind was denied by the system."
 msgstr "系統已拒絕此按鍵綁定。"
 
-#: src/apprt/gtk/class/application.zig:1780
+#: src/apprt/gtk/class/application.zig:1792
 msgid "Global keybind unavailable"
 msgstr "無法使用全域按鍵綁定"
 
-#: src/apprt/gtk/class/application.zig:2259
+#: src/apprt/gtk/class/application.zig:2292
 msgid "Export Terminal IO Events"
 msgstr "匯出終端機 IO 事件"
 
-#: src/apprt/gtk/class/application.zig:2262
+#: src/apprt/gtk/class/application.zig:2295
 msgid "Export"
 msgstr "匯出"
 
-#: src/apprt/gtk/class/application.zig:2783
+#: src/apprt/gtk/class/application.zig:2827
 msgid "Editing configuration file"
 msgstr "正在編輯設定檔"
 
@@ -342,16 +342,16 @@ msgstr "此視窗中的所有終端機工作階段都將被終止。"
 msgid "The currently running process in this split will be terminated."
 msgstr "此窗格中目前執行的處理程序將被終止。"
 
-#: src/apprt/gtk/class/surface.zig:1181
+#: src/apprt/gtk/class/surface.zig:1194
 msgid "Command Finished"
 msgstr "命令執行完成"
 
-#: src/apprt/gtk/class/surface.zig:1182
+#: src/apprt/gtk/class/surface.zig:1195
 #: src/apprt/gtk/class/surface_child_exited.zig:109
 msgid "Command Succeeded"
 msgstr "命令執行成功"
 
-#: src/apprt/gtk/class/surface.zig:1183
+#: src/apprt/gtk/class/surface.zig:1196
 #: src/apprt/gtk/class/surface_child_exited.zig:113
 msgid "Command Failed"
 msgstr "命令執行失敗"
@@ -368,19 +368,19 @@ msgstr "變更分頁標題"
 msgid "Change Window Title"
 msgstr "變更視窗標題"
 
-#: src/apprt/gtk/class/window.zig:1153
+#: src/apprt/gtk/class/window.zig:1159
 msgid "Reloaded the configuration"
 msgstr "已重新載入設定"
 
-#: src/apprt/gtk/class/window.zig:1830
+#: src/apprt/gtk/class/window.zig:1836
 msgid "Copied to clipboard"
 msgstr "已複製到剪貼簿"
 
-#: src/apprt/gtk/class/window.zig:1832
+#: src/apprt/gtk/class/window.zig:1838
 msgid "Cleared clipboard"
 msgstr "已清除剪貼簿"
 
-#: src/apprt/gtk/class/window.zig:1972
+#: src/apprt/gtk/class/window.zig:1978
 msgid "Ghostty Developers"
 msgstr "Ghostty 開發者"
 
@@ -962,134 +962,158 @@ msgstr "重新載入設定"
 msgid "Reload the config file."
 msgstr "重新載入設定檔。"
 
-#: src/input/command.zig:606
+#: src/input/command.zig:607
+msgid "Switch to Dark Appearance"
+msgstr ""
+
+#: src/input/command.zig:608
+msgid "Use a dark application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:612
+msgid "Switch to Light Appearance"
+msgstr ""
+
+#: src/input/command.zig:613
+msgid "Use a light application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:617
+msgid "Switch to System Appearance"
+msgstr ""
+
+#: src/input/command.zig:618
+msgid "Use the system application appearance for this session."
+msgstr ""
+
+#: src/input/command.zig:624
 msgid "Close Terminal"
 msgstr "關閉終端機"
 
-#: src/input/command.zig:607
+#: src/input/command.zig:625
 msgid "Close the current terminal."
 msgstr "關閉目前終端機。"
 
-#: src/input/command.zig:614
+#: src/input/command.zig:632
 msgid "Close the current tab."
 msgstr "關閉目前分頁。"
 
-#: src/input/command.zig:618
+#: src/input/command.zig:636
 msgid "Close Other Tabs"
 msgstr "關閉其他分頁"
 
-#: src/input/command.zig:619
+#: src/input/command.zig:637
 msgid "Close all tabs in this window except the current one."
 msgstr "關閉此視窗中目前分頁以外的所有分頁。"
 
-#: src/input/command.zig:623
+#: src/input/command.zig:641
 msgid "Close Tabs to the Right"
 msgstr "關閉右側的分頁"
 
-#: src/input/command.zig:624
+#: src/input/command.zig:642
 msgid "Close all tabs to the right of the current one."
 msgstr "關閉目前分頁右側的所有分頁。"
 
-#: src/input/command.zig:631
+#: src/input/command.zig:649
 msgid "Close the current window."
 msgstr "關閉目前視窗。"
 
-#: src/input/command.zig:636
+#: src/input/command.zig:654
 msgid "Close All Windows"
 msgstr "關閉所有視窗"
 
-#: src/input/command.zig:637
+#: src/input/command.zig:655
 msgid "Close all windows."
 msgstr "關閉所有視窗。"
 
-#: src/input/command.zig:642
+#: src/input/command.zig:660
 msgid "Toggle Maximize"
 msgstr "切換最大化"
 
-#: src/input/command.zig:643
+#: src/input/command.zig:661
 msgid "Toggle the maximized state of the current window."
 msgstr "切換目前視窗的最大化狀態。"
 
-#: src/input/command.zig:648
+#: src/input/command.zig:666
 msgid "Toggle Fullscreen"
 msgstr "切換全螢幕"
 
-#: src/input/command.zig:649
+#: src/input/command.zig:667
 msgid "Toggle the fullscreen state of the current window."
 msgstr "切換目前視窗的全螢幕狀態。"
 
-#: src/input/command.zig:654
+#: src/input/command.zig:672
 msgid "Toggle Window Decorations"
 msgstr "切換視窗裝飾"
 
-#: src/input/command.zig:655
+#: src/input/command.zig:673
 msgid "Toggle the window decorations."
 msgstr "切換視窗裝飾。"
 
-#: src/input/command.zig:660
+#: src/input/command.zig:678
 msgid "Toggle Float on Top"
 msgstr "切換置頂"
 
-#: src/input/command.zig:661
+#: src/input/command.zig:679
 msgid "Toggle the float on top state of the current window."
 msgstr "切換目前視窗的置頂狀態。"
 
-#: src/input/command.zig:666
+#: src/input/command.zig:684
 msgid "Toggle Secure Input"
 msgstr "切換安全輸入"
 
-#: src/input/command.zig:667
+#: src/input/command.zig:685
 msgid "Toggle secure input mode."
 msgstr "切換安全輸入模式。"
 
-#: src/input/command.zig:672
+#: src/input/command.zig:690
 msgid "Toggle Mouse Reporting"
 msgstr "切換滑鼠回報"
 
-#: src/input/command.zig:673
+#: src/input/command.zig:691
 msgid "Toggle whether mouse events are reported to terminal applications."
 msgstr "切換是否將滑鼠事件回報給終端機應用程式。"
 
-#: src/input/command.zig:678
+#: src/input/command.zig:696
 msgid "Toggle Background Opacity"
 msgstr "切換背景不透明度"
 
-#: src/input/command.zig:679
+#: src/input/command.zig:697
 msgid "Toggle the background opacity of a window that started transparent."
 msgstr "切換以透明狀態啟動之視窗的背景不透明度。"
 
-#: src/input/command.zig:684
+#: src/input/command.zig:702
 msgid "Check for Updates"
 msgstr "檢查更新"
 
-#: src/input/command.zig:685
+#: src/input/command.zig:703
 msgid "Check for updates to the application."
 msgstr "檢查應用程式是否有更新。"
 
-#: src/input/command.zig:690
+#: src/input/command.zig:708
 msgid "Undo"
 msgstr "復原"
 
-#: src/input/command.zig:691
+#: src/input/command.zig:709
 msgid "Undo the last action."
 msgstr "復原上一個動作。"
 
-#: src/input/command.zig:696
+#: src/input/command.zig:714
 msgid "Redo"
 msgstr "重做"
 
-#: src/input/command.zig:697
+#: src/input/command.zig:715
 msgid "Redo the last undone action."
 msgstr "重做上一個已復原的動作。"
 
-#: src/input/command.zig:703
+#: src/input/command.zig:721
 msgid "Quit the application."
 msgstr "結束應用程式。"
 
-#: src/input/command.zig:708
+#: src/input/command.zig:726
 msgid "Ghostty"
 msgstr "Ghostty"
 
-#: src/input/command.zig:709
+#: src/input/command.zig:727
 msgid "Put a little Ghostty in your terminal."
 msgstr "在您的終端機裡放一隻小小的 Ghostty。"

--- a/src/App.zig
+++ b/src/App.zig
@@ -468,6 +468,15 @@ pub fn performAction(
             },
         ),
         .reload_config => _ = try rt_app.performAction(.app, .reload_config, .{}),
+        .set_window_theme => |v| _ = try rt_app.performAction(
+            .app,
+            .set_window_theme,
+            switch (v) {
+                .dark => .dark,
+                .light => .light,
+                .system => .system,
+            },
+        ),
         .close_all_windows => _ = try rt_app.performAction(.app, .close_all_windows, {}),
         .toggle_quick_terminal => _ = try rt_app.performAction(.app, .toggle_quick_terminal, {}),
         .toggle_visibility => _ = try rt_app.performAction(.app, .toggle_visibility, {}),

--- a/src/apprt/action.zig
+++ b/src/apprt/action.zig
@@ -357,6 +357,9 @@ pub const Action = union(Key) {
     /// Move a tab to a new window.
     move_tab_to_new_window,
 
+    /// Set the application window theme for this session.
+    set_window_theme: WindowTheme,
+
     /// Sync with: ghostty_action_tag_e
     pub const Key = enum(c_int) {
         quit,
@@ -428,6 +431,7 @@ pub const Action = union(Key) {
         readonly,
         copy_title_to_clipboard,
         move_tab_to_new_window,
+        set_window_theme,
 
         test "ghostty.h Action.Key" {
             try lib.checkGhosttyHEnum(Key, "GHOSTTY_ACTION_");
@@ -610,6 +614,16 @@ pub const SecureInput = enum(c_int) {
 
     test "ghostty.h SecureInput" {
         try lib.checkGhosttyHEnum(SecureInput, "GHOSTTY_SECURE_INPUT_");
+    }
+};
+
+pub const WindowTheme = enum(c_int) {
+    dark,
+    light,
+    system,
+
+    test "ghostty.h WindowTheme" {
+        try lib.checkGhosttyHEnum(WindowTheme, "GHOSTTY_ACTION_WINDOW_THEME_");
     }
 };
 

--- a/src/apprt/gtk/class/application.zig
+++ b/src/apprt/gtk/class/application.zig
@@ -178,6 +178,9 @@ pub const Application = extern struct {
         /// The configuration for the application.
         config: *Config,
 
+        /// The application window theme selected for this session.
+        window_theme_override: ?apprt.action.WindowTheme = null,
+
         /// State and logic for the underlying windowing protocol.
         winproto: winprotopkg.App,
 
@@ -756,6 +759,8 @@ pub const Application = extern struct {
             .quit_timer => try Action.quitTimer(self, value),
 
             .reload_config => try Action.reloadConfig(self, target, value),
+
+            .set_window_theme => Action.setWindowTheme(self, value),
 
             .render => Action.render(target),
 
@@ -1432,19 +1437,8 @@ pub const Application = extern struct {
         const config = priv.config.get();
 
         // Setup our initial light/dark
+        self.syncStyleManager(config);
         const style = self.as(adw.Application).getStyleManager();
-        style.setColorScheme(switch (config.@"window-theme") {
-            .auto, .ghostty => auto: {
-                const lum = config.background.toTerminalRGB().perceivedLuminance();
-                break :auto if (lum > 0.5)
-                    .prefer_light
-                else
-                    .prefer_dark;
-            },
-            .system => .prefer_light,
-            .dark => .force_dark,
-            .light => .force_light,
-        });
 
         // Setup color change notifications
         _ = gobject.Object.signals.notify.connect(
@@ -1459,6 +1453,23 @@ pub const Application = extern struct {
         // if our current theme matches what libghostty has so its safe to
         // call.
         handleStyleManagerDark(style, undefined, self);
+    }
+
+    fn syncStyleManager(self: *Self, config: *const CoreConfig) void {
+        self.as(adw.Application).getStyleManager().setColorScheme(
+            switch (config.@"window-theme") {
+                .auto, .ghostty => auto: {
+                    const lum = config.background.toTerminalRGB().perceivedLuminance();
+                    break :auto if (lum > 0.5)
+                        .prefer_light
+                    else
+                        .prefer_dark;
+                },
+                .system => .prefer_light,
+                .dark => .force_dark,
+                .light => .force_light,
+            },
+        );
     }
 
     /// Setup signal handlers
@@ -2360,7 +2371,12 @@ const Action = struct {
 
         switch (target) {
             .surface => |core| core.rt_surface.surface.setConfig(config_obj),
-            .app => self.setConfig(config_obj),
+            .app => {
+                self.setConfig(config_obj);
+                if (self.private().window_theme_override == null) {
+                    self.syncStyleManager(new_config);
+                }
+            },
         }
     }
 
@@ -2938,6 +2954,18 @@ const Action = struct {
                 }
             },
         }
+    }
+
+    pub fn setWindowTheme(
+        self: *Application,
+        theme: apprt.action.WindowTheme,
+    ) void {
+        self.private().window_theme_override = theme;
+        self.as(adw.Application).getStyleManager().setColorScheme(switch (theme) {
+            .dark => .force_dark,
+            .light => .force_light,
+            .system => .prefer_light,
+        });
     }
 
     /// Reload the configuration for the application and propagate it

--- a/src/input/Binding.zig
+++ b/src/input/Binding.zig
@@ -722,6 +722,13 @@ pub const Action = union(enum) {
     /// Note that not all changes can be applied at runtime.
     reload_config,
 
+    /// Set the application window theme for this session.
+    ///
+    /// This does not modify the configuration and remains in effect until
+    /// another `set_window_theme` action or the application restarts.
+    /// Valid values are `dark`, `light`, and `system`.
+    set_window_theme: WindowTheme,
+
     /// Close the current "surface", whether that is a window, tab, split, etc.
     ///
     /// This might trigger a close confirmation popup, depending on the value
@@ -1218,6 +1225,12 @@ pub const Action = union(enum) {
         pub const default: OpenConfig = .os_open;
     };
 
+    pub const WindowTheme = enum {
+        dark,
+        light,
+        system,
+    };
+
     fn parseEnum(comptime T: type, value: []const u8) !T {
         return std.meta.stringToEnum(T, value) orelse return Error.InvalidFormat;
     }
@@ -1366,6 +1379,7 @@ pub const Action = union(enum) {
             // Obviously app actions.
             .open_config,
             .reload_config,
+            .set_window_theme,
             .close_all_windows,
             .quit,
             .toggle_quick_terminal,

--- a/src/input/command.zig
+++ b/src/input/command.zig
@@ -601,6 +601,24 @@ fn actionCommands(action: Action.Key) []const Command {
             .description = i18n.N_("Reload the config file."),
         }},
 
+        .set_window_theme => comptime &.{
+            .{
+                .action = .{ .set_window_theme = .dark },
+                .title = i18n.N_("Switch to Dark Appearance"),
+                .description = i18n.N_("Use a dark application appearance for this session."),
+            },
+            .{
+                .action = .{ .set_window_theme = .light },
+                .title = i18n.N_("Switch to Light Appearance"),
+                .description = i18n.N_("Use a light application appearance for this session."),
+            },
+            .{
+                .action = .{ .set_window_theme = .system },
+                .title = i18n.N_("Switch to System Appearance"),
+                .description = i18n.N_("Use the system application appearance for this session."),
+            },
+        },
+
         .close_surface => comptime &.{.{
             .action = .close_surface,
             .title = i18n.N_("Close Terminal"),


### PR DESCRIPTION
Add an app-scoped set_window_theme action with dark, light, and system values so appearance can be changed from keybindings and generated command palette entries. Previously these controls had no shared action and were unavailable across application runtimes.

Apply the action as a session override through NSAppearance on macOS and AdwStyleManager on GTK. Keep overrides across config reloads, matching the existing window-decoration override behavior, without persisting configuration.

See #7221