### PR TITLE
libghostty and renderer base layer to support pixel precise scrolling.

### DIFF
--- a/include/ghostty/vt/render.h
+++ b/include/ghostty/vt/render.h
@@ -210,6 +210,10 @@ typedef enum GHOSTTY_ENUM_TYPED {
   /** All render-state colors in one sized struct (GhosttyRenderStateColors).
    *  Initialize the output with GHOSTTY_INIT_SIZED before querying. */
   GHOSTTY_RENDER_STATE_DATA_COLORS = 19,
+
+  /** Fractional part of the scroll row (double).
+   *  When non-zero, the row iterator yields one extra row below the viewport. */
+  GHOSTTY_RENDER_STATE_DATA_SCROLL_ROW_FRAC = 20,
   GHOSTTY_RENDER_STATE_DATA_MAX_VALUE = GHOSTTY_ENUM_MAX_VALUE,
 } GhosttyRenderStateData;
 

--- a/include/ghostty/vt/terminal.h
+++ b/include/ghostty/vt/terminal.h
@@ -244,6 +244,14 @@ typedef enum GHOSTTY_ENUM_TYPED {
    * GHOSTTY_TERMINAL_DATA_SCROLLBAR round-trips cleanly.
    */
   GHOSTTY_SCROLL_VIEWPORT_ROW,
+
+  /**
+   * Scroll by a fractional number of rows (up is negative). Combined
+   * with the integer viewport pin this updates the fractional scroll
+   * row. Integer GHOSTTY_SCROLL_VIEWPORT_DELTA still resets the
+   * fraction to 0.
+   */
+  GHOSTTY_SCROLL_VIEWPORT_DELTA_F,
   GHOSTTY_SCROLL_VIEWPORT_MAX_VALUE = GHOSTTY_ENUM_MAX_VALUE,
 } GhosttyTerminalScrollViewportTag;
 
@@ -258,6 +266,12 @@ typedef union {
 
   /** Absolute row offset (only used with GHOSTTY_SCROLL_VIEWPORT_ROW). */
   size_t row;
+
+  /**
+   * Fractional row delta (only used with GHOSTTY_SCROLL_VIEWPORT_DELTA_F).
+   * Up is negative.
+   */
+  double delta_f;
 
   /** Padding for ABI compatibility. Do not use. */
   uint64_t _padding[2];
@@ -1552,7 +1566,8 @@ typedef enum GHOSTTY_ENUM_TYPED {
    * scroll position. 0 is row-aligned.
    *
    * A NULL value pointer or a value outside 0 <= value < 1 stores
-   * 0. ghostty_terminal_scroll_viewport resets this to 0. Always
+   * 0. Integer ghostty_terminal_scroll_viewport behaviors reset this
+   * to 0. GHOSTTY_SCROLL_VIEWPORT_DELTA_F updates it. Always
    * reported as 0 at the bottom.
    *
    * Input type: double*
@@ -2227,10 +2242,12 @@ GHOSTTY_API GhosttyResult ghostty_terminal_continuation_alloc(
  * Scrolls the terminal's viewport according to the given behavior.
  * When using GHOSTTY_SCROLL_VIEWPORT_DELTA, set the delta field in
  * the value union to specify the number of rows to scroll (negative
- * for up, positive for down). When using GHOSTTY_SCROLL_VIEWPORT_ROW,
- * set the row field to the absolute row offset from the top of the
- * scrollable area (the same row space as the offset field of
- * GhosttyTerminalScrollbar). For other behaviors, the value is ignored.
+ * for up, positive for down). When using GHOSTTY_SCROLL_VIEWPORT_DELTA_F,
+ * set the delta_f field to a fractional row delta. 
+ * When using GHOSTTY_SCROLL_VIEWPORT_ROW, set the row field to the absolute
+ * row offset from the top of the scrollable area (the same row space as the
+ * offset field of GhosttyTerminalScrollbar). For other behaviors, the value
+ * is ignored.
  *
  * @param terminal The terminal handle (may be NULL, in which case this is a no-op)
  * @param behavior The scroll behavior as a tagged union

--- a/include/ghostty/vt/terminal.h
+++ b/include/ghostty/vt/terminal.h
@@ -1545,6 +1545,19 @@ typedef enum GHOSTTY_ENUM_TYPED {
    * Input type: size_t*
    */
   GHOSTTY_TERMINAL_OPT_CLIPBOARD_WRITE_MAX_BYTES = 39,
+
+  /**
+   * Set the fractional part of the scroll row, 0 <= value < 1.
+   * Combined with the integer scrollbar offset this is the visual
+   * scroll position. 0 is row-aligned.
+   *
+   * A NULL value pointer or a value outside 0 <= value < 1 stores
+   * 0. ghostty_terminal_scroll_viewport resets this to 0. Always
+   * reported as 0 at the bottom.
+   *
+   * Input type: double*
+   */
+  GHOSTTY_TERMINAL_OPT_SCROLL_ROW_FRAC = 40,
   GHOSTTY_TERMINAL_OPT_MAX_VALUE = GHOSTTY_ENUM_MAX_VALUE,
 } GhosttyTerminalOption;
 
@@ -1951,6 +1964,14 @@ typedef enum GHOSTTY_ENUM_TYPED {
    * Output type: size_t *
    */
   GHOSTTY_TERMINAL_DATA_CLIPBOARD_WRITE_MAX_BYTES = 40,
+
+  /**
+   * Fractional part of the scroll row. See
+   * GHOSTTY_TERMINAL_OPT_SCROLL_ROW_FRAC.
+   *
+   * Output type: double *
+   */
+  GHOSTTY_TERMINAL_DATA_SCROLL_ROW_FRAC = 41,
   GHOSTTY_TERMINAL_DATA_MAX_VALUE = GHOSTTY_ENUM_MAX_VALUE,
 } GhosttyTerminalData;
 

--- a/src/inspector/widgets/pagelist.zig
+++ b/src/inspector/widgets/pagelist.zig
@@ -22,7 +22,8 @@ const InspectedCell = struct {
 pub const Inspector = struct {
     pub const empty: Inspector = .{};
 
-    pub fn draw(_: *const Inspector, pages: *PageList) void {
+    pub fn draw(_: *const Inspector, screen: *terminal.Screen) void {
+        const pages = &screen.pages;
         cimgui.c.ImGui_TextWrapped(
             "PageList manages the backing pages that hold scrollback and the active " ++
                 "terminal grid. Each page is a contiguous memory buffer with its " ++
@@ -48,7 +49,7 @@ pub const Inspector = struct {
             cimgui.c.ImGuiTreeNodeFlags_DefaultOpen,
         )) {
             cimgui.c.ImGui_SeparatorText("Scrollbar");
-            scrollbarInfo(pages);
+            scrollbarInfo(screen);
             cimgui.c.ImGui_SeparatorText("Regions");
             regionsTable(pages);
         }
@@ -310,7 +311,8 @@ fn percentage(numerator: usize, denominator: usize) f64 {
         @as(f64, @floatFromInt(denominator));
 }
 
-fn scrollbarInfo(pages: *PageList) void {
+fn scrollbarInfo(screen: *terminal.Screen) void {
+    const pages = &screen.pages;
     const scrollbar = pages.scrollbar();
 
     // If we have a scrollbar, show it.
@@ -346,6 +348,30 @@ fn scrollbarInfo(pages: *PageList) void {
     widgets.helpMarker("Current scroll position as row offset from the top of scrollback.");
     _ = cimgui.c.ImGui_TableSetColumnIndex(2);
     cimgui.c.ImGui_Text("%d", scrollbar.offset);
+
+    cimgui.c.ImGui_TableNextRow();
+    _ = cimgui.c.ImGui_TableSetColumnIndex(0);
+    cimgui.c.ImGui_Text("Row Frac");
+    _ = cimgui.c.ImGui_TableSetColumnIndex(1);
+    widgets.helpMarker(
+        "Fractional part of the scroll row. Combined with Offset this is the visual " ++
+            "scroll position. Always 0 at the bottom; scroll up to change it.",
+    );
+    _ = cimgui.c.ImGui_TableSetColumnIndex(2);
+    {
+        var frac: f32 = @floatCast(screen.scrollRowFrac());
+        cimgui.c.ImGui_BeginDisabled(screen.viewportIsBottom());
+        defer cimgui.c.ImGui_EndDisabled();
+        cimgui.c.ImGui_SetNextItemWidth(cimgui.c.ImGui_GetFontSize() * 8);
+        if (cimgui.c.ImGui_SliderFloat(
+            "##scroll_row_frac",
+            &frac,
+            0,
+            std.math.nextAfter(f32, 1.0, 0.0),
+        )) {
+            screen.setScrollRowFrac(frac);
+        }
+    }
 
     cimgui.c.ImGui_TableNextRow();
     _ = cimgui.c.ImGui_TableSetColumnIndex(0);

--- a/src/inspector/widgets/screen.zig
+++ b/src/inspector/widgets/screen.zig
@@ -110,7 +110,7 @@ pub const Info = struct {
                 null,
                 cimgui.c.ImGuiWindowFlags_NoFocusOnAppearing,
             )) break :pagelist;
-            self.pagelist.draw(&screen.pages);
+            self.pagelist.draw(screen);
         }
 
         // The remainder is the open state

--- a/src/renderer/generic.zig
+++ b/src/renderer/generic.zig
@@ -727,6 +727,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                     .grid_size = undefined,
                     .grid_padding = undefined,
                     .screen_size = undefined,
+                    .content_offset = .{ 0, 0 },
                     .padding_extend = .{},
                     .min_contrast = options.config.min_contrast,
                     .cursor_pos = .{ std.math.maxInt(u16), std.math.maxInt(u16) },
@@ -1597,6 +1598,17 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
 
                 // Update custom shader uniforms that depend on terminal state.
                 self.updateCustomShaderUniformsFromState();
+
+                // Sub-row scroll: shift the grid up by frac * cell height.
+                // Set every frame so a frac-only change still draws.
+                const px: f32 = @floatCast(
+                    -self.terminal_state.scroll_row_frac *
+                        @as(f64, @floatFromInt(self.grid_metrics.cell_height)),
+                );
+                if (self.uniforms.content_offset[1] != px) {
+                    self.uniforms.content_offset = .{ 0, px };
+                    self.cells_rebuilt = true;
+                }
             }
 
             // Start the display link now that the rebuilt frame is ready.
@@ -2148,7 +2160,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 self.size.padding,
                 .{
                     .columns = self.cells.size.columns,
-                    .rows = self.cells.size.rows,
+                    .rows = self.terminal_state.rows,
                 },
                 .{
                     .width = self.grid_metrics.cell_width,
@@ -2507,13 +2519,14 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
         ) Allocator.Error!void {
             const state: *terminal.RenderState = &self.terminal_state;
 
+            const paint_rows: u16 = @intCast(state.row_data.len);
             const grid_size_diff =
-                self.cells.size.rows != state.rows or
+                self.cells.size.rows != paint_rows or
                 self.cells.size.columns != state.cols;
 
             if (grid_size_diff) {
                 var new_size = self.cells.size;
-                new_size.rows = state.rows;
+                new_size.rows = paint_rows;
                 new_size.columns = state.cols;
                 try self.cells.resize(self.alloc, new_size);
 
@@ -2561,7 +2574,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
             // the viewport is shorter than the cell contents buffer, we align
             // the top of the viewport with the top of the contents buffer.
             const row_len: usize = @min(
-                state.rows,
+                state.row_data.len,
                 self.cells.size.rows,
             );
 
@@ -2573,6 +2586,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 // don't show it.
                 const cursor_vp = state.cursor.viewport orelse
                     break :preedit null;
+                if (cursor_vp.y >= row_dirty.len) break :preedit null;
 
                 // If our preedit row isn't dirty then we don't need the
                 // preedit range. This also avoids an issue later where we
@@ -2642,6 +2656,7 @@ pub fn Renderer(comptime GraphicsAPI: type) type {
                 // a cursor. Otherwise, get our cursor cell, because we may
                 // need it for styling.
                 const cursor_vp = state.cursor.viewport orelse break :cursor;
+                if (cursor_vp.y >= state.row_data.len) break :cursor;
                 const cursor_style: terminal.Style = cursor_style: {
                     const cells = state.row_data.items(.cells);
                     const cell = cells[cursor_vp.y].get(cursor_vp.x);

--- a/src/renderer/metal/shaders.zig
+++ b/src/renderer/metal/shaders.zig
@@ -199,6 +199,10 @@ pub const Uniforms = extern struct {
     /// Size of a single cell in pixels, unscaled.
     cell_size: [2]f32 align(8),
 
+    /// Pixel offset applied to the grid for a sub-row scroll.
+    /// `(0, -frac * cell_height)` when `scroll_row_frac` is set.
+    content_offset: [2]f32 align(8) = .{ 0, 0 },
+
     /// Size of the grid in columns and rows.
     grid_size: [2]u16 align(4),
 

--- a/src/renderer/opengl/shaders.zig
+++ b/src/renderer/opengl/shaders.zig
@@ -165,6 +165,10 @@ pub const Uniforms = extern struct {
     /// Size of a single cell in pixels, unscaled.
     cell_size: [2]f32 align(8),
 
+    /// Pixel offset applied to the grid for a sub-row scroll.
+    /// `(0, -frac * cell_height)` when `scroll_row_frac` is set.
+    content_offset: [2]f32 align(8) = .{ 0, 0 },
+
     /// Size of the grid in columns and rows.
     grid_size: [2]u16 align(4),
 

--- a/src/renderer/shaders/glsl/cell_bg.f.glsl
+++ b/src/renderer/shaders/glsl/cell_bg.f.glsl
@@ -12,7 +12,7 @@ layout(binding = 1, std430) readonly buffer bg_cells {
 
 vec4 cell_bg() {
     uvec2 grid_size = unpack2u16(grid_size_packed_2u16);
-    ivec2 grid_pos = ivec2(floor((gl_FragCoord.xy - grid_padding.wx) / cell_size));
+    ivec2 grid_pos = ivec2(floor((gl_FragCoord.xy - grid_padding.wx - content_offset) / cell_size));
     bool use_linear_blending = (bools & USE_LINEAR_BLENDING) != 0;
 
     vec4 bg = vec4(0.0);

--- a/src/renderer/shaders/glsl/cell_text.v.glsl
+++ b/src/renderer/shaders/glsl/cell_text.v.glsl
@@ -47,7 +47,7 @@ void main() {
     bool use_linear_blending = (bools & USE_LINEAR_BLENDING) != 0;
 
     // Convert the grid x, y into world space x, y by accounting for cell size
-    vec2 cell_pos = cell_size * vec2(grid_pos);
+    vec2 cell_pos = cell_size * vec2(grid_pos) + content_offset;
 
     int vid = gl_VertexID;
 

--- a/src/renderer/shaders/glsl/common.glsl
+++ b/src/renderer/shaders/glsl/common.glsl
@@ -15,6 +15,7 @@ layout(binding = 1, std140) uniform Globals {
     uniform mat4 projection_matrix;
     uniform vec2 screen_size;
     uniform vec2 cell_size;
+    uniform vec2 content_offset;
     uniform uint grid_size_packed_2u16;
     uniform vec4 grid_padding;
     uniform uint padding_extend;

--- a/src/renderer/shaders/glsl/image.v.glsl
+++ b/src/renderer/shaders/glsl/image.v.glsl
@@ -40,7 +40,7 @@ void main() {
 
     // The position of our image starts at the top-left of the grid cell and
     // adds the source rect width/height components.
-    vec2 image_pos = (cell_size * grid_pos) + cell_offset;
+    vec2 image_pos = (cell_size * grid_pos) + cell_offset + content_offset;
     image_pos += dest_size * corner;
 
     gl_Position = projection_matrix * vec4(image_pos.xy, 1.0, 1.0);

--- a/src/renderer/shaders/shaders.metal
+++ b/src/renderer/shaders/shaders.metal
@@ -13,6 +13,7 @@ struct Uniforms {
   float4x4 projection_matrix;
   float2 screen_size;
   float2 cell_size;
+  float2 content_offset;
   ushort2 grid_size;
   float4 grid_padding;
   uint8_t padding_extend;
@@ -453,7 +454,7 @@ fragment float4 cell_bg_fragment(
   constant Uniforms& uniforms [[buffer(1)]],
   constant uchar4 *cells [[buffer(2)]]
 ) {
-  int2 grid_pos = int2(floor((in.position.xy - uniforms.grid_padding.wx) / uniforms.cell_size));
+  int2 grid_pos = int2(floor((in.position.xy - uniforms.grid_padding.wx - uniforms.content_offset) / uniforms.cell_size));
 
   float4 bg = float4(0.0);
 
@@ -560,7 +561,7 @@ vertex CellTextVertexOut cell_text_vertex(
   constant uchar4 *bg_colors [[buffer(2)]]
 ) {
   // Convert the grid x, y into world space x, y by accounting for cell size
-  float2 cell_pos = uniforms.cell_size * float2(in.grid_pos);
+  float2 cell_pos = uniforms.cell_size * float2(in.grid_pos) + uniforms.content_offset;
 
   // We use a triangle strip with 4 vertices to render quads,
   // so we determine which corner of the cell this vertex is in
@@ -820,7 +821,7 @@ vertex ImageVertexOut image_vertex(
 
   // The position of our image starts at the top-left of the grid cell and
   // adds the source rect width/height components.
-  float2 image_pos = (uniforms.cell_size * in.grid_pos) + in.cell_offset;
+  float2 image_pos = (uniforms.cell_size * in.grid_pos) + in.cell_offset + uniforms.content_offset;
   image_pos += in.dest_size * corner;
 
   out.position =

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -44,6 +44,12 @@ alloc: Allocator,
 /// The list of pages in the screen.
 pages: PageList,
 
+/// Fractional part of the scroll row (`0 <= value < 1`). Combined with the
+/// integer viewport pin this is the visual scroll position. `0` is
+/// row-aligned. While the viewport is at the bottom this is ignored
+/// and `scrollRowFrac` returns `0`.
+scroll_row_frac: f64 = 0,
+
 /// Special-case where we want no scrollback whatsoever. We have to flag
 /// this because max_size 0 in PageList gets rounded up to two pages so
 /// we can always have an active screen.
@@ -367,6 +373,7 @@ pub fn assertIntegrity(self: *const Screen) void {
 
         assert(self.cursor.x < self.pages.cols);
         assert(self.cursor.y < self.pages.rows);
+        assert(self.scroll_row_frac >= 0 and self.scroll_row_frac < 1);
 
         // Our cursor x/y should always match the pin. If this doesn't
         // match then it indicates that the tracked pin moved and we didn't
@@ -438,6 +445,7 @@ pub fn reset(self: *Screen) void {
     }
 
     // Reset our basic state
+    self.scroll_row_frac = 0;
     self.saved_cursor = null;
     self.charset = .{};
     self.kitty_keyboard = .{};
@@ -1626,6 +1634,9 @@ pub const Scroll = union(enum) {
 pub inline fn scroll(self: *Screen, behavior: Scroll) void {
     defer self.assertIntegrity();
 
+    // Integer viewport motion is row-aligned.
+    self.scroll_row_frac = 0;
+
     if (comptime build_options.kitty_graphics) {
         // No matter what, scrolling marks our image state as dirty since
         // it could move placements. If there are no placements or no images
@@ -1648,6 +1659,7 @@ pub inline fn scroll(self: *Screen, behavior: Scroll) void {
 pub inline fn scrollClear(self: *Screen) !void {
     defer self.assertIntegrity();
 
+    self.scroll_row_frac = 0;
     try self.pages.scrollClear();
     self.cursorReload();
 
@@ -1662,6 +1674,21 @@ pub inline fn scrollClear(self: *Screen) !void {
 /// Returns true if the viewport is scrolled to the bottom of the screen.
 pub inline fn viewportIsBottom(self: Screen) bool {
     return self.pages.viewport == .active;
+}
+
+/// Fractional part of the scroll row. Always `0` at the bottom.
+pub fn scrollRowFrac(self: Screen) f64 {
+    if (self.viewportIsBottom()) return 0;
+    return self.scroll_row_frac;
+}
+
+/// Set the fractional part of the scroll row. If not `0 <= value < 1`, stores `0`.
+pub fn setScrollRowFrac(self: *Screen, frac: f64) void {
+    defer self.assertIntegrity();
+    self.scroll_row_frac = if (frac > 0 and frac < 1) frac else 0;
+    if (comptime build_options.kitty_graphics) {
+        self.kitty_images.dirty = true;
+    }
 }
 
 /// Erase the region specified by tl and br, inclusive. This will physically
@@ -5549,6 +5576,40 @@ test "Screen: scrolling moves viewport" {
             .y = 1,
         } }, s.pages.pointFromPin(.screen, s.pages.getTopLeft(.viewport)));
     }
+}
+
+test "Screen: scroll row frac" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    var s = try init(io, alloc, .{
+        .cols = 10,
+        .rows = 3,
+        .max_scrollback_bytes = 10_000,
+    });
+    defer s.deinit();
+    try s.testWriteString("A\nB\nC\nD\nE");
+
+    try testing.expect(s.viewportIsBottom());
+    s.setScrollRowFrac(0.25);
+    try testing.expectEqual(@as(f64, 0), s.scrollRowFrac());
+
+    s.scroll(.top);
+    try testing.expectEqual(@as(f64, 0), s.scrollRowFrac());
+    s.setScrollRowFrac(0.25);
+    try testing.expectEqual(@as(f64, 0.25), s.scrollRowFrac());
+
+    s.setScrollRowFrac(0);
+    try testing.expectEqual(@as(f64, 0), s.scrollRowFrac());
+    s.setScrollRowFrac(1);
+    try testing.expectEqual(@as(f64, 0), s.scrollRowFrac());
+    s.setScrollRowFrac(-0.1);
+    try testing.expectEqual(@as(f64, 0), s.scrollRowFrac());
+
+    s.setScrollRowFrac(0.5);
+    s.scroll(.{ .delta_row = 1 });
+    try testing.expectEqual(@as(f64, 0), s.scrollRowFrac());
 }
 
 test "Screen: scrolling when viewport is pruned" {

--- a/src/terminal/Screen.zig
+++ b/src/terminal/Screen.zig
@@ -1627,12 +1627,21 @@ pub const Scroll = union(enum) {
     pin: Pin,
     row: usize,
     delta_row: isize,
+    delta_f: f64,
     delta_prompt: isize,
 };
 
 /// Scroll the viewport of the terminal grid.
 pub inline fn scroll(self: *Screen, behavior: Scroll) void {
     defer self.assertIntegrity();
+
+    switch (behavior) {
+        .delta_f => |delta_rows| {
+            self.scrollDeltaF(delta_rows);
+            return;
+        },
+        else => {},
+    }
 
     // Integer viewport motion is row-aligned.
     self.scroll_row_frac = 0;
@@ -1651,6 +1660,7 @@ pub inline fn scroll(self: *Screen, behavior: Scroll) void {
         .row => |v| self.pages.scroll(.{ .row = v }),
         .delta_row => |v| self.pages.scroll(.{ .delta_row = v }),
         .delta_prompt => |v| self.pages.scroll(.{ .delta_prompt = v }),
+        .delta_f => unreachable,
     }
 }
 
@@ -1689,6 +1699,31 @@ pub fn setScrollRowFrac(self: *Screen, frac: f64) void {
     if (comptime build_options.kitty_graphics) {
         self.kitty_images.dirty = true;
     }
+}
+
+/// Scroll by a (possibly fractional) number of rows. Positive is toward
+/// the bottom, matching `delta_row`. The integer pin and `scroll_row_frac`
+/// are updated together. At the bottom the fraction is always `0`.
+fn scrollDeltaF(self: *Screen, delta_rows: f64) void {
+    if (delta_rows == 0) return;
+
+    const sb = self.pages.scrollbar();
+    const max_off: usize = sb.total -| sb.len;
+    if (max_off == 0) return;
+
+    const cur = @as(f64, @floatFromInt(sb.offset)) + self.scrollRowFrac();
+    const next = std.math.clamp(
+        cur + delta_rows,
+        0,
+        @as(f64, @floatFromInt(max_off)),
+    );
+    const new_off: usize = @intFromFloat(@floor(next));
+    const new_frac = next - @as(f64, @floatFromInt(new_off));
+    const off_delta: isize =
+        @as(isize, @intCast(new_off)) - @as(isize, @intCast(sb.offset));
+
+    if (off_delta != 0) self.scroll(.{ .delta_row = off_delta });
+    self.setScrollRowFrac(if (new_off == max_off) 0 else new_frac);
 }
 
 /// Erase the region specified by tl and br, inclusive. This will physically
@@ -5608,6 +5643,58 @@ test "Screen: scroll row frac" {
     try testing.expectEqual(@as(f64, 0), s.scrollRowFrac());
 
     s.setScrollRowFrac(0.5);
+    s.scroll(.{ .delta_row = 1 });
+    try testing.expectEqual(@as(f64, 0), s.scrollRowFrac());
+}
+
+test "Screen: scroll delta_f" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    var s = try init(io, alloc, .{
+        .cols = 10,
+        .rows = 3,
+        .max_scrollback_bytes = 10_000,
+    });
+    defer s.deinit();
+    try s.testWriteString("A\nB\nC\nD\nE\nF\nG");
+
+    try testing.expect(s.viewportIsBottom());
+    const max_off = s.pages.scrollbar().offset;
+    try testing.expect(max_off >= 3);
+
+    s.scroll(.{ .delta_f = 0 });
+    try testing.expect(s.viewportIsBottom());
+    try testing.expectEqual(@as(f64, 0), s.scrollRowFrac());
+
+    s.scroll(.{ .delta_f = 1 });
+    try testing.expect(s.viewportIsBottom());
+    try testing.expectEqual(@as(f64, 0), s.scrollRowFrac());
+
+    s.scroll(.{ .delta_f = -0.25 });
+    try testing.expect(!s.viewportIsBottom());
+    try testing.expectEqual(max_off - 1, s.pages.scrollbar().offset);
+    try testing.expectEqual(@as(f64, 0.75), s.scrollRowFrac());
+
+    s.scroll(.{ .delta_f = 0.25 });
+    try testing.expect(s.viewportIsBottom());
+    try testing.expectEqual(max_off, s.pages.scrollbar().offset);
+    try testing.expectEqual(@as(f64, 0), s.scrollRowFrac());
+
+    s.scroll(.{ .delta_f = -2.25 });
+    try testing.expectEqual(max_off - 3, s.pages.scrollbar().offset);
+    try testing.expectEqual(@as(f64, 0.75), s.scrollRowFrac());
+
+    s.scroll(.{ .delta_f = -10_000 });
+    try testing.expectEqual(@as(usize, 0), s.pages.scrollbar().offset);
+    try testing.expectEqual(@as(f64, 0), s.scrollRowFrac());
+
+    s.scroll(.{ .delta_f = 10_000 });
+    try testing.expect(s.viewportIsBottom());
+    try testing.expectEqual(@as(f64, 0), s.scrollRowFrac());
+
+    s.scroll(.{ .delta_f = -0.25 });
     s.scroll(.{ .delta_row = 1 });
     try testing.expectEqual(@as(f64, 0), s.scrollRowFrac());
 }

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -2752,11 +2752,15 @@ pub const ScrollViewport = union(Tag) {
     /// This is the same row space as PageList.Scrollbar offset.
     row: usize,
 
+    /// Scroll by a fractional number of rows, up is negative.
+    delta_f: f64,
+
     pub const Tag = lib.Enum(lib.target, &.{
         "top",
         "bottom",
         "delta",
         "row",
+        "delta_f",
     });
 
     const c_union = lib.TaggedUnion(
@@ -2777,6 +2781,7 @@ pub fn scrollViewport(self: *Terminal, behavior: ScrollViewport) void {
         .top => .{ .top = {} },
         .bottom => .{ .active = {} },
         .delta => |delta| .{ .delta_row = delta },
+        .delta_f => |delta| .{ .delta_f = delta },
         .row => |row| .{ .row = row },
     });
 }

--- a/src/terminal/Terminal.zig
+++ b/src/terminal/Terminal.zig
@@ -2781,6 +2781,16 @@ pub fn scrollViewport(self: *Terminal, behavior: ScrollViewport) void {
     });
 }
 
+/// Fractional part of the scroll row.
+pub fn scrollRowFrac(self: *const Terminal) f64 {
+    return self.screens.active.scrollRowFrac();
+}
+
+/// Set the fractional part of the scroll row.
+pub fn setScrollRowFrac(self: *Terminal, frac: f64) void {
+    self.screens.active.setScrollRowFrac(frac);
+}
+
 /// Return the current compression activity value.
 ///
 /// Callers should schedule a `compress` call whenever this value changes. The

--- a/src/terminal/c/render.zig
+++ b/src/terminal/c/render.zig
@@ -139,6 +139,7 @@ pub const Data = enum(c_int) {
     cursor_viewport_wide_tail = 17,
     cursor = 18,
     colors = 19,
+    scroll_row_frac = 20,
 
     /// Output type expected for querying the data of the given kind.
     pub fn OutType(comptime self: Data) type {
@@ -156,6 +157,7 @@ pub const Data = enum(c_int) {
             .cursor_viewport_x, .cursor_viewport_y => size.CellCountInt,
             .cursor => Cursor,
             .colors => Colors,
+            .scroll_row_frac => f64,
         };
     }
 };
@@ -319,6 +321,7 @@ fn getTyped(
         .invalid => return .invalid_value,
         .cols => out.* = state.state.cols,
         .rows => out.* = state.state.rows,
+        .scroll_row_frac => out.* = state.state.scroll_row_frac,
         .dirty => out.* = state.state.dirty,
         .row_iterator => {
             const it = out.* orelse return .invalid_value;
@@ -1259,6 +1262,71 @@ test "render: set null value" {
     defer free(state);
 
     try testing.expectEqual(Result.invalid_value, set(state, .dirty, null));
+}
+
+test "render: scroll row frac extra row" {
+    var terminal: terminal_c.Terminal = null;
+    try testing.expectEqual(Result.success, terminal_c.new(
+        &lib.alloc.test_allocator,
+        &terminal,
+        10,
+        3,
+    ));
+    defer terminal_c.free(terminal);
+
+    const t = terminal.?.terminal;
+    var s = t.vtStream();
+    defer s.deinit();
+    s.nextSlice("A\r\nB\r\nC\r\nD\r\nE");
+
+    var state: RenderState = null;
+    try testing.expectEqual(Result.success, new(
+        &lib.alloc.test_allocator,
+        &state,
+    ));
+    defer free(state);
+
+    try testing.expectEqual(Result.success, update(state, terminal));
+
+    var rows_val: size.CellCountInt = 0;
+    var frac: f64 = 1;
+    try testing.expectEqual(Result.success, get(state, .rows, @ptrCast(&rows_val)));
+    try testing.expectEqual(Result.success, get(state, .scroll_row_frac, @ptrCast(&frac)));
+    try testing.expectEqual(@as(size.CellCountInt, 3), rows_val);
+    try testing.expectEqual(@as(f64, 0), frac);
+
+    {
+        var iterator: RowIterator = null;
+        try testing.expectEqual(Result.success, row_iterator_new(
+            &lib.alloc.test_allocator,
+            &iterator,
+        ));
+        defer row_iterator_free(iterator);
+        try testing.expectEqual(Result.success, get(state, .row_iterator, @ptrCast(&iterator)));
+        var n: usize = 0;
+        while (row_iterator_next(iterator)) n += 1;
+        try testing.expectEqual(@as(usize, 3), n);
+    }
+
+    t.scrollViewport(.top);
+    t.setScrollRowFrac(0.25);
+    try testing.expectEqual(Result.success, update(state, terminal));
+    try testing.expectEqual(Result.success, get(state, .rows, @ptrCast(&rows_val)));
+    try testing.expectEqual(Result.success, get(state, .scroll_row_frac, @ptrCast(&frac)));
+    try testing.expectEqual(@as(size.CellCountInt, 3), rows_val);
+    try testing.expectEqual(@as(f64, 0.25), frac);
+
+    var iterator: RowIterator = null;
+    try testing.expectEqual(Result.success, row_iterator_new(
+        &lib.alloc.test_allocator,
+        &iterator,
+    ));
+    defer row_iterator_free(iterator);
+    try testing.expectEqual(Result.success, get(state, .row_iterator, @ptrCast(&iterator)));
+
+    var n: usize = 0;
+    while (row_iterator_next(iterator)) n += 1;
+    try testing.expectEqual(@as(usize, 4), n);
 }
 
 test "render: row iterator get invalid value" {

--- a/src/terminal/c/terminal.zig
+++ b/src/terminal/c/terminal.zig
@@ -1221,6 +1221,7 @@ pub const Option = enum(c_int) {
     terminfo_name = 37,
     clipboard_read = 38,
     clipboard_write_max_bytes = 39,
+    scroll_row_frac = 40,
 
     /// Input type expected for setting the option.
     pub fn InType(comptime self: Option) type {
@@ -1258,6 +1259,7 @@ pub const Option = enum(c_int) {
             .unknown_max_bytes,
             .clipboard_write_max_bytes,
             => ?*const usize,
+            .scroll_row_frac => ?*const f64,
             .selection => ?*const selection_c.CSelection,
             .default_cursor_style => ?*const TerminalCursorStyle,
             .default_cursor_blink => ?*const bool,
@@ -1459,6 +1461,9 @@ fn setTyped(
             if (value) |ptr| ptr.* else 0,
         .clipboard_write_max_bytes => wrapper.stream.handler.kitty_clipboard_write_max_bytes =
             if (value) |ptr| ptr.* else kitty_clipboard.max_write_size,
+        .scroll_row_frac => wrapper.terminal.setScrollRowFrac(
+            if (value) |ptr| ptr.* else 0,
+        ),
         .mode, .mode_default => {
             const config = (value orelse return .invalid_value).*;
             const mode = config.toMode() orelse return .invalid_value;
@@ -1593,6 +1598,7 @@ pub const TerminalData = enum(c_int) {
     vt_ground = 38,
     cursor_at_prompt = 39,
     clipboard_write_max_bytes = 40,
+    scroll_row_frac = 41,
 
     /// Output type expected for querying the data of the given kind.
     pub fn OutType(comptime self: TerminalData) type {
@@ -1620,6 +1626,7 @@ pub const TerminalData = enum(c_int) {
             .clipboard_write_max_bytes,
             => usize,
             .width_px, .height_px => u32,
+            .scroll_row_frac => f64,
             .color_foreground,
             .color_background,
             .color_cursor,
@@ -1775,6 +1782,7 @@ fn getTyped(
             out.value = t.modes.get(mode);
         },
         .cursor_at_prompt => out.* = t.cursorIsAtPrompt(),
+        .scroll_row_frac => out.* = t.scrollRowFrac(),
     }
 
     return .success;
@@ -2390,6 +2398,37 @@ test "scroll_viewport row" {
     }
     try testing.expectEqual(Result.success, get(t, .scrollbar, @ptrCast(&scrollbar_data)));
     try testing.expectEqual(@as(u64, 2), scrollbar_data.offset);
+}
+
+test "scroll row frac get/set" {
+    var t: Terminal = null;
+    try testing.expectEqual(Result.success, new(
+        &lib.alloc.test_allocator,
+        &t,
+        10,
+        3,
+    ));
+    defer free(t);
+
+    vt_write(t, "A\r\nB\r\nC\r\nD\r\nE", 17);
+
+    var frac: f64 = 1;
+    try testing.expectEqual(Result.success, get(t, .scroll_row_frac, @ptrCast(&frac)));
+    try testing.expectEqual(@as(f64, 0), frac);
+
+    const set_frac: f64 = 0.25;
+    try testing.expectEqual(Result.success, set(t, .scroll_row_frac, @ptrCast(&set_frac)));
+    try testing.expectEqual(Result.success, get(t, .scroll_row_frac, @ptrCast(&frac)));
+    try testing.expectEqual(@as(f64, 0), frac);
+
+    scroll_viewport(t, .{ .tag = .top, .value = undefined });
+    try testing.expectEqual(Result.success, set(t, .scroll_row_frac, @ptrCast(&set_frac)));
+    try testing.expectEqual(Result.success, get(t, .scroll_row_frac, @ptrCast(&frac)));
+    try testing.expectEqual(@as(f64, 0.25), frac);
+
+    scroll_viewport(t, .{ .tag = .delta, .value = .{ .delta = 1 } });
+    try testing.expectEqual(Result.success, get(t, .scroll_row_frac, @ptrCast(&frac)));
+    try testing.expectEqual(@as(f64, 0), frac);
 }
 
 test "scroll_viewport row alt screen" {

--- a/src/terminal/c/terminal.zig
+++ b/src/terminal/c/terminal.zig
@@ -1514,6 +1514,7 @@ pub fn scroll_viewport(
         .top => .top,
         .bottom => .bottom,
         .delta => .{ .delta = behavior.value.delta },
+        .delta_f => .{ .delta_f = behavior.value.delta_f },
         .row => .{ .row = behavior.value.row },
     });
 }
@@ -2426,6 +2427,42 @@ test "scroll row frac get/set" {
     try testing.expectEqual(Result.success, get(t, .scroll_row_frac, @ptrCast(&frac)));
     try testing.expectEqual(@as(f64, 0.25), frac);
 
+    scroll_viewport(t, .{ .tag = .delta, .value = .{ .delta = 1 } });
+    try testing.expectEqual(Result.success, get(t, .scroll_row_frac, @ptrCast(&frac)));
+    try testing.expectEqual(@as(f64, 0), frac);
+}
+
+test "scroll_viewport delta_f" {
+    var t: Terminal = null;
+    try testing.expectEqual(Result.success, new(
+        &lib.alloc.test_allocator,
+        &t,
+        10,
+        3,
+    ));
+    defer free(t);
+
+    vt_write(t, "A\r\nB\r\nC\r\nD\r\nE\r\nF\r\nG", 19);
+
+    var scrollbar_data: TerminalScrollbar = undefined;
+    try testing.expectEqual(Result.success, get(t, .scrollbar, @ptrCast(&scrollbar_data)));
+    const max_off = scrollbar_data.offset;
+    try testing.expect(max_off >= 3);
+
+    var frac: f64 = 1;
+    scroll_viewport(t, .{ .tag = .delta_f, .value = .{ .delta_f = -0.25 } });
+    try testing.expectEqual(Result.success, get(t, .scroll_row_frac, @ptrCast(&frac)));
+    try testing.expectEqual(@as(f64, 0.75), frac);
+    try testing.expectEqual(Result.success, get(t, .scrollbar, @ptrCast(&scrollbar_data)));
+    try testing.expectEqual(max_off - 1, scrollbar_data.offset);
+
+    scroll_viewport(t, .{ .tag = .delta_f, .value = .{ .delta_f = 0.25 } });
+    try testing.expectEqual(Result.success, get(t, .scroll_row_frac, @ptrCast(&frac)));
+    try testing.expectEqual(@as(f64, 0), frac);
+    try testing.expectEqual(Result.success, get(t, .scrollbar, @ptrCast(&scrollbar_data)));
+    try testing.expectEqual(max_off, scrollbar_data.offset);
+
+    scroll_viewport(t, .{ .tag = .delta_f, .value = .{ .delta_f = -0.25 } });
     scroll_viewport(t, .{ .tag = .delta, .value = .{ .delta = 1 } });
     try testing.expectEqual(Result.success, get(t, .scroll_row_frac, @ptrCast(&frac)));
     try testing.expectEqual(@as(f64, 0), frac);

--- a/src/terminal/render.zig
+++ b/src/terminal/render.zig
@@ -82,13 +82,20 @@ pub const RenderState = struct {
     rows: size.CellCountInt,
     cols: size.CellCountInt,
 
+    /// Fractional part of the scroll row copied from the screen on update.
+    /// `0` is row-aligned. When this is non-zero, `row_data` includes one
+    /// extra document row below the viewport (if it exists) so a renderer
+    /// can fill the gap from a sub-row shift.
+    scroll_row_frac: f64 = 0,
+
     /// The color state for the terminal.
     colors: Colors,
 
     /// Cursor state within the viewport.
     cursor: Cursor,
 
-    /// The rows (y=0 is top) of the viewport. Guaranteed to be `rows` length.
+    /// The rows (y=0 is top) of the viewport. Guaranteed to be `rows` length
+    /// when `scroll_row_frac` is 0.
     ///
     /// This is a MultiArrayList because only the update cares about
     /// the allocators. Callers care about all the other properties, and
@@ -377,6 +384,11 @@ pub const RenderState = struct {
     ) Allocator.Error!void {
         const s: *Screen = t.screens.active;
         const viewport_pin = s.pages.getTopLeft(.viewport);
+        const frac = s.scrollRowFrac();
+        const paint_rows: usize = if (frac == 0)
+            s.pages.rows
+        else
+            s.pages.rows + 1;
         const redraw = redraw: {
             // If our screen key changed, we need to do a full rebuild
             // because our render state is viewport-specific.
@@ -400,7 +412,8 @@ pub const RenderState = struct {
 
             // If our dimensions changed, we do a full rebuild.
             if (self.rows != s.pages.rows or
-                self.cols != s.pages.cols)
+                self.cols != s.pages.cols or
+                self.row_data.len != paint_rows)
             {
                 break :redraw true;
             }
@@ -416,6 +429,7 @@ pub const RenderState = struct {
         // Always set our cheap fields, its more expensive to compare
         self.rows = s.pages.rows;
         self.cols = s.pages.cols;
+        self.scroll_row_frac = frac;
         self.viewport_pin = viewport_pin;
         self.cursor.active = .{ .x = s.cursor.x, .y = s.cursor.y };
         self.cursor.cell = s.cursor.page_cell.*;
@@ -459,19 +473,22 @@ pub const RenderState = struct {
         // Ensure our row length is exactly our height, freeing or allocating
         // data as necessary. In most cases we'll have a perfectly matching
         // size.
-        if (self.row_data.len != self.rows) {
+        //
+        // Height here is the viewport plus the extra row when
+        // `scroll_row_frac` is non-zero.
+        if (self.row_data.len != paint_rows) {
             @branchHint(.unlikely);
 
-            if (self.row_data.len < self.rows) {
+            if (self.row_data.len < paint_rows) {
                 // Resize our rows to the desired length, marking any added
                 // values undefined.
                 const old_len = self.row_data.len;
-                try self.row_data.resize(alloc, self.rows);
+                try self.row_data.resize(alloc, paint_rows);
 
                 // Initialize all our values. Its faster to use slice() + set()
                 // because appendAssumeCapacity does this multiple times.
                 var row_data = self.row_data.slice();
-                for (old_len..self.rows) |y| {
+                for (old_len..paint_rows) |y| {
                     row_data.set(y, .{
                         .arena = .{},
                         .pin = undefined,
@@ -487,16 +504,16 @@ pub const RenderState = struct {
             } else {
                 const row_data = self.row_data.slice();
                 for (
-                    row_data.items(.arena)[self.rows..],
-                    row_data.items(.cells)[self.rows..],
-                    row_data.items(.applied_styles)[self.rows..],
+                    row_data.items(.arena)[paint_rows..],
+                    row_data.items(.cells)[paint_rows..],
+                    row_data.items(.applied_styles)[paint_rows..],
                 ) |state, *cell, *applied| {
                     var arena: ArenaAllocator = state.promote(alloc);
                     arena.deinit();
                     cell.deinit(alloc);
                     applied.deinit(alloc);
                 }
-                self.row_data.shrinkRetainingCapacity(self.rows);
+                self.row_data.shrinkRetainingCapacity(paint_rows);
             }
         }
 
@@ -538,7 +555,7 @@ pub const RenderState = struct {
         var y: usize = 0;
         var any_dirty: bool = false;
         var page_it = viewport_pin.pageIterator(.right_down, null);
-        while (y < self.rows) {
+        while (y < paint_rows) {
             const chunk = page_it.next() orelse break;
             const node = chunk.node;
             const node_serial = node.serial;
@@ -549,7 +566,7 @@ pub const RenderState = struct {
             // exactly `rows` tall) so we clamp.
             const take: usize = @min(
                 @as(usize, chunk.end - chunk.start),
-                self.rows - y,
+                paint_rows - y,
             );
 
             // Find our cursor if we haven't found it yet. We do this even
@@ -650,7 +667,7 @@ pub const RenderState = struct {
 
             y += take;
         }
-        assert(y == self.rows);
+        assert(y == paint_rows);
 
         // If our screen has a selection, then mark the rows with the
         // selection. We do this outside of the loop above because its unlikely
@@ -2393,5 +2410,92 @@ test "dirty row resets highlights" {
         const row_data = state.row_data.slice();
         const row_highlights = row_data.items(.highlights);
         try testing.expectEqual(0, row_highlights[0].items.len);
+    }
+}
+
+test "scroll row frac collects extra row" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    var t = try Terminal.init(io, alloc, .{
+        .cols = 10,
+        .rows = 3,
+    });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    s.nextSlice("A\r\nB\r\nC\r\nD\r\nE");
+
+    var state: RenderState = .empty;
+    defer state.deinit(alloc);
+
+    try state.update(alloc, &t);
+    try testing.expectEqual(3, state.rows);
+    try testing.expectEqual(3, state.row_data.len);
+    try testing.expectEqual(@as(f64, 0), state.scroll_row_frac);
+
+    // At the bottom a fraction is ignored: no extra row.
+    t.setScrollRowFrac(0.25);
+    try state.update(alloc, &t);
+    try testing.expectEqual(3, state.row_data.len);
+    try testing.expectEqual(@as(f64, 0), state.scroll_row_frac);
+
+    t.scrollViewport(.top);
+    t.setScrollRowFrac(0.25);
+    try state.update(alloc, &t);
+    try testing.expectEqual(3, state.rows);
+    try testing.expectEqual(4, state.row_data.len);
+    try testing.expectEqual(@as(f64, 0.25), state.scroll_row_frac);
+
+    const cells = state.row_data.items(.cells);
+    try testing.expectEqual('A', cells[0].get(0).raw.codepoint());
+    try testing.expectEqual('D', cells[3].get(0).raw.codepoint());
+
+    t.setScrollRowFrac(0);
+    try state.update(alloc, &t);
+    try testing.expectEqual(3, state.row_data.len);
+    try testing.expectEqual(@as(f64, 0), state.scroll_row_frac);
+}
+
+test "scroll row frac extra row dirties independently" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    var t = try Terminal.init(io, alloc, .{
+        .cols = 10,
+        .rows = 3,
+    });
+    defer t.deinit(alloc);
+
+    var s = t.vtStream();
+    defer s.deinit();
+    s.nextSlice("A\r\nB\r\nC\r\nD\r\nE");
+
+    var state: RenderState = .empty;
+    defer state.deinit(alloc);
+
+    t.scrollViewport(.{ .delta = -1 });
+    t.setScrollRowFrac(0.5);
+    try state.update(alloc, &t);
+    try testing.expectEqual(4, state.row_data.len);
+    try testing.expectEqual('B', state.row_data.items(.cells)[0].get(0).raw.codepoint());
+    try testing.expectEqual('E', state.row_data.items(.cells)[3].get(0).raw.codepoint());
+    try testing.expectEqual(3, state.cursor.viewport.?.y);
+
+    state.dirty = .false;
+    @memset(state.row_data.items(.dirty), false);
+
+    s.nextSlice("X");
+    try state.update(alloc, &t);
+    try testing.expectEqual(.partial, state.dirty);
+    {
+        const dirty = state.row_data.items(.dirty);
+        try testing.expect(!dirty[0]);
+        try testing.expect(!dirty[1]);
+        try testing.expect(!dirty[2]);
+        try testing.expect(dirty[3]);
     }
 }


### PR DESCRIPTION
This PR is the base layer to support pixel precise (smooth) scrolling. It does not change any existing behaviors yet, but supplies an inspector to manually manipulate the extra fractional row.

It is a smaller, hopefully more correct implementation aligned with the ideas in https://github.com/ghostty-org/ghostty/pull/14122.

When fractional scrolling (GHOSTTY_TERMINAL_OPT_SCROLL_ROW_FRAC) is enabled the render puts one extra document row under the viewport (if it exists) so the consuming renderer can fill the fractional gap.

The row iterator will hold this extra row when set, the default of 0 leaves existing behavior unchanged.

Add GHOSTTY_TERMINAL_OPT_SCROLL_ROW_FRAC to scrollViewport.

The renderer additions make it possible to manipulate and visualize this with the inspector, as content_offset is always zero now, (no callers to any new interface), it does not change the behavior.

AI, Grok and Claude were used, I wrote all the code in the runtime path. AI tools extended the limited tests I implemented with more complete coverage subject to my review.

